### PR TITLE
Add Podcast Feed

### DIFF
--- a/app/controllers/podcast_controller.rb
+++ b/app/controllers/podcast_controller.rb
@@ -4,7 +4,7 @@ class PodcastController < ApplicationController
     @body_id = "podcast"
     @podcast = Podcast.find_by(title: "The Ex-Worker")
 
-    @episodes = @podcast.episodes.to_a
+    @episodes = @podcast.episodes.sort_by{|e| e.published_at }.reverse
     @latest_episode = @episodes.shift
   end
 
@@ -23,6 +23,6 @@ class PodcastController < ApplicationController
 
   def feed
     @podcast = Podcast.find_by(title: "The Ex-Worker")
-    @episodes = @podcast.episodes
+    @episodes = @podcast.episodes.sort_by{|e| e.published_at }.reverse
   end
 end

--- a/app/controllers/podcast_controller.rb
+++ b/app/controllers/podcast_controller.rb
@@ -4,7 +4,7 @@ class PodcastController < ApplicationController
     @body_id = "podcast"
     @podcast = Podcast.find_by(title: "The Ex-Worker")
 
-    @episodes = @podcast.episodes.sort_by{|e| e.published_at }.reverse
+    @episodes = @podcast.episodes.to_a
     @latest_episode = @episodes.shift
   end
 
@@ -23,5 +23,6 @@ class PodcastController < ApplicationController
 
   def feed
     @podcast = Podcast.find_by(title: "The Ex-Worker")
+    @episodes = @podcast.episodes
   end
 end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -18,4 +18,14 @@ class Episode < ApplicationRecord
   def meta_description
     subtitle || content.truncate(200)
   end
+
+  def duration_string
+    duration_in_seconds = duration.to_i.minutes
+
+    hours   =  (duration_in_seconds / 3600).to_i
+    minutes =  (duration_in_seconds / 60 - hours * 60).to_i
+    seconds =  (duration_in_seconds - (minutes * 60 + hours * 3600)).to_i
+
+    ['%.2d' % hours, '%.2d' % minutes, '%.2d' % seconds].join(":")
+  end
 end

--- a/app/views/podcast/feed.rss.builder
+++ b/app/views/podcast/feed.rss.builder
@@ -35,9 +35,12 @@ xml.rss "version"      => "2.0",
       xml.text! @podcast.tags
     end
 
-    @podcast.itunes_categories.split(",").map(&:strip).each do |category|
-      xml.tag!("itunes:category", text: category)
+    # TODO: These are hardcoded for now.  Find a simple way to nest categories.
+    xml.tag!("itunes:category", text: "News &amp; Politics")
+    xml.tag!("itunes:category", text: "Society &amp; Culture") do
+      xml.tag!("itunes:category", text: "Philosophy")
     end
+    xml.tag!("itunes:category", text: "Arts")
 
     xml.tag!("itunes:image", href: @podcast.image)
 

