### PR TITLE
Move RT issues to /journals

### DIFF
--- a/app/controllers/admin/journals_controller.rb
+++ b/app/controllers/admin/journals_controller.rb
@@ -17,7 +17,7 @@ module Admin
     end
 
     def new
-      @book = Journal.new(journal: true)
+      @book = Journal.new
       @title = admin_title
       render 'admin/books/new'
     end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -3,6 +3,8 @@ class Journal < ApplicationRecord
   include Slug
   include Publishable
 
+  belongs_to :series
+
   has_many :taggings, dependent: :destroy, as: :taggable
   has_many :tags, through: :taggings
 

--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -1,0 +1,3 @@
+class Series < ApplicationRecord
+  has_many :journals, dependent: :destroy
+end

--- a/db/migrate/20181027230134_add_series_to_journal.rb
+++ b/db/migrate/20181027230134_add_series_to_journal.rb
@@ -1,0 +1,6 @@
+class AddSeriesToJournal < ActiveRecord::Migration[5.2]
+  def change
+    add_column :journals, :series_id, :integer
+    add_column :journals, :issue, :integer
+  end
+end

--- a/db/migrate/20181027230207_create_series.rb
+++ b/db/migrate/20181027230207_create_series.rb
@@ -1,0 +1,11 @@
+class CreateSeries < ActiveRecord::Migration[5.2]
+  def change
+    create_table :series do |t|
+      t.string :title
+      t.string :subtitle
+      t.text   :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_21_000005) do
+ActiveRecord::Schema.define(version: 2018_10_27_230207) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -188,6 +188,8 @@ ActiveRecord::Schema.define(version: 2018_10_21_000005) do
     t.boolean "print_black_and_white_download_present"
     t.boolean "screen_single_page_view_download_present"
     t.boolean "screen_two_page_view_download_present"
+    t.integer "series_id"
+    t.integer "issue"
   end
 
   create_table "logos", force: :cascade do |t|
@@ -298,6 +300,14 @@ ActiveRecord::Schema.define(version: 2018_10_21_000005) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "article_id"
+  end
+
+  create_table "series", force: :cascade do |t|
+    t.string "title"
+    t.string "subtitle"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "statuses", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,15 +1,16 @@
-%w(draft published).each do |status|
-  Status.create!(name: status)
-end
-
-test_user = User.new(
-              username:              "tester",
-              password:              "a long passphrase to meet the minimum length",
-              password_confirmation: "a long passphrase to meet the minimum length")
-test_user.save!(validate: false)
+# %w(draft published).each do |status|
+#   Status.create!(name: status)
+# end
+#
+# test_user = User.new(
+#               username:              "tester",
+#               password:              "a long passphrase to meet the minimum length",
+#               password_confirmation: "a long passphrase to meet the minimum length")
+# test_user.save!(validate: false)
 
 puts "Trying dev seeds for each post-type..."
-%w(articles books pages podcasts episodes redirects videos).each do |posttype|
+# articles books pages podcasts episodes redirects videos
+%w(journals ).each do |posttype|
   filepath = File.expand_path("../seeds/#{posttype}.rb", __FILE__)
 
   puts "  Trying: #{posttype}"

