### PR TITLE
Add a key to the footer caching

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<% cache do %>
+<% cache [Digest::MD5.hexdigest(Marshal.dump(social_links))] do %>
   <footer id="site-footer">
     <div class="footer-sections">
       <%= render "shared/footer/nav" %>

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,1 +1,3 @@
-Rack::Timeout.timeout = 20 # seconds
+unless Rails.env.development? # To allow breakpoint debugging
+  Rack::Timeout.timeout = 20 # seconds
+end


### PR DESCRIPTION
I added a key based on a checksum of the social share links:

```ruby
Digest::MD5.hexdigest(Marshal.dump(social_links))
#  => "e2d99a6344f6e3e0b79f2c29d2f99d19"
```
It isn't perfect, since something else might change in the footer and
not bust the cache, but the social links seem the most likely to
change.

I also made it so that the timeout isn't so short in development
mode (for `byebug` usage)