### PR TITLE
[#598] Redirect from heroku subdomain

### DIFF
--- a/app/middlewares/rack/domain_redirect.rb
+++ b/app/middlewares/rack/domain_redirect.rb
@@ -7,15 +7,23 @@ module Rack
     def call(env)
       request = Rack::Request.new(env)
 
-      if request.host.downcase =~ /cwc/ || request.host.downcase =~ /herokuapp/
-        location = "https://crimethinc.com" + request.path
-        return redirect(location)
+      if request.host.downcase =~ /cwc/
+        return redirect_to_crimethinc request
+      end
+
+      if request.host.downcase =~ /crimethinc.herokuapp.com$/
+        return redirect_to_crimethinc request
       end
 
       @app.call(env)
     end
 
     private
+
+    def redirect_to_crimethinc request
+      location = "https://crimethinc.com#{request.path}"
+      redirect location
+    end
 
     def redirect(location)
       [

--- a/app/middlewares/rack/domain_redirect.rb
+++ b/app/middlewares/rack/domain_redirect.rb
@@ -7,7 +7,7 @@ module Rack
     def call(env)
       request = Rack::Request.new(env)
 
-      if request.host.downcase =~ /cwc/
+      if request.host.downcase =~ /cwc/ || request.host.downcase =~ /herokuapp/
         location = "https://crimethinc.com" + request.path
         return redirect(location)
       end


### PR DESCRIPTION
Now redirect from crimethinc.herokuapp.com to crimethinc.com

It's quite simple, but maybe extract the regex comparaison in a private method `is_domain_matching request, domain` to avoid code duplication, but otherwise it should work.