### PR TITLE
Fix Rubocop warning: RSpec/NamedSubject

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,10 +11,3 @@ RSpec/ExpectInHook:
   Exclude:
     - 'spec/controllers/admin/admin_controller_spec.rb'
     - 'spec/helpers/articles_helper_spec.rb'
-
-# Offense count: 16
-RSpec/NamedSubject:
-  Exclude:
-    - 'spec/models/redirect_spec.rb'
-    - 'spec/models/tag_spec.rb'
-    - 'spec/services/tag_assigner_spec.rb'

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -10,43 +10,39 @@ RSpec.describe Redirect, type: :model do
   end
 
   describe '#add_leading_slash' do
-    subject { redirect }
-
     before { redirect.add_leading_slash }
 
     context 'with absolute urls' do
       let(:redirect) { Redirect.new(source_path: 'http://example.com/source', target_path: 'http://example.com/target') }
 
-      specify { expect(subject.source_path).to eq('http://example.com/source') }
-      specify { expect(subject.target_path).to eq('http://example.com/target') }
+      specify { expect(redirect.source_path).to eq('http://example.com/source') }
+      specify { expect(redirect.target_path).to eq('http://example.com/target') }
     end
 
     context 'with relative urls' do
       let(:redirect) { Redirect.new(source_path: 'source', target_path: 'target') }
 
-      specify { expect(subject.source_path).to eq('/source') }
-      specify { expect(subject.target_path).to eq('/target') }
+      specify { expect(redirect.source_path).to eq('/source') }
+      specify { expect(redirect.target_path).to eq('/target') }
     end
 
     context 'with relative source path and absolute target path' do
       https_target_path = 'https://example.com/foo/bar'
       let(:redirect) { Redirect.new(source_path: 'source', target_path: https_target_path) }
 
-      specify { expect(subject.source_path).to eq('/source') }
-      specify { expect(subject.target_path).to eq(https_target_path) }
+      specify { expect(redirect.source_path).to eq('/source') }
+      specify { expect(redirect.target_path).to eq(https_target_path) }
     end
   end
 
   describe '#downcase_source_path' do
-    subject { redirect }
-
     before { redirect.downcase_source_path }
 
     context 'with mixed case' do
       let(:redirect) { Redirect.new(source_path: 'SoUrCe', target_path: 'TaRgEt') }
 
-      specify { expect(subject.source_path).to eq('source') }
-      specify { expect(subject.target_path).to eq('TaRgEt') }
+      specify { expect(redirect.source_path).to eq('source') }
+      specify { expect(redirect.target_path).to eq('TaRgEt') }
     end
   end
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,24 +1,24 @@
 require 'rails_helper'
 
 describe Tag do
-  subject { described_class.new(name: 'test') }
+  subject(:tag) { described_class.new(name: 'test') }
 
   describe 'assigned_to?' do
     let(:page) { Page.create(title: 'about') }
 
     context 'when assigned to a page' do
       before do
-        subject.assign_to!(page)
+        tag.assign_to!(page)
       end
 
       it 'returns true' do
-        expect(subject).to be_assigned_to(page)
+        expect(tag).to be_assigned_to(page)
       end
     end
 
     context 'when not assigned to a page' do
       it 'returns false' do
-        expect(subject).not_to be_assigned_to(page)
+        expect(tag).not_to be_assigned_to(page)
       end
     end
   end
@@ -30,13 +30,13 @@ describe Tag do
     let(:page) { Page.new(title: 'about') }
 
     it 'assigns the tag to articles' do
-      subject.assign_to!(article)
-      expect(subject.articles).to eq [article]
+      tag.assign_to!(article)
+      expect(tag.articles).to eq [article]
     end
 
     it 'assigns the tag to pages' do
-      subject.assign_to!(page)
-      expect(subject.pages).to eq [page]
+      tag.assign_to!(page)
+      expect(tag.pages).to eq [page]
     end
   end
 end

--- a/spec/services/tag_assigner_spec.rb
+++ b/spec/services/tag_assigner_spec.rb
@@ -21,7 +21,7 @@ describe TagAssigner do
   end
 
   describe 'assign_tags_to!' do
-    subject { described_class.new(tag1, tag2, tag3) }
+    subject(:tag_assigner) { described_class.new(tag1, tag2, tag3) }
 
     let(:tag1) { double }
     let(:tag2) { double }
@@ -37,7 +37,7 @@ describe TagAssigner do
       expect(tag2).not_to receive(:assign_to!).with(taggable)
       expect(tag3).to receive(:assign_to!).with(taggable)
 
-      subject.assign_tags_to!(taggable)
+      tag_assigner.assign_tags_to!(taggable)
     end
   end
 end


### PR DESCRIPTION
removed uses of unnamed subjects where they were not required and I
changed unnamed subjects to named subjects at places where the subject
was referenced explicitly

resolves #777 