### PR TITLE
Set local per request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ require 'json'
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  before_action :set_locale
   before_action :check_for_redirection
   before_action :strip_file_extension
   before_action :authorize, if: :staging?
@@ -48,6 +49,10 @@ class ApplicationController < ActionController::Base
     action_name == 'new'
   end
   helper_method :creating?
+
+  def set_locale
+    I18n.locale = I18n.default_locale
+  end
 
   def check_for_redirection
     redirect = Redirect.where(source_path: request.path.downcase).last

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,6 @@ module Crimethinc
 
     # allow nested diretories in locales
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+    config.i18n.default_locale = :en
   end
 end


### PR DESCRIPTION
Lesson learned: If you start managing the locale per-request, you need
to manage it for *every* request

so thins makes every request use `:en`, (unless TCE requests overwrite that)