### PR TITLE
[BUG] 500 on admin/articles#preview

### DIFF
--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -28,7 +28,9 @@
     </div>
 
     <footer>
-      <%= render "articles/share_on_social_networks", article: @article %>
+      <% if @article.published? %>
+        <%= render "articles/share_on_social_networks", article: @article %>
+      <% end %>
       <%= render "articles/published_on",  article: @article, linked: true %>
       <%= render "articles/categories",    article: @article %>
       <%= render "articles/tags",          article: @article %>


### PR DESCRIPTION
The url_helpers blow up because the articles are not published yet on preview.

I just set the share urls to `#` for previews because we probably don't want to accidentally share drafts anyways 

fixes part of #586 