### PR TITLE
[#341] Add max character counters to tweet and summary on Article

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -2,3 +2,18 @@
 //= require jquery_ujs
 //= require bootstrap
 //= require cocoon
+
+$(function() {
+  return $("textarea[data-max-length]").keyup(function(e) {
+    e.preventDefault();
+
+    var text_length = e.currentTarget.value.length;
+    var text_max, id_to_update;
+
+    id_to_update = $(this).data("feedback-box");
+    text_max = $(this).data("max-length");
+
+    var text_remaining = text_max - text_length;
+    return $('#'+id_to_update).html(text_remaining);
+  });
+});

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -20,8 +20,11 @@ class Article < ApplicationRecord
   before_validation :generate_slug,            on: [:create, :update]
   before_validation :generate_published_dates, on: [:create, :update]
   before_validation :downcase_content_format,  on: [:create, :update]
+  before_validation :normalize_newlines,       on: [:create, :update]
 
   validates :short_path, uniqueness: true, unless: "short_path.blank?"
+  validates :tweet, length: { maximum: 115 }
+  validates :summary, length: { maximum: 200 }
   # validate :redirect_source_path_unique
 
   # before_save :create_redirect
@@ -78,5 +81,10 @@ class Article < ApplicationRecord
 
   def redirect_source_path_unique
     errors.add(:short_path, ' is already defined by a redirect') if Redirect.where(source_path: "/"+self.short_path).exists?
+  end
+
+  def normalize_newlines
+    tweet.gsub!("\r\n", "\n") if tweet.present?
+    summary.gsub!("\r\n", "\n") if summary.present?
   end
 end

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -126,7 +126,8 @@
       <div class="col-xs-12 col-sm-6">
         <div class="form-group">
           <%= f.label :tweet %>
-          <%= f.text_area :tweet, class: "form-control" %>
+          <%= f.text_area :tweet, class: "form-control", data: { 'max-length': '115', 'feedback-box': 'tweet-length' } %>
+          <div id="tweet-length"></div>
           <p class="help-block">
             Maximum 115 characters to leave room for the <code>t.co</code> short URL that Twitter creates.
             Used for syndicated tweet for this Article.
@@ -137,7 +138,8 @@
       <div class="col-xs-12 col-sm-6">
         <div class="form-group">
           <%= f.label :summary %>
-          <%= f.text_area :summary, class: "form-control" %>
+          <%= f.text_area :summary, class: "form-control", data: { 'max-length': '200', 'feedback-box': 'summary-length' } %>
+          <div id="summary-length"></div>
           <p class="help-block">
             Maximum 200 characters.
             Used for page description and previews in story cards on other sites.

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,6 +1,40 @@
 require "rails_helper"
 
 describe Article do
+  describe 'validations' do
+    it 'validates tweet is less than 115 characters' do
+      invalid_article = build(:article, tweet: 'a' * 116)
+      valid_article   = build(:article, tweet: 'a' * 115)
+
+      expect(valid_article).to be_valid
+      expect(invalid_article).not_to be_valid
+    end
+
+    it 'validates summary is less than 200 characters' do
+      invalid_article = build(:article, summary: 'a' * 201)
+      valid_article   = build(:article, summary: 'a' * 200)
+
+      expect(valid_article).to be_valid
+      expect(invalid_article).not_to be_valid
+    end
+
+    it 'replace \r\n with \n in tweet and summary' do
+      new_article = build(
+        :article,
+        tweet: "ab\r\ncd" * 23,
+        summary: "a\r\nbc" * 50
+      )
+
+      expect(new_article).to be_valid
+      expect(new_article.tweet.length).to eq(115)
+
+      new_article.save!
+      expect(new_article.reload).to be_valid
+      expect(new_article.summary.length).to eq(200)
+      expect(new_article.tweet.length).to eq(115)
+    end
+  end
+
   describe "#path" do
     subject { article.path }
 


### PR DESCRIPTION
This sort of works, but three details probably need more work:

1. ~~I never know where to put javascript in a rails app~~
2. ~~should the model validation only happen on publish? (so draft articles can have tweets/summaries that are longer)~~
3. ~~there is a difference between the newlines in the textarea and in Ruby (described below) and I don't know how to handle it, so it makes the counting code a little confusing~~

### newline issue
<details>
<summary>A newline in the `textarea` will count as 2 characters on the ruby
end.</summary>

e.g.

```textarea
foo

bar
```

translates to the ruby string
```ruby
"foo
\r\n
bar"
```
~~I didn't know the right way to handle this, so I just counted every
newline in the textarea as 2 when calculating how many characters are
left.~~

~~that said, entering a newline on twitter only counts as 1 character, so maybe I should `.gsub("\r\n", "\n")` in a `before_save` action instead?~~


I added a `before_validation` hook to replace `\r\n\` with `\n`
</details>


### tweet char counter

![tweet](https://cloud.githubusercontent.com/assets/13190980/24006971/7a3ad17a-0a2a-11e7-9208-428430a851f7.gif)
