### PR TITLE
Emphasized elements should not change font weight.

### DIFF
--- a/app/assets/stylesheets/views/_article.scss
+++ b/app/assets/stylesheets/views/_article.scss
@@ -226,11 +226,7 @@
     }
 
     i, cite, em, var, address, dfn, blockquote {
-      font: {
-        style: italic;
-        weight: lighter;
-        weight: 300;
-      }
+      font-style: italic;
     }
 
     dt, b, strong {


### PR DESCRIPTION
I toyed around with this, adding `font-weight: inherit;` and testing
throughout article bodies, it's not necessary. There *is* some
hinkiness on macOS Sierra—I don't think Apple provides San Francisco
italic at 300 weight, so blockquotes aren't as light as I suspect the
design would reflect.

resolves #352 