--- a/app/views/podcast/feed.rss.builder
+++ b/app/views/podcast/feed.rss.builder
@@ -1,0 +1,89 @@
+xml.instruct! :xml, version: "1.0", encoding: "UTF-8"
+xml.rss "version"      => "2.0",
+        "xmlns:atom"   => "http://www.w3.org/2005/Atom",
+        "xmlns:cc"     => "http://web.resource.org/cc/",
+        "xmlns:itunes" => "http://www.itunes.com/dtds/podcast-1.0.dtd",
+        "xmlns:media"  => "http://search.yahoo.com/mrss/",
+        "xmlns:rdf"    => "http://www.w3.org/1999/02/22-rdf-syntax-ns#" do
+
+  xml.channel do
+    xml.tag!("atom:link", href: podcast_feed_url, rel: "self", type: "application/rss+xml")
+    xml.title @podcast.title
+    xml.pubDate @episodes.first.published_at.to_s(:rfc822)
+    xml.lastBuildDate @episodes.first.published_at.to_s(:rfc822)
+    xml.link podcast_url
+    xml.language @podcast.language
+    xml.copyright do
+      xml.cdata! @podcast.copyright
+    end
+    xml.docs podcast_url
+    xml.managingEditor "#{@podcast.itunes_owner_email} (#{@podcast.itunes_owner_email})"
+    xml.tag!("itunes:summary") do
+      xml.cdata! @podcast.itunes_summary
+    end
+    xml.image do
+      xml.url @podcast.image
+      xml.title @podcast.title
+      xml.link do
+        xml.cdata! podcast_url
+      end
+    end
+    xml.tag!("itunes:author") do
+      xml.text! @podcast.itunes_author
+    end
+    xml.tag!("itunes:keywords") do
+      xml.text! @podcast.tags
+    end
+
+    @podcast.itunes_categories.split(",").map(&:strip).each do |category|
+      xml.tag!("itunes:category", text: category)
+    end
+
+    xml.tag!("itunes:image", href: @podcast.image)
+
+    xml.tag!("itunes:explicit") do
+      xml.text! @podcast.itunes_explicit? ? "yes" : "no"
+    end
+    xml.tag!("itunes:owner") do
+      xml.tag!("itunes:name") do
+        xml.cdata! @podcast.itunes_owner_name
+      end
+      xml.tag!("itunes:email") do
+        xml.text! @podcast.itunes_owner_email
+      end
+    end
+    xml.description do
+      xml.cdata! @podcast.meta_description
+    end
+    xml.tag!("itunes:subtitle") do
+      xml.cdata! @podcast.subtitle
+    end
+
+    @episodes.each do |episode|
+      xml.item do
+        xml.title episode.title
+        xml.pubDate episode.published_at.to_s(:rfc822)
+        xml.guid(isPermalink: false) do
+          xml.text! episode.id.to_s
+        end
+        xml.link do
+          xml.cdata! episode_url(episode)
+        end
+        xml.tag!("itunes:image", href: episode.image)
+        xml.description do
+          xml.cdata! episode.content
+        end
+        xml.enclosure(length: episode.audio_length, type: episode.audio_type, url: episode.audio_mp3_url)
+        xml.tag!("itunes:duration") do
+          xml.text! episode.duration_string
+        end
+        xml.tag!("itunes:explicit") do
+          xml.text! @podcast.itunes_explicit? ? "yes" : "no"
+        end
+        xml.tag!("itunes:subtitle") do
+          xml.cdata! @podcast.meta_description
+        end
+      end
+    end
+  end
+end

--- a/app/views/podcast/feed.rss.builder
+++ b/app/views/podcast/feed.rss.builder
@@ -36,8 +36,8 @@ xml.rss "version"      => "2.0",
     end
 
     # TODO: These are hardcoded for now.  Find a simple way to nest categories.
-    xml.tag!("itunes:category", text: "News &amp; Politics")
-    xml.tag!("itunes:category", text: "Society &amp; Culture") do
+    xml.tag!("itunes:category", text: "News & Politics")
+    xml.tag!("itunes:category", text: "Society & Culture") do
       xml.tag!("itunes:category", text: "Philosophy")
     end
     xml.tag!("itunes:category", text: "Arts")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,8 +55,7 @@ Rails.application.routes.draw do
 
 
   # Podcast
-  get "podcast/feed", to: redirect("http://exworker.libsyn.com/rss"), as: :podcast_feed_redirect # TEMP TODO
-  get "podcast/feed", to: "podcast#feed",   as: :podcast_feed
+  get "podcast/feed", to: "podcast#feed",   as: :podcast_feed, defaults: { format: "rss" }
   get "podcast",      to: "podcast#index",  as: :podcast
   get "podcast/:id",  to: "podcast#show",   as: :episode
   get "podcast/:id/transcript",  to: "podcast#transcript", as: :episode_transcript


### PR DESCRIPTION
The only problem I ran into while doing this was that the iTunes categories aren't set up to match how they appear in the feed.  We have them saved as a comma separated list, but the feed has Philosophy nested under Society & Culture.  For now they're all top level category tags.

``` xml
<itunes:category text="News &amp; Politics"/>
<itunes:category text="Society &amp; Culture">
  <itunes:category text="Philosophy"/>
</itunes:category>
<itunes:category text="Arts"/>
```

#31 