### PR TITLE
#350 - Change CMS note on Article specific CSS field

### DIFF
--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -199,8 +199,8 @@
               <% if @article.new_record? %>
               After you save this, you can add <b>Custom CSS</b> by editing the saved <i>Article</i>.
               <% else %>
-              Prefix your CSS selectors with <b><code>#article-<%= @article.id %></code></b> to scope your styles to just this <i>Article</i>.
-              For example, <code>#article-<%= @article.id %> b { background: green }</code>.
+              Prefix your CSS selectors with <b><code>#article-<%= @article.slug %></code></b> to scope your styles to just this <i>Article</i>.
+              For example, <code>#article-<%= @article.slug %> b { background: green }</code>.
               <% end %>
             </p>
           </div>


### PR DESCRIPTION
Now the note tell  editors to prefix there selectors with #article-the-article-slug instead of #article-id.