### PR TITLE
Fix duplicate articles in archive.

### DIFF
--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -10,12 +10,13 @@ class Archive
     @year  = year
     @month = month
     @page  = page
+    @day   = day
   end
 
   def articles
     return @articles if defined?(@articles)
 
-    @articles = Article.published.live.root.all
+    @articles = Article.published.live.root.order(title: :desc)
 
     @articles = @articles.where(year:  year)  if year.present?
     @articles = @articles.where(month: month) if month.present?


### PR DESCRIPTION
During the initial article import, many of the articles had the same
created_at.  It looks like the sort wasn't deterministic when only
sorting by created_at causing some articles to be duplicated when
paginating.  This commit adds a secondary sort by article title so that
it will always sort them in the same way.

Closes #359