### PR TITLE
Inline social icons SVG for fewer HTTP requests

### DIFF
--- a/app/assets/stylesheets/base/_mixins.scss
+++ b/app/assets/stylesheets/base/_mixins.scss
@@ -31,10 +31,10 @@
   @include image-replacement();
 
   @media screen and #{$standard-def} {
-    background-image: url(asset-path($url));
+    background-image: asset-data-url($url);
   }
   @media screen and #{$retina} {
-    background-image: url(asset-path($retina-url));
+    background-image: asset-data-url($retina-url);
   }
 }
 


### PR DESCRIPTION
This is a possible solution to [#217][0], but I am not sure it is the "right" change

I used the `asset_data_url` helper to have rails inline a base64 data string on assets precompile.

You don't actually *need* to base_64 encode it (this [reference][1] explains why and is also why I think this might not be the right change), but this was a quick way to get the desired affect without changing too much of the asset structure.

[0]:https://github.com/crimethinc/website/issues/217
[1]:https://css-tricks.com/probably-dont-base64-svg/