--- a/db/seeds/journals.rb
+++ b/db/seeds/journals.rb
@@ -1,0 +1,197 @@
+# These hashes are all smushed to the left to preserve Markdown formatting of their values
+rolling_thunder_series = Series.create!(
+title: 'Rolling Thunder',
+subtitle: 'An Anarchist Journal of Dangerous Living',
+description: %q{
+_Rolling Thunder_ was a biannual journal covering passionate living and creative resistance in all the forms they take: from consensus process to streetfighting, from workplace struggles to graffiti art, from gender mutiny to subversive humor. Each issue runs the gamut from on-the-spot reporting, strategic analysis, and instructional guides to poetry, comics, and games. _Rolling Thunder_ was published from 2005 to 2015.
+}
+)
+
+[
+{
+title: 'Rolling Thunder #10',
+subtitle: 'Summer 2012',
+summary: %q{
+Rolling Thunder #10 begins with a reappraisal of the anarchist project in today’s context of crisis and technological transformation. From there, we chart the global trajectory of momentum from 2010 to 2012: the student movements in the [US](/2010/03/09/march-4-anarchists-in-the-student-movement) and [UK](/2011/01/27/the-uk-student-movement)—the insurrections in Tunisia, [Egypt](/2011/02/02/egypt-today-tomorrow-the-world), and beyond—the occupation movements in [Spain](/2011/06/08/fire-extinguishers-and-fire-starters-anarchist-interventions-in-the-spanish-revolution-an-account-from-barcelona), Greece, and finally the USA, from its awkward beginnings in [Wisconsin](/2011/03/10/spread-the-chaos-from-capitol-to-capital) to its aftereffects in [Oakland](/2012/05/10/may-day-a-strike-is-a-blow). For case studies, we focus in on the anti-police struggles that catalyzed the rise of confrontational anarchism in Seattle, and scrutinize how US immigration policy is applied on the ground at the border to explain how its actual objectives differ from its ostensible purpose. The issue concludes with a historical review of Canadian anarchism, following it from its origins through the 2010 [Olympics](/2010/02/16/riot-2010) and [G20](/2010/07/06/toronto-g20-eyewitness-report) riots and up to the present day. All this, plus a graphic history from Argentine anarchism, 24 pages in full color, and all the other bells and whistles you’ve come to expect from us times two.
+},
+description: %q{
+[Download Table of Contents PDF](https://cloudfront.crimethinc.com/assets/journals/rolling-thunder-10/rolling-thunder-10_table_of_contents.pdf) (140 k).
+
+Full issue PDF download: 26 MB.
+
+[[ https://cloudfront.crimethinc.com/images/rt10/3b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt10/4b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt10/5b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt10/6b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt10/7b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt10/8b.jpg ]]
+},
+pages: 114,
+},
+{
+title: 'Rolling Thunder #9',
+subtitle: 'Spring 2010',
+summary: %q{
+How important is legitimacy—in our own eyes, in the eyes of potential allies, in the eyes of the public? How can anarchists cultivate it? What pitfalls does it hold? _Rolling Thunder_ #9 explores these questions while reporting on the past six months of upheavals around the US. Following up on our coverage of the [2008 convention protests](/2009/05/05/going-it-alone), this issue assesses anarchist action at the 2009 [G20 summit](/2009/10/07/g20-mobilization-preliminary-assessment), mapping conflict throughout the city and analyzing the strategies of the police and protesters. The accompanying Pittsburgh scene report examines the decade of local organizing that prepared the ground for this and other confrontations. Elsewhere herein, we scrutinize protest and resistance on campus—from the recent [occupation movement](http://afterthefallcommuniques.info) to efforts to shut down fascist student organizations—and overseas in the [Smash EDO](http://www.smashedo.org.uk) campaign. All this, plus obscure Russian history, a reappraisal of the concept of “free speech,” and the usual stunning prose. No advertisements; 16 full-color pages. Check out the [online supplement](/2010/03/03/rolling-thunder-9) to this issue.
+},
+description: %q{
+[Download Table of Contents PDF](https://cloudfront.crimethinc.com/assets/journals/rolling-thunder-9/rolling-thunder-9_table_of_contents.pdf) (303 k).
+
+Full issue PDF download: 22 MB.
+
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt9spread_b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt9single_b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt9closeup_b.jpg ]]
+},
+pages: 106,
+},
+{
+title: 'Rolling Thunder #7',
+subtitle: 'Spring 2009',
+summary: %q{
+So much happened in the second half of 2008 that we had to put off all our other content and add an extra 8 pages just to cover it all. Anarchists coordinated mass mobilizations against the Democratic and Republican National Conventions, provoking major clashes; the global economy collapsed; Greece experienced an anarchist-organized insurrection in response to a police murder; and at the beginning of 2009, Oakland was shaken by similar unrest. Our coverage pushes beyond the surface of events to offer insight into the organizing structures and historical background, fleshing out timelines and analyses with personal narratives and cutting-edge cartography. In addition to all this, the issue includes an exploration of the relationship between the punk subculture and the anarchist movement, complemented by interviews with bands and collectives from beyond the white punk ghetto, and ends with a primer on small-town organizing using Winona, Minnesota as a case study. No advertisements; 24 pages in full color.
+},
+description: %q{
+[Download Table of Contents PDF](https://cloudfront.crimethinc.com/assets/journals/rolling-thunder-7/rolling-thunder-7_table_of_contents.pdf) (512 k).
+
+Full issue PDF download: 13 MB.
+
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt7_2b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt7_3b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt7_4b.jpg ]]
+},
+pages: 114,
+},
+{
+title: 'Rolling Thunder #6',
+subtitle: 'Fall 2008',
+summary: %q{
+The theme of _Rolling Thunder_ #6 is experimentation: the processes by which radicals invent and refine new approaches. To this end, it features an evaluation of the model [activists](http://en.wikipedia.org/wiki/Stop_Huntingdon_Animal_Cruelty) have used to target the animal testing corporation HLS, discussing whether it could be effective in other contexts; a photoessay documenting the efforts of [Swedish anarchists](http://www.kulturkampanjen.se) who, unable to defend a squat, built a social center from the ground up; a consideration of the role proper support plays in cultivating communities of resistance; a report from student strikes and riots in [Colombia](/texts/recentfeatures/colombia.php); and an analysis of the past decade of anarchist organizing in NYC. In addition, the issue includes an investigation of the function of gift shops in maintaining global empire, historical accounts of Bakunin’s daring escape from Sibera and the riots that killed off the hated poll tax in Britain, and lots more. As usual, there are 16 pages of full color, plenty of fun tidbits, and no advertisements.
+},
+description: %q{
+[Download Table of Contents PDF](https://cloudfront.crimethinc.com/assets/journals/rolling-thunder-6/rolling-thunder-6_table_of_contents.pdf) (186 k).
+
+Full issue PDF download: 13 MB.
+
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt6_2b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt6_3b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt6_4b.jpg ]]
+},
+pages: 106,
+},
+{
+title: 'Rolling Thunder #5',
+subtitle: 'Spring 2008',
+summary: %q{
+This issue focuses on different ways of conceptualizing strategy, exploring the ways anarchist efforts can be repressed, assimilated, and neutralized only to reappear in new forms. It opens with a study by [David Graeber](http://en.wikipedia.org/wiki/David_Graeber) of the successes and stumbling blocks of direct action movements over the past thirty years, followed by a special report distilling lessons from the recent wave of federal repression known as the [Green Scare](/2008/02/22/green-scared). Two features give the inside story on anarchist mobilizations overseas via interviews, personal narratives, and 16 pages of full color photos: an examination of [the riots](https://youtube.com/watch?v=iupbxsHGlAA) following the eviction of Denmark’s beloved social center [Ungdomshuset](http://en.wikipedia.org/wiki/Ungdomshuset), and a full review of last summer’s [G8 protests](http://www.infoshop.org/inews/article.php?story=20070612082401642&query=g8) in Germany. The issue is rounded out by a subject’s analysis of the medical study industry as a case study in modern day precarious labor, a spotlight on anarchist organizing in [Modesto, California](http://www.geocities.com/anarcho209), and reviews of controversial works by anti-art duo [Brener](https://youtube.com/watch?v=P8MM_cf2e-U) and [Schurz](http://en.wikipedia.org/wiki/Barbara_Schurz). As always, 100% ad-free.
+},
+description: %q{
+[Download Table of Contents PDF](https://cloudfront.crimethinc.com/assets/journals/rolling-thunder-5/rolling-thunder-5_table_of_contents.pdf) (510 k).
+
+Full issue PDF download: 12 MB.
+
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt5_2b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt5_3b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt5_4b.jpg ]]
+},
+pages: 106,
+},
+{
+title: 'Rolling Thunder #4',
+subtitle: 'Spring 2007',
+summary: %q{
+The centerpiece of the fourth _Rolling Thunder_ is a full-color photoessay chronicling the popular uprising during which the people of Oaxaca, Mexico wrested control of their city from the government for a period of months. Continuing that theme, other feature articles cover the defense and eviction of South Central Farm in Los Angeles, the Really Really Free Market as a model for reclaiming public space from capitalism and bureaucracy, the resurgence of squatting in Buffalo of all places, the university occupation movement in France, and the ins and outs of urban exploration. The remainder of the issue includes a comprehensive guide to supporting prisoners and defendants, the lyrics to “The Big Rock Candy Mountain” as interpreted by acclaimed comic artist Nate Powell, a gallery of ready-to-use stencils, and plenty of the edgy artwork and poignant prose you’ve come to expect. Still 100% ad-free.
+},
+description: %q{
+[Download Table of Contents PDF](https://cloudfront.crimethinc.com/assets/journals/rolling-thunder-4/rolling-thunder-4_table_of_contents.pdf) (488 k).
+
+Full issue PDF download: 10 MB.
+
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt4_2b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt4_3b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt4_4b.jpg ]]
+},
+pages: 106,
+},
+{
+title: 'Rolling Thunder #3',
+subtitle: 'Summer 2006',
+summary: %q{
+International reports from last Mayday’s pro-immigrant rallies! Analysis of the Bush regime’s strategy to promote terrorism worldwide! Discussion of the latest wave of federal repression! Testimony from a convicted anti-war arsonist! Anarchist perspectives on and reports from the struggle against domestic violence! A tell-all interview with notorious graffiti artist(s) BORF! A shocking exposé on German pro-Zionist lunatics! A how-to guide to funneling resources out of universities! A spy’s-eye-view of immigrant labor in factory farming! A narrow escape from the flaming Pentagon on September 11, 2001! A history of direct action and rioting in queer liberation struggles! A cartoon recounting the riots at the canceled World Bank conference in Barcelona! A mad-lib for radicals with poor social skills! A satirical guide to writing reviews! Visionary storytelling, technical advice on computer security, eulogies and poster designs and more, more, more! 100% advertisement free.
+},
+description: %q{
+[Download Table of Contents PDF](https://cloudfront.crimethinc.com/assets/journals/rolling-thunder-3/rolling-thunder-3_table_of_contents.pdf). (228 k)
+
+Full issue PDF download: 9 MB.
+
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt3_2b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt3_3b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt3_4b.jpg ]]
+},
+pages: 114,
+},
+{
+title: 'Rolling Thunder #2',
+subtitle: 'Winter 2006',
+summary: %q{
+The lengthiest articles in our second issue are an analysis of last summer’s protests against the G8 meeting in Scotland, a retrospective on squatting and resistance culture in northern Europe, and an in-depth discussion of subcultural marginality and refusal that is to dropping out what the first issue’s sixteen-page feature article was to protest activism. The last of these is rounded out by an inside report on the workings of current labor unions, a memoir of gender mutiny, and an account of how to establish a squatted community center; other highlights include an intimate reflection on the patterns by which abusive relationships perpetuate themselves and a primer on communications technology for direct action. This issue also features plenty of the unorthodox fare that distinguishes CrimethInc. projects from the sometimes listless work of other radicals: a haunting fairy tale, cutting edge games to play between more serious adventures, a crossword puzzle, and sheet music for a classic blues song about the preponderance of bread products in the dumpsterer’s diet.
+},
+description: %q{
+[Download Table of Contents PDF](https://cloudfront.crimethinc.com/assets/journals/rolling-thunder-2/rolling-thunder-2_table_of_contents.pdf) (500 k).
+
+Full issue PDF download: 10 MB.
+
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt2_2b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt2_3b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt2_4b.jpg ]]
+},
+pages: 106,
+},
+{
+title: 'Rolling Thunder #1',
+subtitle: 'Summer 2005',
+summary: %q{
+The debut issue includes an extensive analysis of the preceding decade of direct action, feature articles on consent in sexual relationships and alternative conceptions of education, and testimonials from maniacs who squatted their own workplaces and set themselves on fire while fighting police… and that’s just the beginning! All told, this is 116 pages of radical commentary, history, poetry, artwork, fiction, parlor games (!), comics (!!), skills (e.g., “how to survive a police raid”), and culinary advice, all with an emphasis on personal narratives and celebrating the ways subversion thrives in the most unlikely places. 85,000 words adorned with tons of photos and illustrations and not a single advertisement, printed on recycled book paper and square-bound with the fanciest cover we've ever produced.
+},
+description: %q{
+[Download Table of Contents PDF](https://cloudfront.crimethinc.com/assets/journals/rolling-thunder-1/rolling-thunder-1_table_of_contents.pdf) (900 k).
+
+Full issue PDF download: 13 MB.
+
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt1_2b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt1_3b.jpg ]]
+[[ https://cloudfront.crimethinc.com/images/rt/pics/rt1_4b.jpg ]]
+},
+pages: 114,
+}
+].each do |rt|
+  journal           = Journal.new rt
+  journal.height    = '11"'
+  journal.width     = '8.5"'
+  journal.series_id = rolling_thunder_series.id
+
+  season, year = rt[:subtitle].split
+  month = case season
+  when 'Spring'
+    '04'
+  when 'Summer'
+    '07'
+  when 'Fall'
+    '10'
+  when 'Winter'
+    '1'
+  end
+
+  journal.screen_two_page_view_download_present = true
+
+  journal.published_at = Time.parse("#{year}-#{month}-01T12:00 -0800")
+  journal.status       = Status.find_by(name: 'published')
+  journal.ink          = 'Soy'
+  journal.issue        = journal.title.split('#').last
+
+  journal.content      = [journal.summary, journal.description].join("\n\n")
+  journal.description  = nil
+
+  puts "    ==> Saving Journal: #{journal.name}"
+  journal.save!
+end

--- a/spec/factories/series.rb
+++ b/spec/factories/series.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :series do
+    name { 'MyString' }
+  end
+end

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Series, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/series_spec.rb
+++ b/spec/models/series_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Series, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'exists' do
+  end
 end


### PR DESCRIPTION
- Add `Series` model
- Add `series_id` and `issue` to `Journal` model
- Add `journals.rb` seed script
- TEMP: Comment out all of `seeds.rb` except the `Journals` part to be able to run this in production

TODO: 
- add RTs that are still for sale / not for download yet: Issues 8, 11 & 12
- uncomment `seeds.rb`
- add `Journals` that were formerly `Zines` into `seeds/journals.rb`
