### PR TITLE
[#450] Get Heroku CI to play nice with headless chromedriver

### DIFF
--- a/app.json
+++ b/app.json
@@ -34,5 +34,15 @@
     "heroku-postgresql:hobby-dev"
   ],
 
-  "image": "heroku/cedar"
+  "image": "heroku/cedar",
+
+  "environments": {
+    "test": {
+      "buildpacks": [
+        { "url": "heroku/ruby" },
+        { "url": "https://github.com/heroku/heroku-buildpack-chromedriver" },
+        { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" }
+      ]
+    }
+  }
 }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,16 +63,20 @@ RSpec.configure do |config|
 end
 
 # set up headless chrome webdriver for feature specs
-Capybara.register_driver(:headless_chrome) do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu] }
-  )
+chrome_bin = ENV.fetch('GOOGLE_CHROME_SHIM', nil) # This is from the heroku bin defined in app.json
+chrome_opts = if chrome_bin
+                # CI is running on heroku
+                { chromeOptions: { 'binary' => chrome_bin } }
+              else
+                # CI is running locally or in Travis
+                { chromeOptions: { args: %w[headless disable-gpu] } }
+              end
 
+Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(chrome_opts)
   )
 end
-
 Capybara.javascript_driver = :headless_chrome


### PR DESCRIPTION
This change adds the needed build-packs mentioned in the [Heroku Docs][0]
to get chrome headless to run.

That said, there might be alternative changes we could make:

- since specs already ran in Travis, just skip them in Heroku
- since feature specs take the longest (and already ran in travis), skip the feature specs in heroku
- since specs will run in heroku, skip the specs in travis
  - I am not a fan of this option as setting up heroku on a repo fork is harder than setting up travis

It just seems redundant (not in a useful way) to run the specs multiple times.

[0]:https://devcenter.heroku.com/articles/heroku-ci-browser-and-user-acceptance-testing-uat#google-chrome-via-headless