### PR TITLE
Add specs to verify current publication date behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ ISSUES.md
 /vendor/gems
 /coverage
 .idea/
+TAGS

--- a/app/views/admin/_datetime_group.html.erb
+++ b/app/views/admin/_datetime_group.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group">
+<div class="form-group" id="publication_datetime">
   <%= f.label :published_at, "Publication Date &amp; Time".html_safe %>
 
   <div class="row">

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -145,7 +145,7 @@
         </div>
       <% end %>
 
-      <div class="form-check">
+      <div class="form-check" id="publication_status">
         <%= f.label :status_id, "Publication Status" %><br>
 
         <span class="d-inline-block mr-3">

--- a/spec/controllers/about_controller_spec.rb
+++ b/spec/controllers/about_controller_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.describe AboutController, type: :controller do
   describe "GET #library" do
-    let(:status)  { FactoryGirl.create(:status) }
-    let!(:featured_current_events) { FactoryGirl.create(:article, slug:"feature-report-back-from-the-battle-for-sacred-ground", status: status, published_at: Date.current) }
-    let!(:featured_strategy_and_analysis) { FactoryGirl.create(:article, slug:"feature-understanding-the-kurdish-resistance-historical-overview-eyewitness-report", status: status, published_at: Date.current)}
-    let!(:featured_theory_and_critique) { FactoryGirl.create(:article, slug:"feature-from-democracy-to-freedom", status: status, published_at: Date.current) }
-    let!(:featured_classics) { FactoryGirl.create(:article, slug:"why-we-dont-make-demands", status: status, published_at: Date.current) }
+    let(:status)  { create(:status, :published) }
+    let!(:featured_current_events) { create(:article, slug:"feature-report-back-from-the-battle-for-sacred-ground", status: status, published_at: Date.current) }
+    let!(:featured_strategy_and_analysis) { create(:article, slug:"feature-understanding-the-kurdish-resistance-historical-overview-eyewitness-report", status: status, published_at: Date.current)}
+    let!(:featured_theory_and_critique) { create(:article, slug:"feature-from-democracy-to-freedom", status: status, published_at: Date.current) }
+    let!(:featured_classics) { create(:article, slug:"why-we-dont-make-demands", status: status, published_at: Date.current) }
 
     it "assigns all instance variables" do
       get :library

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe CategoriesController, type: :controller do
 
   describe "GET #show" do
-    let(:status)  { FactoryGirl.create(:status) }
-    let(:category) { FactoryGirl.create(:category, name: "Test Category") }
+    let(:status)  { create(:status, :published) }
+    let(:category) { create(:category, name: "Test Category") }
     it "redirects with a normalized slug" do
       slug = "underscored_slug"
       normalized_slug = slug.sub("_", "-")
@@ -15,7 +15,7 @@ RSpec.describe CategoriesController, type: :controller do
     end
 
     it "renders on a category with articles" do
-      article = FactoryGirl.create(:article, title: "Test", published_at: 1.day.ago, category_ids: [category.id], status: status)
+      article = create(:article, title: "Test", published_at: 1.day.ago, category_ids: [category.id], status: status)
 
       get :show, params: {slug: category.slug}
 
@@ -30,10 +30,10 @@ RSpec.describe CategoriesController, type: :controller do
   end
 
   describe "GET #feed" do
-    let(:status)  { FactoryGirl.create(:status) }
-    let(:category) { FactoryGirl.create(:category, name: "Test Category") }
+    let(:status)  { create(:status) }
+    let(:category) { create(:category, name: "Test Category") }
     it "renders on a category with articles" do
-      article = FactoryGirl.create(:article, title: "Test", published_at: 1.day.ago, category_ids: [category.id], status: status)
+      article = create(:article, title: "Test", published_at: 1.day.ago, category_ids: [category.id], status: status)
 
       get :feed, params: {slug: category.slug}
 

--- a/spec/controllers/tags_controller_spec.rb
+++ b/spec/controllers/tags_controller_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe TagsController, type: :controller do
 
   describe "GET #show" do
-    let(:status)  { FactoryGirl.create(:status) }
+    let(:status)  { create(:status, :published) }
     it "renders on a tag with articles" do
-      article = FactoryGirl.create(:article, title: "Test", published_at: 1.day.ago, status: status)
+      article = create(:article, title: "Test", published_at: 1.day.ago, status: status)
       article.tags << Tag.new(name: "Test Tag")
       tag = Tag.last
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,6 +3,6 @@ FactoryGirl.define do
     published_at { Time.now }
     sequence :title { |n| "Article #{n}" }
     short_path { SecureRandom.hex }
-    status
+    association :status
   end
 end

--- a/spec/factories/statuses.rb
+++ b/spec/factories/statuses.rb
@@ -1,5 +1,13 @@
 FactoryGirl.define do
   factory :status do
-    name { "published" }
+    initialize_with { Status.find_or_create_by(name: "draft") }
+  end
+
+  trait :draft do
+    initialize_with { Status.find_or_create_by(name: "draft") }
+  end
+
+  trait :published do
+    initialize_with { Status.find_or_create_by(name: "published") }
   end
 end

