### PR TITLE
[WIP] [Feature suggestion] Check passwords on user sign-up against DB of known leaks

### DIFF
--- a/app/models/burned_password.rb
+++ b/app/models/burned_password.rb
@@ -1,0 +1,3 @@
+class BurnedPassword < ActiveRecord::Base
+  self.primary_key = 'password_sha1'
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ActiveRecord::Base
               in: ["mickey fickie fire cracker soap on a rope", "a long passphrase to meet the minimum length"],
               message: "The passphrase '%{value}' is prohibited."
             }
+  validate :password_not_already_burned, on: :create
 
   default_scope { order(username: :asc) }
 
@@ -27,5 +28,12 @@ class User < ActiveRecord::Base
 
   def name
     username
+  end
+
+  private
+
+  def password_not_already_burned
+    burned = BurnedPassword.exists?(Digest::SHA1.hexdigest(password))
+    errors.add(:password, :burned_password) if burned
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,7 +275,7 @@ en:
       index_title: "Users"
       new_title: "New Users"
       show_title: "Users : %{name}"
-      edit_title: "Editing user %{id} %{name}"
+      edit_title: "Editing user %{id} %{username}"
     settings:
       index_title: "Settings"
       new_title: "New Settings"
@@ -316,3 +316,11 @@ en:
       new_title: "New Themes"
       show_title: "Themes : %{name}"
       edit_title: "Editing theme %{id} %{name}"
+
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            password:
+              burned_password: ": This password has previously appeared in a data breach. Please choose a more secure alternative."

--- a/db/migrate/20170928125909_create_burned_passwords.rb
+++ b/db/migrate/20170928125909_create_burned_passwords.rb
@@ -1,0 +1,6 @@
+class CreateBurnedPasswords < ActiveRecord::Migration[5.1]
+  def change
+    create_table :burned_passwords, id: :string, primary_key: :password_sha1 do |t|
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170913061727) do
+ActiveRecord::Schema.define(version: 20170928125909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,13 +92,16 @@ ActiveRecord::Schema.define(version: 20170913061727) do
     t.integer "gallery_images_count"
     t.boolean "epub_download_present"
     t.boolean "mobi_download_present"
+    t.integer "status_id"
     t.boolean "print_black_and_white_a4_download_present"
     t.boolean "print_color_a4_download_present"
     t.boolean "print_color_download_present"
     t.boolean "print_black_and_white_download_present"
     t.boolean "screen_single_page_view_download_present"
     t.boolean "screen_two_page_view_download_present"
-    t.integer "status_id"
+  end
+
+  create_table "burned_passwords", primary_key: "password_sha1", id: :string, force: :cascade do |t|
   end
 
   create_table "categories", id: :serial, force: :cascade do |t|

--- a/spec/factories/burned_passwords.rb
+++ b/spec/factories/burned_passwords.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :burned_password do
+  end
+end

--- a/spec/features/burned_password_checks_spec.rb
+++ b/spec/features/burned_password_checks_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+feature "Checking known burned passwords" do
+  background do
+    create(:user, username: 'user1', password: 'c'*31)
+
+    # sha1 of '1'*32
+    create(:burned_password, password_sha1: 'c66ebd709ec9ee11911ba2718c65a416e194fcc8')
+  end
+
+  scenario "When creating a new user" do
+    # sign in as current user
+    visit '/signin'
+    within('main') do
+      fill_in 'username', with: 'user1'
+      fill_in 'password', with: 'c'*31
+    end
+    click_button 'Sign In'
+    expect(page).to have_content 'Logged in!'
+
+    # proceed to sign up a new user
+    visit '/admin/users/new'
+    expect(current_path).to eq(new_admin_user_path)
+
+    within('main') do
+      fill_in 'Username', with: 'user2'
+      fill_in 'Password', with: '1'*32
+      fill_in 'Password confirmation', with: '1'*32
+    end
+    click_button 'Sign Up'
+
+    # be blocked from signing up a user with a known leaked password
+    expect(current_path).to eq(admin_users_path)
+    within('.alert-danger') do
+      expect(page).to have_content "This password has previously appeared" \
+                                   " in a data breach. Please choose a " \
+                                   "more secure alternative."
+    end
+  end
+end


### PR DESCRIPTION
I was going through a bunch of accounts on [HaveIBeenPwned][0] and I
noticed the [Passwords][1] tab for the first time.

That led me to reading this [post][2] about checking against this
password DB.

This PR specifically implements the registration use case [mentioned here][3].

There are still several technical issue to resolve, but I wanted to
open a PR to start getting feedback before continuing.

My open questions are:

1. Do we want to do this?
2. Would we want to implement the other Use Cases mentioned?
3. If so, what is the best way to store this giant password DB (It's 5.7 GB *compressed*)
4. A faster way to do the DB lookup (probably don't want to use ActiveRecord for this)

[0]:https://haveibeenpwned.com/
[1]:https://haveibeenpwned.com/Passwords
[2]:https://www.troyhunt.com/introducing-306-million-freely-downloadable-pwned-passwords/
[3]:https://www.troyhunt.com/introducing-306-million-freely-downloadable-pwned-passwords/#usecase1registration