### PR TITLE
stop article pagination from inlining when no tags/categories exist

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -30,18 +30,20 @@
       </div>
     <% end %>
 
-    <ul class="pagination">
-      <% if @previous_article.present? %>
-        <li class="page">
-          <%= link_to t("views.pagination.previous_article", title: @previous_article.title).html_safe, @previous_article.path %>
-        </li>
-      <% end %>
+    <div>
+      <ul class="pagination">
+        <% if @previous_article.present? %>
+          <li class="page">
+            <%= link_to t("views.pagination.previous_article", title: @previous_article.title).html_safe, @previous_article.path %>
+          </li>
+        <% end %>
 
-      <% if @next_article.present? %>
-        <li class="page">
-          <%= link_to t("views.pagination.next_article", title: @next_article.title).html_safe, @next_article.path %>
-        </li>
-      <% end %>
-    </ul>
+        <% if @next_article.present? %>
+          <li class="page">
+            <%= link_to t("views.pagination.next_article", title: @next_article.title).html_safe, @next_article.path %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   </footer>
 <% end %>


### PR DESCRIPTION
fixes #310 

the wrapping only occurs if there isn't a category or tag div before the pagination

~~tested this on the front-end by manually adding the `div`, but couldn't test it locally since `script/server` was being funny for me~~

### before
![screen shot 2017-02-21 at 2 04 34 pm](https://cloud.githubusercontent.com/assets/13190980/23187225/ee46b99c-f83e-11e6-9c90-49603c38cc33.png)

### after 
![screen shot 2017-02-21 at 2 04 11 pm](https://cloud.githubusercontent.com/assets/13190980/23187236/f6ca3508-f83e-11e6-9244-3a54612359e6.png)
