### PR TITLE
[#397] Fix specs

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -188,15 +188,6 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  describe "#strip_www" do
-    it "strips www" do
-      request.host = "www.crimethinc.com"
-
-      get :index
-
-      expect(response.status).to eq(302)
-    end
-  end
 
   describe "#render_markdown" do
     subject { controller.render_markdown("text").strip }

--- a/spec/requests/paginations_spec.rb
+++ b/spec/requests/paginations_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe "Pagination Redirects", type: :request do
   describe "archives" do
     it "redirects on page 1" do
-      get "/2017/01/01/page/1"
+      get "http://example.com/2017/01/01/page/1"
 
       expect(response).to redirect_to("/2017/01/01/")
     end
 
     it "redirects when no page number given" do
-      get "/2017/01/01/page"
+      get "http://example.com/2017/01/01/page"
 
       expect(response).to redirect_to("/2017/01/01/")
     end
@@ -17,13 +17,13 @@ RSpec.describe "Pagination Redirects", type: :request do
 
   describe "categories" do
     it "redirects on page 1" do
-      get "/categories/slug/page/1"
+      get "http://example.com/categories/slug/page/1"
 
       expect(response).to redirect_to("/categories/slug/")
     end
 
     it "redirects when no page number given" do
-      get "/categories/slug/page"
+      get "http://example.com/categories/slug/page"
 
       expect(response).to redirect_to("/categories/slug/")
     end
@@ -31,13 +31,13 @@ RSpec.describe "Pagination Redirects", type: :request do
 
   describe "tags" do
     it "redirects on page 1" do
-      get "/tags/slug/page/1"
+      get "http://example.com/tags/slug/page/1"
 
       expect(response).to redirect_to("/tags/slug/")
     end
 
     it "redirects when no page number given" do
-      get "/tags/slug/page"
+      get "http://example.com/tags/slug/page"
 
       expect(response).to redirect_to("/tags/slug/")
     end
@@ -45,13 +45,13 @@ RSpec.describe "Pagination Redirects", type: :request do
 
   describe "videos" do
     it "redirects on page 1" do
-      get "/videos/page/1"
+      get "http://example.com/videos/page/1"
 
       expect(response).to redirect_to("/videos/")
     end
 
     it "redirects when no page number given" do
-      get "/videos/page"
+      get "http://example.com/videos/page"
 
       expect(response).to redirect_to("/videos/")
     end
@@ -59,13 +59,13 @@ RSpec.describe "Pagination Redirects", type: :request do
 
   describe "admin" do
     it "redirects on page 1" do
-      get "/admin/videos/page/1"
+      get "http://example.com/admin/videos/page/1"
 
       expect(response).to redirect_to("/admin/videos/")
     end
 
     it "redirects when no page number given" do
-      get "/admin/videos/page"
+      get "http://example.com/admin/videos/page"
 
       expect(response).to redirect_to("/admin/videos/")
     end

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -2,25 +2,25 @@ require "rails_helper"
 
 RSpec.describe "Rack::Redirect", type: :request do
   it "redirects according to redirects.txt" do
-    get "/about/faq.html"
+    get "http://example.com/about/faq.html"
 
     expect(response).to redirect_to("/faq")
   end
 
   it "redirects with query string" do
-    get "/about/faq.html?test=true"
+    get "http://example.com/about/faq.html?test=true"
 
     expect(response).to redirect_to("/faq?test=true")
   end
 
   it "doesn't redirect when not found" do
-    get "/videos"
+    get "http://example.com/videos"
 
     expect(response.status).to eq(200)
   end
 
   it "redirects when the path starts with /blog/" do
-    get "/blog/2017/01/01/slug"
+    get "http://example.com/blog/2017/01/01/slug"
 
     expect(response).to redirect_to("/2017/01/01/slug")
   end


### PR DESCRIPTION
resolves https://github.com/crimethinc/website/issues/397

---

There were 2 things from the 'www' stripping feature that
caused some specs to fail.

First, It looks like the method that a spec was unit
testing (`#strip_www`) was commented out in
8021cf5d2bd56c65653093370950009e6617ec38 and eventually removed
entirely. So this spec is testing something that no longer exists (and
therefore is failing)

I just removed that spec.

Second, capybara/rspec uses a default host of `http://www.example.com`, so
specs using the `redirect_to` matcher were failing (because `www` is now stripped
from requests).

I tried to figure out how to change the default test app host, but nothing
worked and [this rspec issue][0] indicates this is a known, open issue.

Using a full URL in the failing specs gets around the issue, so I did that to
fix the failures.

[0]:https://github.com/rspec/rspec-rails/issues/1275