### PR TITLE
Change bootstrap script to support different ruby managers

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
+# check for existing ruby-install, otherwise install rbenv
+brew 'rbenv' unless system 'command -v ruby-install >/dev/null 2>&1'
 brew 'postgresql'
 brew 'heroku'
 cask 'chromedriver'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,6 +4,11 @@
 
 set -e
 
+# used to check if certain commands are available to script
+command_exists () {
+    command -v $1 >/dev/null 2>&1 || { echo >&2 "==> I looked for $1, but couldn't find it. Trying something else."; return 1; }
+}
+
 cd "$(dirname "$0")/.."
 
 if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
@@ -18,9 +23,21 @@ fi
 ruby_version=`cat .ruby-version`
 
 echo "==> Installing Ruby: $ruby_version"
-ruby-install ruby $ruby_version --no-reinstall
-source /usr/local/opt/chruby/share/chruby/chruby.sh
-chruby $ruby_version
+if command_exists rbenv; then
+    echo '==> using rbenv for install'
+    rbenv install -s $ruby_version
+elif command_exists ruby-install; then
+    echo '==> using ruby-install for install'
+    ruby-install ruby $ruby_version --no-reinstall
+    source /usr/local/opt/chruby/share/chruby/chruby.sh
+    chruby $ruby_version
+else
+    echo '==> Did not find rbenv or ruby-install!'
+    echo '==> Please install either tool to manage ruby'
+    echo '==> rbenv: `brew install rbenv`'
+    echo '==> ruby-install: `brew install ruby-install`'
+    exit 1
+fi
 
 which bundle >/dev/null 2>&1  || {
   gem install bundler


### PR DESCRIPTION
I think this script originally used `rbenv`, but at some point
switched to using `ruby-install`.

I modified it to check for either (and `rvm` could also be added if
someone uses that)

---

Some example output from `script/bootstrap`:

```sh

# uninstall rbenv to test Brewfile
$ brew uninstall rbenv
Uninstalling /usr/local/Cellar/rbenv/1.1.1... (36 files, 62.7KB)

$ script/bootstrap
==> Installing Homebrew dependencies…
Installing rbenv
Using postgresql
Using heroku
Using chromedriver
Homebrew Bundle complete! 4 Brewfile dependencies now installed.
Stopping `postgresql`... (might take a while)
==> Successfully stopped `postgresql` (label: homebrew.mxcl.postgresql)
==> Successfully started `postgresql` (label: homebrew.mxcl.postgresql)
==> Installing Ruby: 2.5.1
==> using rbenv for install

# uninstall rbenv
$ brew uninstall rbenv
Uninstalling /usr/local/Cellar/rbenv/1.1.1... (36 files, 62.7KB)

# install ruby-install and chruby to test Brewfile
$ brew install ruby-install
==> Downloading https://homebrew.bintray.com/bottles/ruby-install-0.6.1.high_sierra.bottle.tar.gz
==> Pouring ruby-install-0.6.1.high_sierra.bottle.tar.gz
🍺  /usr/local/Cellar/ruby-install/0.6.1: 27 files, 67.5KB

$ brew install chruby

$ script/bootstrap
==> Installing Ruby: 2.5.1
==> I looked for rbenv, but couldn't find it. Trying something else.
==> using ruby-install for install
>>> Updating ruby versions ...
>>> Installing ruby 2.5.1 into 
>>> Installing dependencies for ruby 2.5.1 ...

# whole lotta output ...
# ...

>>> Successfully installed ruby 2.5.1 into 

```