### PR TITLE
fix categories_controller_spec

### DIFF
--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Admin::CategoriesController, type: :controller do
         category = create(:category)
         get :show, params: {id: category.id}
 
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(302)
         expect(assigns[:category]).to eq(category)
       end
     end


### PR DESCRIPTION
in d11578aa7354d4970d812efb8fcd8620089324b2 a redirect was added to
the `#show` action in `categories_controller.rb`.

So, this spec is actually correct. We just need to updated the
expectation to reflect the added redirect