### PR TITLE
Mark the specific ruby version

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -18,7 +18,7 @@ fi
 
 if [ -f ".ruby-version" ] && [ -z "$(rbenv version-name 2>/dev/null)" ]; then
   echo "==> Installing Ruby..."
-  rbenv install --skip-existing
+  rbenv install 2.4.1 --skip-existing
   which bundle >/dev/null 2>&1  || {
     gem install bundler
     rbenv rehash


### PR DESCRIPTION
Since the current version is 2.4.1p111 bundle won't install your gem because it's not the 2.4.1 version that is installed.