### PR TITLE
[#399] Search error : with quote in query

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -7,7 +7,7 @@ class SearchController < ApplicationController
       return redirect_to root_path
     end
 
-    @search  = Search.new(params[:q])
+    @search  = Search.new(search_params)
     @results = @search.perform.page(params[:page]).per(15)
     @title = "Search results for \"#{@search.query}\""
   end
@@ -25,5 +25,17 @@ class SearchController < ApplicationController
     @advanced_search.update_attributes(params[:advanced_search])
 
     redirect_to(search_path(q: @advanced_search.query))
+  end
+
+  private
+
+  def search_params
+    # single quotes are part of postgres's plain text search syntax
+    # and need to be removed to prevent syntax errors.
+    #
+    # There may be a way to handle single quotes in search terms that
+    # doesn't cause database-level concerns up to the controller
+    # level, but I didn't find any (see commit message for links)
+    params[:q].tr("'", "")
   end
 end


### PR DESCRIPTION
resolves https://github.com/crimethinc/website/issues/399

---

The search feature uses PostgreSQL's `tsquery` feature to enable
searching.

The [documentation indicates that][0]

> PostgreSQL provides the functions to_tsquery and plainto_tsquery for converting a query to the tsquery data type. to_tsquery offers access to more features than plainto_tsquery, **but is less forgiving about its input**

The actual issue is that each term passed to `phraseto_tsquery` must
be surrounded by single quotes.

There seems to be 3 options for making sure single-quotes in user searches don't cause
syntax errors:

1. using `plainto_tsquery` instead (doesn't seem like a good search experience)
2. passing query to [`quote_literal`][1] twice first (didn't seem to work when I tried it)
3. just stripping single quotes in the controller (what I ended up doing)

---

**Note on advanced search:**
Advanced search had this issue too, but fixing simple-search also
fixes advanced. This is because advanced search just parses the form
entry and then redirects to simple-search with the parsed form data as
the query string (so the search ultimately ends up flowing through the
`search_params` method I added.

[0]:https://www.postgresql.org/docs/9.3/static/textsearch-controls.html
[1]:https://dba.stackexchange.com/questions/135030/filtering-special-characters-in-to-tsquery