### PR TITLE
Switch index from builder to erb to allow for fragment caching

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -57,4 +57,18 @@ module ArticlesHelper
     links.join("-").html_safe
   end
 
+  XML_ENCODING = ::Encoding.find("utf-8")
+
+  require 'builder/xchar'
+  def xml_escape(text)
+    result = Builder::XChar.encode(text)
+    begin
+      result.encode(XML_ENCODING)
+    rescue
+      # if the encoding can't be supported, use numeric character references
+      result.
+        gsub(/[^\u0000-\u007F]/) {|c| "&##{c.ord};"}.
+        force_encoding('ascii')
+    end
+  end
 end

--- a/app/views/articles/index.atom.erb
+++ b/app/views/articles/index.atom.erb
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0" xml:base="http://localhost:3000/feed" xml:lang="en-us">
+  <id><%= request.original_url %></id>
+  <link rel="alternate" type="text/html" href="<%= request.original_url.sub('/feed', '') %>"/>
+  <link rel="self" type="application/atom+xml" href="<%= request.original_url %>"/>
+  <title><%= page_title %></title>
+  <subtitle><%= meta_title(nil) %></subtitle>
+  <link href="./"/>
+  <link rel="self" href=""/>
+  <logo><%= largest_touch_icon_url %></logo>
+  <icon><%= asset_url("icons/favicon.ico") %></icon>
+  <updated><%= @articles.first.updated_at.xmlschema %></updated>
+  <author>
+    <name><%= author %></name>
+    <email>help@crimethinc.com</email>
+  </author>
+  <% @articles.each do |article| %>
+    <% cache article do %>
+      <entry>
+        <id><%= request.base_url + article.path %></id>
+        <published><%= article.published_at.xmlschema %></published>
+        <updated><%= article.updated_at.xmlschema %></updated>
+        <link rel="alternate" type="text/html" href="<%= request.base_url + article.path %>"/>
+        <title><%= article.name %></title>
+        <summary><%= article.summary %></summary>
+        <% article.categories.each do |category| %>
+        <category scheme="<%= category.name %>" term="<%= category.name %>"/>
+        <% end %>
+        <content type="html">
+          <%= xml_escape figure_image_with_caption_tag(article) %>
+
+          <%= xml_escape render_content(article)  %>
+        </content>
+      </entry>
+    <% end %>
+  <% end %>
+</feed>

--- a/app/views/articles/index.atom.erb
+++ b/app/views/articles/index.atom.erb
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0" xml:base="http://localhost:3000/feed" xml:lang="en-us">
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0" xml:base="<%= request.original_url %>" xml:lang="en-us">
   <id><%= request.original_url %></id>
   <link rel="alternate" type="text/html" href="<%= request.original_url.sub('/feed', '') %>"/>
   <link rel="self" type="application/atom+xml" href="<%= request.original_url %>"/>


### PR DESCRIPTION
The builder views are nice Ruby DSL, but because of the way they work, it's impossible to cache a subset of the output. It's only possible to cache the whole thing, which is more problematic because  that means properly caching on the articles collection.

This change switches it to being an erb template and allows for caching of the entry xml. The source of the current slowdown is this subset and is largely due to embedding a large amount of html in xml, which requires performing a fairly expensive escaping operation. The erb template caches the entry xml per article, allowing that escaping to be elided in the fast path.