### PR TITLE
[#454] disable rack-attack if Rails.env.test?

### DIFF
--- a/config/initializers/rack-attack.rb
+++ b/config/initializers/rack-attack.rb
@@ -1,11 +1,13 @@
-# Only enable throttling if REDIS_URL is set
-if ENV["REDIS_URL"]
-  Redis.current = Redis.new(url: ENV["REDIS_URL"])
-  Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.current)
-end
+unless Rails.env.test?
+  # Only enable throttling if REDIS_URL is set
+  if ENV["REDIS_URL"]
+    Redis.current = Redis.new(url: ENV["REDIS_URL"])
+    Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.current)
+  end
 
-class Rack::Attack
-  throttle("limit requests per IP", limit: 60, period: 1.minute) do |req|
-    req.ip unless req.path.start_with?("/assets")
+  class Rack::Attack
+    throttle("limit requests per IP", limit: 60, period: 1.minute) do |req|
+      req.ip unless req.path.start_with?("/assets")
+    end
   end
 end


### PR DESCRIPTION
Rack attack was causing HTTP response `429` if you ran the test suite
back-to-back several times.

tested the fix by running:
```sh
while true; do rspec; done
```

and watched it for several runs

resolves: https://github.com/crimethinc/website/issues/454