### PR TITLE
Use TCE assets on CDN

### DIFF
--- a/app/views/layouts/to_change_everything.html.erb
+++ b/app/views/layouts/to_change_everything.html.erb
@@ -26,7 +26,7 @@
     }
   </script>
 
-  <script src="/tce/js/jquery.responsImg.min.js"></script>
+  <script src="https://cloudfront.crimethinc.com/assets/tce/js/jquery.responsImg.min.js"></script>
   <script>
     $(document).ready(function() {
 
@@ -44,9 +44,9 @@
   </script>
 
 
-  <link rel="stylesheet" href="/tce/css/jquery.fancybox.css" media="screen" />
+  <link rel="stylesheet" href="https://cloudfront.crimethinc.com/assets/tce/css/jquery.fancybox.css" media="screen" />
 
-  <script src="/tce/js/jquery.fancybox.pack.js"></script>
+  <script src="https://cloudfront.crimethinc.com/assets/tce/js/jquery.fancybox.pack.js"></script>
   <script>
     $(document).ready(function() {
       $(".fancybox").fancybox({
@@ -76,7 +76,7 @@
   <meta property="og:image" content="https://cloudfront.crimethinc.com/assets/tce/images/twitter-card-1486.jpg" />
   <meta property="og:type" content="article" />
 
-  <link rel="stylesheet" href="https://cloudfront.crimethinc.com/tce/images/546676/CE039F8C7119876F1.css" />
+  <link rel="stylesheet" href="https://cloudfront.crimethinc.com/assets/tce/images/546676/CE039F8C7119876F1.css" />
 </head>
 
 <body class="<%=@locale.to_s%>">

--- a/app/views/to_change_everything/show.html.erb
+++ b/app/views/to_change_everything/show.html.erb
@@ -5,8 +5,8 @@
   </div>
 
   <div id="videopdf">
-    <a class="fancybox" href="#video-container"><div id="video"><img src="https://cloudfront.crimethinc.com/tce/images/video-play-icon-300.png" /><p><%=t('.video_cte')%></p></div></a>
-    <a href="<%=t('.pdf_get_url')%>"><div id="pdf"><div id="pdfleft"><img src="https://cloudfront.crimethinc.com/tce/images/<%=t('.pdf_image').html_safe%>" /></div><div id="pdfright"><p><%=t('.pdf_cte_html')%></p></div></div></a>
+    <a class="fancybox" href="#video-container"><div id="video"><img src="https://cloudfront.crimethinc.com/assets/tce/images/video-play-icon-300.png" /><p><%=t('.video_cte')%></p></div></a>
+    <a href="<%=t('.pdf_get_url')%>"><div id="pdf"><div id="pdfleft"><img src="https://cloudfront.crimethinc.com/assets/tce/images/<%=t('.pdf_image').html_safe%>" /></div><div id="pdfright"><p><%=t('.pdf_cte_html')%></p></div></div></a>
   </div>
 </div>
 
@@ -242,7 +242,7 @@
 
     <div class="third">
       <%=t('.anarchy.third_html')%>
-      <img src="https://cloudfront.crimethinc.com/tce/images/circle-a-logo-hands-white-large@2x.png" />
+      <img src="https://cloudfront.crimethinc.com/assets/tce/images/circle-a-logo-hands-white-large@2x.png" />
     </div>
   </div>
 


### PR DESCRIPTION
I plan on "testing" this by doing a `diff -q old new` and making sure they are the same

- [x] `jquery.responsImg.min.js` diffed
- [x] `jquery.fancybox.css` diffed
  - This does differ, but when I ignore whitespace (`diff -qw old new`) there is no diff
- [x] `jquery.fancybox.pack.js` diffed
- [x] `video-play-icon-300.png` diffed
- [x] `<%=t('.pdf_image').html_safe%>` diffed
- [x] `circle-a-logo-hands-white-large@2x.png` diffed

closes [#584][0] (**sort of!** only TCEs that use the erb template will no longer depend on the old assets. The remaining static html TCEs still rely on the original asset paths. **so we cannot delete the assets from `/public` just yet** )

[0]:https://github.com/crimethinc/website/issues/584