### PR TITLE
Add awesome-print gem to rails console

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,4 @@
+if defined?(Rails) && (Rails.env.development? || Rails.env.test?)
+  require 'awesome_print'
+  AwesomePrint.irb!
+end

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'logstash-event'
 
 # dev and testing
 group :development, :test do
+  gem 'awesome_print'
   gem 'byebug', platform: :mri
   gem 'capybara'
   gem 'chromedriver-helper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.3.1)
       execjs
+    awesome_print (1.8.0)
     bcrypt (3.1.12)
     bindex (0.5.0)
     bootstrap (4.1.3)
@@ -342,6 +343,7 @@ PLATFORMS
 
 DEPENDENCIES
   autoprefixer-rails
+  awesome_print
   bcrypt (~> 3.1.12)
   bootstrap (~> 4.1.3)
   bugsnag
@@ -399,4 +401,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.0
+   1.17.1


### PR DESCRIPTION
This loads the [awesome-print gem][0] when you run `rails c`

## before
![screen shot 2018-10-28 at 3 48 25 pm](https://user-images.githubusercontent.com/13190980/47623036-78840600-dac9-11e8-8803-2b9ff64df167.png)

## after
![screen shot 2018-10-28 at 3 48 15 pm](https://user-images.githubusercontent.com/13190980/47623038-7e79e700-dac9-11e8-9ec5-d78c7171a5f2.png)

[0]:https://github.com/awesome-print/awesome_print