### PR TITLE
superscript footnote link styles

### DIFF
--- a/app/assets/stylesheets/base/_elements.scss
+++ b/app/assets/stylesheets/base/_elements.scss
@@ -27,7 +27,6 @@ h1, h2, h3, h4, h5, h6, p, a, span {
 
 b,
 strong {
-  font-weight: bold;
   font-weight: 700;
 }
 
@@ -42,14 +41,27 @@ input[type=search] {
 
 main {
   clear: both;
-  margin: 0 auto;
   width: 100%;
   padding: 0 $border-size-medium;
   margin: 0 auto $border-size-xlarge auto;
 }
 
 a {
-  color: black;
+  &:link, &:visited, &:hover, &:active {
+    color: $color-true-black;
+  }
+}
+
+p > a {
+  &:link, &:visited, &:hover, &:active {
+    color: $color-gray-medium;
+    text-decoration: underline;
+    font-weight: 700;
+  }
+
+  &:hover, &:active {
+    color: $color-true-black;
+  }
 }
 
 video,
@@ -57,4 +69,22 @@ audio,
 img {
   max-width: 100%;
   height: auto;
+}
+
+sup {
+  display: inline-block;
+  font: {
+    size: 0.625em;
+    weight: 500;
+  }
+  position: relative;
+  top: -0.625em;
+  left: -0.125em;
+
+  > a {
+    &:link, &:visited, &:hover, &:active {
+      display: block;
+      text-decoration: none;
+    }
+  }
 }

--- a/app/assets/stylesheets/views/_article.scss
+++ b/app/assets/stylesheets/views/_article.scss
@@ -125,20 +125,6 @@
       margin-bottom: 1em;
     }
 
-    a {
-      color: $color-gray-medium;
-      text-decoration: underline;
-      font: {
-        weight: bold;
-        weight: 700;
-      }
-
-      &:hover {
-        color: black;
-        text-decoration: underline;
-      }
-    }
-
     h1, h2, h3, h4, h5, h6 {
       font-weight: bold;
       line-height: 1em;


### PR DESCRIPTION
closes #260

How do you feel about this look?

![smol](https://snaps.akibraun.com/bdvyh.png)
![big](https://snaps.akibraun.com/tehj2.png)

there of course is style for a standalone `<sup>` but honestly the styles here assume it will have an `<a>` inside. because footnotes.