### PR TITLE
Add flash notices to admin layout

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -25,6 +25,7 @@
     <% end %>
 
     <main>
+      <%= render "shared/alerts" %>
       <%= yield %>
     </main>
   </div>


### PR DESCRIPTION
Notices keep showing up late, once you view the non-admin section because they haven't been triggered from admin.