### PR TITLE
Fix slug_spec

### DIFF
--- a/spec/models/slug_spec.rb
+++ b/spec/models/slug_spec.rb
@@ -4,7 +4,7 @@ describe Slug do
   let(:model) { Page.new(title: "test") }
 
   describe "generating a new slug when slug exists" do
-    before { Page.create!(slug: "test") }
+    before { Page.create!(title: "test") }
 
     subject { model.generate_slug }
 


### PR DESCRIPTION
The reason this spec was failing was because you cannot directly do a
`Page.create!(slug: "test")` and get a page created with a slug of
`"test"`.

Not sure why as I haven't reall used Rails `Concerns` much, but
setting the `:title` to `"test"` will give that `Page` a slug of
`"test"`, allowing us to test the "when a slug already exists" case
correctly.