### PR TITLE
Strange stretched images at top of features

### DIFF
--- a/app/assets/stylesheets/base/_elements.scss
+++ b/app/assets/stylesheets/base/_elements.scss
@@ -54,4 +54,5 @@ a {
 
 img {
   max-width: 100%;
+  height: auto;
 }


### PR DESCRIPTION
fixes  #183 
---

I added `height: auto;` to the image css class. This
[StackOverflow question][0] indicates that this will resize the
image's height in order to keep the native image aspect ratio.

### Testing:
- checked that http://localhost:3000/1900/09/11/border looks better
- checked that http://localhost:3000/2017/01/09/under-no-management
  was un-affected

### Before
![screen shot 2017-01-12 at 11 41 23 am](https://cloud.githubusercontent.com/assets/13190980/21905732/5ed20730-d8bd-11e6-9b98-0f4864a0b15c.png)
### After
![screen shot 2017-01-12 at 11 40 57 am](https://cloud.githubusercontent.com/assets/13190980/21905744/65dc3b72-d8bd-11e6-9383-dbbf93228072.png)

[0]:https://stackoverflow.com/questions/12991351/css-force-image-resize-and-keep-aspect-ratio