### PR TITLE
[TCE] normalize variable images

### DIFF
--- a/app/views/to_change_everything/show.html.erb
+++ b/app/views/to_change_everything/show.html.erb
@@ -153,11 +153,11 @@
     <div class="left">
       <img src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
            class="responsive-image"
-           data-responsimg-phonesmall="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-phonesmall.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-phonesmall@2x.jpg"
-           data-responsimg-phone="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-phone.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-phone@2x.jpg"
-           data-responsimg-tablet="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-tablet.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-large.jpg"
-           data-responsimg-small="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-small.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-small@2x.jpg"
-           data-responsimg-large="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-large.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name').html_safe%>-large@2x.jpg"
+           data-responsimg-phonesmall="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-phonesmall.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-phonesmall@2x.jpg"
+           data-responsimg-phone="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-phone.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-phone@2x.jpg"
+           data-responsimg-tablet="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-tablet.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-large.jpg"
+           data-responsimg-small="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-small.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-small@2x.jpg"
+           data-responsimg-large="https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-large.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.revolt.image_name')%>-large@2x.jpg"
            alt="A anonymous man stands in front of a column of tanks on June 5, 1989, the morning after the Chinese military had suppressed the Tiananmen Square protests of 1989 by force, who later became known as the Tank Man. The tanks manoeuvred to pass by the man, and he moved to continue to obstruct them, in something like a dance."
            />
       <h2><%=t('.revolt.left_text_html')%></h2>
@@ -216,11 +216,11 @@
     <div class="left">
       <img src=data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==
            class="responsive-image"
-           data-responsimg-phonesmall="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-phonesmall.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-phonesmall@2x.jpg"
-           data-responsimg-phone="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-phone.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-phone@2x.jpg"
-           data-responsimg-tablet="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-tablet.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-tablet@2x.jpg"
-           data-responsimg-small="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-small.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-small@2x.jpg"
-           data-responsimg-large="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-large.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name').html_safe%>-large@2x.jpg"
+           data-responsimg-phonesmall="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-phonesmall.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-phonesmall@2x.jpg"
+           data-responsimg-phone="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-phone.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-phone@2x.jpg"
+           data-responsimg-tablet="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-tablet.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-tablet@2x.jpg"
+           data-responsimg-small="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-small.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-small@2x.jpg"
+           data-responsimg-large="https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-large.jpg, https://cloudfront.crimethinc.com/tce/images/<%=t('.borders.image_name')%>-large@2x.jpg"
            alt="a grouple of people sits upon a tall boundary fence they have climbed"
            />
       <h2><%=t('.borders.left_text_html')%></h2>


### PR DESCRIPTION
When different languages have different images, we swap
between them by using a convention with the image paths.

e.g.

english version:
- https://cloudfront.crimethinc.com/tce/images/revolt-large.jpg

spanish version:
- https://cloudfront.crimethinc.com/tce/images/rebelarte-large.jpg

This requires the same image variations to be uploaded for every language,
otherwise one language will look fine, the other will have an image missing.

I noticed that for espanol we have:
- https://cloudfront.crimethinc.com/tce/images/rebelarte-large@2x.jpg

But we do not have the equivalent file in the english version.

@veganstraightedge, can you please upload [revolt-large.jpg][0] to the CDN with a filename of `/tce/images/revolt-large@2x.jpg`

[0]:https://cloudfront.crimethinc.com/tce/images/revolt-large.jpg