--- a/spec/features/article_datetime_settings_spec.rb
+++ b/spec/features/article_datetime_settings_spec.rb
@@ -68,6 +68,7 @@ feature "Setting and changing an articles published_at date" do
 
     within('#datetime') { click_on 'Publish NOW!' }
 
+    expect(page).to have_content 'Article was successfully created'
     article = Article.last
 
     # rough approximation of 'now'

--- a/spec/features/article_datetime_settings_spec.rb
+++ b/spec/features/article_datetime_settings_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+feature "Setting and changing an articles published_at date" do
+  let(:admin) do
+    create(:user, username: 'user1', email: 'user@example.com', password: 'c'*31)
+  end
+
+  background do
+    create(:status, :published)
+    create(:status, :draft)
+  end
+
+  scenario "Creating a new article" do
+    login_user(admin)
+
+    click_on 'NEW'
+
+    within '#publication_datetime' do
+      select('2018', from: 'article_published_at_1i')
+      select('12 - December', from: 'article_published_at_2i')
+      select('24', from: 'article_published_at_3i')
+      select('11', from: 'article_published_at_4i')
+      select('59', from: 'article_published_at_5i')
+    end
+
+    within('#publication_status') { choose 'Draft' }
+
+    find_button('Save', match: :first).click
+
+    article = Article.first
+    expect(article.published_at.utc).to eq('2018-12-24 11:59:00 UTC')
+    expect(article.published_at.utc).to eq('2018-12-24 11:59:00 UTC')
+  end
+
+  scenario "updating an existing article" do
+    article = create(:article, published_at: Time.parse('2018-12-24 11:59:00 UTC'))
+    expect(article.published_at.utc).to eq('2018-12-24 11:59:00 UTC')
+
+    login_user(admin)
+
+    click_on 'EDIT'
+    within '#publication_datetime' do
+      select('2018', from: 'article_published_at_1i')
+      select('12 - December', from: 'article_published_at_2i')
+      select('26', from: 'article_published_at_3i')
+      select('22', from: 'article_published_at_4i')
+      select('59', from: 'article_published_at_5i')
+    end
+
+    within('#publication_status') { choose 'Draft' }
+
+    find_button('Save', match: :first).click
+
+    expect(article.reload.published_at.utc).to eq('2018-12-26 22:59:00 UTC')
+  end
+
+  scenario "Using 'PUBLISH NOW' feature", :js do
+    # TODO: the 'publish now' feature relies on a JavaScript in
+    # the front-end to automatically set the form fields and submit the
+    # form. This makes testing time hard since we cannot
+    # Timecop.freeze the front-end. Consider making the 'Publish Now!'
+    # feature a back-end feature
+    login_user(admin)
+
+    click_on 'NEW'
+
+    time = Time.now.utc
+
+    within('#datetime') { click_on 'Publish NOW!' }
+
+    article = Article.last
+
+    # rough approximation of 'now'
+    expect(article.published_at.day).to eq(time.day)
+    expect(article.published_at.month).to eq(time.month)
+    expect(article.published_at.year).to eq(time.year)
+    expect(article.published_at.min).to eq(time.min)
+    expect(article.published_at.hour).to eq(time.hour)
+    expect(article).to be_published
+  end
+end

--- a/spec/models/archive_spec.rb
+++ b/spec/models/archive_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe Archive, type: :model do
   describe "it sorts the articles correctly" do
     Status.delete_all
-    let(:status)  { FactoryGirl.create(:status) }
-    let!(:first) { FactoryGirl.create(:article, published_at: DateTime.parse("2017-01-01"), status: status) }
-    let!(:last) { FactoryGirl.create(:article, published_at: DateTime.parse("2017-01-20"), status: status) }
+    let(:status)  { create(:status, :published) }
+    let!(:first) { create(:article, published_at: DateTime.parse("2017-01-01"), status: status) }
+    let!(:last) { create(:article, published_at: DateTime.parse("2017-01-20"), status: status) }
 
     subject { Archive.new(year: "2017", month: "01").first }
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -39,42 +39,42 @@ describe Article do
     subject { article.path }
 
     context "published" do
-      let(:article) { FactoryGirl.create(:article, slug: "slug", published_at: date, status: status) }
+      let(:article) { create(:article, slug: "slug", published_at: date, status: status) }
       let(:date)    { Date.parse("2017-01-01") }
-      let(:status)  { FactoryGirl.create(:status) }
+      let(:status)  { create(:status, :published) }
 
       it { is_expected.to eq("/2017/01/01/slug") }
     end
 
     context "not published" do
-      let(:article) { FactoryGirl.create(:article, draft_code: "draft-code", status: status) }
-      let(:status)  { FactoryGirl.create(:status, name: "draft") }
+      let(:article) { create(:article, draft_code: "draft-code", status: status) }
+      let(:status)  { create(:status, :draft) }
 
       it { is_expected.to eq("/drafts/articles/draft-code") }
     end
   end
 
   describe "#slug_exists?" do
