### PR TITLE
ref #411 - hide the content format form's section

### DIFF
--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -100,7 +100,7 @@
         </div>
 
         <div class="col-12 col-sm-6">
-          <div class="form-group">
+          <div class="form-group sr-only">
             <%= f.label :content_format, "Content Format" %>
 
             <div class="radio">


### PR DESCRIPTION
This PR hide the format form's section in the article form.