### PR TITLE
[TCE] fix text overlap in farsi on sm. laptops

### DIFF
--- a/app/assets/stylesheets/to_change_everything/_farsi.scss
+++ b/app/assets/stylesheets/to_change_everything/_farsi.scss
@@ -412,26 +412,38 @@
       padding-top: 5%;
     }
 
-    #reconciling h2 {
-      font-size: 6.5vw;
-      line-height: 1.25;
-      padding-top: 5%;
+    #reconciling {
+      .righttext p { font-size: 1rem; }
+      h2 {
+        font-size: 6.5vw;
+        line-height: 1.25;
+        padding-top: 5%;
+      }
     }
-    
+
     #liberation h2 {
       font-size: 6vw;
     }
 
-    #revolt h2 {
-      font-size: 7vw;
+    #revolt {
+      .righttext p { font-size: 1rem; }
+      h2 {
+        font-size: 7vw;
+      }
     }
 
-    #control h2 {
-      font-size: 9vw;
+    #control {
+      .righttext p { font-size: 1rem; }
+      h2 {
+        font-size: 9vw;
+      }
     }
 
-    #hierarchy h2 {
-      font-size: 9vw;
+    #hierarchy {
+      .righttext p { font-size: 1rem; }
+      h2 {
+        font-size: 9vw;
+      }
     }
 
     #borders h2 {
@@ -454,7 +466,7 @@
       .righttext p {
         line-height: 1.15;
         font-weight: 300;
-        font-size: 1.1rem;
+        font-size: 1rem;
       }
 
       h2 {
@@ -462,16 +474,19 @@
         font-size: 7vw;
       }
     }
-    #profit h2 {
-      padding-top: 5%;
-      line-height: 1.25;
-      font-size: 6.5vw;
+    #profit {
+      .righttext p { font-size: 1rem; }
+      h2 {
+        padding-top: 5%;
+        line-height: 1.25;
+        font-size: 6.5vw;
+      }
     }
     #property {
       .righttext p {
         line-height: 1.15;
         font-weight: 300;
-        font-size: 1.1rem;
+        font-size: 1rem;
       }
       .left { padding-top: 50%; }
       h2 {


### PR DESCRIPTION
I miss the "Small laptop" breakpoint when tweaking font sizes:

```css
  /*-------------DESKTOP SMALL CSS------------------*/
  @media (min-width:1201px) and (max-width:1670px) {
```

## Current prod
![screen shot 2018-01-05 at 01 35 30](https://user-images.githubusercontent.com/13190980/34598123-f2deb9ae-f1b8-11e7-9df1-49af11d2af81.png)

## PR fix
![screen shot 2018-01-05 at 01 34 26](https://user-images.githubusercontent.com/13190980/34598146-04f14d00-f1b9-11e7-9d29-a32f36adeca9.png)
