### PR TITLE
ref #408 - Update the date & time form's note

### DIFF
--- a/app/views/admin/_datetime_group.html.erb
+++ b/app/views/admin/_datetime_group.html.erb
@@ -46,8 +46,8 @@
   </div>
 
   <p class="help-block">
-    Timezones are in UTC (or GMT or Zulu).
-    EST is offset by -05:00.
-    PST is offset by -08:00.
+    Timezones are in UTC (or GMT or Zulu).<br>
+    EST is offset by -05:00.<br>
+    PST is offset by -08:00 (-07:00 during daylignt) if you want to publish at 10:00 am PST you have to set it at 06:00 pm (05:00 pm during daylight).
   </p>
 </div>

--- a/app/views/admin/_datetime_group.html.erb
+++ b/app/views/admin/_datetime_group.html.erb
@@ -48,6 +48,6 @@
   <p class="help-block">
     Timezones are in UTC (or GMT or Zulu).<br>
     EST is offset by -05:00.<br>
-    PST is offset by -08:00 (-07:00 during daylignt) if you want to publish at 10:00 am PST you have to set it at 06:00 pm (05:00 pm during daylight).
+    PST is offset by -08:00 (-07:00 during daylignt) if you want to publish at 10:00 am PST you have to set it at 18:00 (17:00 pm during daylight).
   </p>
 </div>


### PR DESCRIPTION
The note now give the conversion PST -> UTC offset during normal time and daylight time and it also give the example when you post at 10 am PST