### PR TITLE
Fix asset pipeline deprecation warning in specs

### DIFF
--- a/spec/helpers/books_helper_spec.rb
+++ b/spec/helpers/books_helper_spec.rb
@@ -3,15 +3,15 @@ require "rails_helper"
 RSpec.describe BooksHelper, type: :helper do
   describe "#thumbnail_link_to_large_image" do
     context "with large_url" do
-      subject { helper.thumbnail_link_to_large_image("test/small.png", "/test/larger.png") }
+      subject { helper.thumbnail_link_to_large_image("http://example.com/test/small.png", "/test/larger.png") }
 
-      it { is_expected.to eq(%{<a href="/test/larger.png"><img src="/images/test/small.png" alt="Small" /></a>}) }
+      it { is_expected.to eq(%{<a href="/test/larger.png"><img src="http://example.com/test/small.png" alt="Small" /></a>}) }
     end
 
     context "without large_url" do
-      subject { helper.thumbnail_link_to_large_image("test/small.png") }
+      subject { helper.thumbnail_link_to_large_image("http://example.com/test/small.png") }
 
-      it { is_expected.to eq(%{<a href="test/large.png"><img src="/images/test/small.png" alt="Small" /></a>}) }
+      it { is_expected.to eq(%{<a href="http://example.com/test/large.png"><img src="http://example.com/test/small.png" alt="Small" /></a>}) }
     end
   end
 end


### PR DESCRIPTION
Rails has deprecated `image_tag` with relative images that aren't present in the asset pipeline.  Since on production we're displaying images from a CDN with an absolute URL, we don't run into that problem.  I've updated the tests to use an absolute URL which gets rid of the deprecation warning.

Closes #363