-    let(:status)  { FactoryGirl.create(:status) }
+    let(:status)  { create(:status, :published) }
     let(:article) { Article.new(slug: "slug", published_at: date, short_path: SecureRandom.hex, status: Status.last) }
     let(:date)    { Date.parse("2017-01-01") }
 
     subject { article.slug_exists? }
 
     context "with the same slug on the same date" do
-      before { FactoryGirl.create(:article, slug: "slug", published_at: date, status: status) }
+      before { create(:article, slug: "slug", published_at: date, status: status) }
 
       it { is_expected.to be true }
     end
 
     context "with the same slug on a different date" do
-      before { FactoryGirl.create(:article, slug: "slug", published_at: date + 1.day, status: status) }
+      before { create(:article, slug: "slug", published_at: date + 1.day, status: status) }
 
       it { is_expected.to be false }
     end
 
     context "with a unique slug" do
-      before { FactoryGirl.create(:article, slug: "another-slug", published_at: date, status: status) }
+      before { create(:article, slug: "another-slug", published_at: date, status: status) }
 
       it { is_expected.to be false }
     end
@@ -100,30 +100,30 @@ describe Article do
   # end
 
   describe "#collection_posts" do
-    let(:status)  { FactoryGirl.create(:status) }
+    let(:status)  { create(:status) }
     let(:published_at) { Date.current }
     it "finds related collection_posts by collection_id" do
-      collection = FactoryGirl.create(:article, title: 'test', status: status, published_at: published_at)
-      article = FactoryGirl.create(:article, title: 'test', collection_id: collection.id, status: status, published_at: published_at)
+      collection = create(:article, title: 'test', status: status, published_at: published_at)
+      article = create(:article, title: 'test', collection_id: collection.id, status: status, published_at: published_at)
 
       expect(collection.collection_posts).to include article
     end
   end
 
   describe "collection_root?" do
-    let(:status)  { FactoryGirl.create(:status) }
+    let(:status)  { create(:status) }
     let(:published_at) { Date.current }
     context "when #collection_posts exists" do
       it "returns true" do
-        collection = FactoryGirl.create(:article, title: 'test', status: status, published_at: published_at)
-        article = FactoryGirl.create(:article, title: 'test', collection_id: collection.id, status: status, published_at: published_at)
+        collection = create(:article, title: 'test', status: status, published_at: published_at)
+        article = create(:article, title: 'test', collection_id: collection.id, status: status, published_at: published_at)
 
         expect(collection.collection_root?).to eq true
       end
     end
     context "when zero #collection_posts exist" do
       it "returns false" do
-        article = FactoryGirl.create(:article, title: 'test', status: status, published_at: published_at)
+        article = create(:article, title: 'test', status: status, published_at: published_at)
 
         expect(article.collection_root?).to eq false
       end
@@ -131,19 +131,19 @@ describe Article do
   end
 
   describe "in_collection?" do
-    let(:status)  { FactoryGirl.create(:status) }
+    let(:status)  { create(:status) }
     let(:published_at) { Date.current }
     context "when it has a collection_id" do
       it "returns true" do
-        collection = FactoryGirl.create(:article, title: 'test', status: status, published_at: published_at)
-        article = FactoryGirl.create(:article, title: 'test', collection_id: collection.id, status: status, published_at: published_at)
+        collection = create(:article, title: 'test', status: status, published_at: published_at)
+        article = create(:article, title: 'test', collection_id: collection.id, status: status, published_at: published_at)
 
         expect(article.in_collection?).to eq true
       end
     end
     context "when collection_id is nil" do
       it "returns false" do
-        article = FactoryGirl.create(:article, title: 'test', status: status, published_at: published_at)
+        article = create(:article, title: 'test', status: status, published_at: published_at)
 
         expect(article.in_collection?).to eq false
       end
@@ -151,11 +151,11 @@ describe Article do
   end
 
   describe "short_path_redirect_creation" do
-    let(:status)  { FactoryGirl.create(:status) }
+    let(:status)  { create(:status) }
     let(:published_at) { Date.current }
     context "successfull creates a short_path redirect" do
       it "returns true" do
-        article = FactoryGirl.create(:article, title: 'test', status: status, published_at: published_at)
+        article = create(:article, title: 'test', status: status, published_at: published_at)
         # expect(Redirect.last.source_path[/\w+/]).to eq article.short_path
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,13 @@ RSpec.configure do |config|
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
+
+def login_user(user)
+  visit '/signin'
+  within('main') do
+    fill_in 'username', with: 'user1'
+    fill_in 'password', with: 'c'*31
+  end
+  click_button 'Sign In'
+  expect(page).to have_content 'Logged in!'
+end


### PR DESCRIPTION
These specs are prepwork for [Issue #431][0]

They verify the current behavior of the `admin/article` form when it
comes to setting a publication date for an article and when it comes
to clicking the `Publish NOW!` button

### TODO

- [x] some unrelated specs are failing on `master`, fix those in a separate PR first
  - fixed in #433 and #434 
- [x] ~this is the first feature spec that requires `:js` to be on, I need to figure out how to configure Travis CI to run these specs in chrome headless (currently they run only locally in firefox with GUI)~
  will be fixed in #435

[0]:https://github.com/crimethinc/website/issues/431