### PR TITLE
spacing around Related Articles [close #557]

### DIFF
--- a/app/assets/stylesheets/views/_related_articles.scss
+++ b/app/assets/stylesheets/views/_related_articles.scss
@@ -6,6 +6,8 @@
   .related-articles-heading {
     font-weight: 700;
     font-size: 5rem;
+    margin-left: 1rem;
+    margin-right: 1rem;
     margin-bottom: 3rem;
     border-bottom: 1px solid $color-black;
   }
@@ -13,7 +15,14 @@
   .related-articles-category-heading {
     font-weight: 500;
     font-size: 3rem;
+    margin-left: 1rem;
+    margin-right: 1rem;
     margin-bottom: 1rem;
+  }
+
+  .h-entry {
+    margin-left: 1rem;
+    margin-right: 1rem;
   }
 
   .h-entry header h1 {


### PR DESCRIPTION
modify the _related_articles.scss style sheet to include a small margin around entries in the Related Articles list.

<details>
<summary>screenshot</summary>
<img width="422" alt="screen shot 2017-12-08 at 8 53 58 pm" src="https://user-images.githubusercontent.com/31468172/33792633-fa1158c2-dc59-11e7-8b70-9ceb19a02629.png">

</details>
