### PR TITLE
[TCE] load farsi font from CDN

### DIFF
--- a/app/assets/stylesheets/to_change_everything/_farsi.scss
+++ b/app/assets/stylesheets/to_change_everything/_farsi.scss
@@ -1,6 +1,28 @@
 .فارسی {
   $black-text-shadow: 0 0 2rem #444;
   $white-text-shadow: 0 0 2rem #CCC;
+  @font-face {
+    font-family: 'Noto Kufi Arabic';
+    font-style: normal;
+    font-weight: 400;
+    src: local("Noto Kufi Arabic Regular"),
+         local("NotoKufiArabic-Regular"),
+         url(https://cloudfront.crimethinc.com/assets/tce/fonts/NotoKufiArabic-Regular.eot) format('embedded-opentype'),
+         url(https://cloudfront.crimethinc.com/assets/tce/fonts/NotoKufiArabic-Regular.woff2) format('woff2'),
+         url(https://cloudfront.crimethinc.com/assets/tce/fonts/NotoKufiArabic-Regular.woff) format('woff'),
+         url(https://cloudfront.crimethinc.com/assets/tce/fonts/NotoKufiArabic-Regular.ttf) format('truetype');
+  }
+  @font-face {
+    font-family: 'Noto Kufi Arabic';
+    font-style: normal;
+    font-weight: 700;
+    src: local("Noto Kufi Arabic Bold"),
+         local("NotoKufiArabic-Bold"),
+         url(https://cloudfront.crimethinc.com/assets/tce/fonts/NotoKufiArabic-Bold.eot) format('embedded-opentype'),
+         url(https://cloudfront.crimethinc.com/assets/tce/fonts/NotoKufiArabic-Bold.woff2) format('woff2'),
+         url(https://cloudfront.crimethinc.com/assets/tce/fonts/NotoKufiArabic-Bold.woff) format('woff'),
+         url(https://cloudfront.crimethinc.com/assets/tce/fonts/NotoKufiArabic-Bold.ttf) format('truetype');
+  }
 
   /*--- Highlight language in mobile language menu ---*/
   #lang1  li  > a[href="/tce/farsi"] { color: #d62d34 !important; }

--- a/app/views/layouts/to_change_everything.html.erb
+++ b/app/views/layouts/to_change_everything.html.erb
@@ -77,7 +77,6 @@
   <meta property="og:type" content="article" />
 
   <link rel="stylesheet" href="https://cloudfront.crimethinc.com/assets/tce/images/546676/CE039F8C7119876F1.css" />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/earlyaccess/notokufiarabic.css" />
 </head>
 
 <body class="<%=@locale.to_s%>">

--- a/config/locales/to_change_everything/fa.yml
+++ b/config/locales/to_change_everything/fa.yml
@@ -42,7 +42,7 @@
   to_change_everything:
     show:
       title_html: "دگرگون<br />کردن<br />همه چیز"
-      subtitle_html: <span class="green">فراخوانیی</span> <span class="blue">آنارشیستی</span>
+      subtitle_html: <span class="green"> فراخوانی</span> <span class="blue">آنارشیستی</span>
       video_cte: تماشای ویدیو # Google translate "Watch Video"
       pdf_cte_html: دانلود<br />&nbsp;PDF # Google translate "Download PDF"
       pdf_get_url: http://www.crimethinc.com/blog/2016/09/21/to-change-everything-in-11-more-languages/#farsi


### PR DESCRIPTION
I never really use web-fonts, and just basically copied
the syntax from the [MDN docs][0].

It looks right when I open in safari,chrome, and FF. If someone has
a microsoft browser to test in that would be nice

this change also fixes a big copypasta on the subtitle

## screenshots of subtitle fix
### current
<img width="368" alt="screen shot 2018-01-04 at 6 02 32 pm" src="https://user-images.githubusercontent.com/13190980/34588335-6b7c7f7a-f17a-11e7-9d5a-78dc240d327d.png">

### fixed
<img width="498" alt="screen shot 2018-01-04 at 6 02 09 pm" src="https://user-images.githubusercontent.com/13190980/34588334-6b5282f6-f17a-11e7-8ed4-6526ef0f4bdf.png">


---

demo: https://crimethinc-staging-pr-613.herokuapp.com/tce/فارسی

[0]:https://developer.mozilla.org/en-US/docs/Web/CSS/%40font-face
  