### PR TITLE
Remove pinning

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -10,7 +10,7 @@ if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
   brew bundle check >/dev/null 2>&1  || {
     echo "==> Installing Homebrew dependencies..."
     brew bundle
-    brew services restart postgresql@9.6
+    brew services restart postgresql
   }
 fi
 


### PR DESCRIPTION
pinning was added in https://github.com/crimethinc/website/pull/524 to make sure development matched prod.

prod was updated in c2e26562090026641e601481b50dc44a53812c2c, so pinning is no longer needed