### PR TITLE
[WIP] Add import of partials used in article scss

### DIFF
--- a/app/assets/stylesheets/views/_article.scss
+++ b/app/assets/stylesheets/views/_article.scss
@@ -1,3 +1,7 @@
+@import '../base/variables/colors';
+@import '../base/variables/viewports';
+@import '../base/variables/borders';
+
 .draft-preview-message {
   background: red;
   padding: 1em;
@@ -20,6 +24,8 @@
 
     header {
       color: $color-white;
+      // maybe a fix for https://github.com/crimethinc/website/issues/657
+      // background: $color-true-black;
       margin-bottom: 1em;
       position: relative;
 


### PR DESCRIPTION
I was messing around with some new plugins on my editor and
I started getting `undefined variable` warnings on some of the
`scss` files.

I don't know if rails has a way outside of normal `scss` convention
that actually resolves these variables, or if we are currently just
silently failing on this.

Figured I would just add the imports and see if anything looks different in
staging