### PR TITLE
Add status UI to book/zines

### DIFF
--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -4,6 +4,7 @@ module Admin
     before_action :set_book,             only: [:show, :edit, :update, :destroy]
     before_action :set_publication_type, only: [:show, :edit, :new, :index]
     before_action :set_ebook_formats,    only: [:edit, :new]
+    before_action :set_statuses,         only: [:new, :edit]
 
     def index
       @books = Book.book.order(slug: :asc).page(params[:page])
@@ -19,6 +20,7 @@ module Admin
     def new
       @book = Book.new
       @title = admin_title
+      @book.status = Status.find_by(name: 'draft')
     end
 
     def edit
@@ -34,6 +36,7 @@ module Admin
       if @book.save
         redirect_to [:admin, @book], notice: "#{publication_type.to_s.capitalize.singularize} was successfully created."
       else
+        set_statuses
         render :new
       end
     end
@@ -61,6 +64,11 @@ module Admin
 
     def set_publication_type
       @publication_type = 'book'
+    end
+
+    def set_statuses
+      @draft     = Status.find_by(name: 'draft')
+      @published = Status.find_by(name: 'published')
     end
 
     def set_ebook_formats

--- a/app/controllers/admin/zines_controller.rb
+++ b/app/controllers/admin/zines_controller.rb
@@ -4,6 +4,7 @@ module Admin
     before_action :set_zine,             only: [:show, :edit, :update, :destroy]
     before_action :set_publication_type, only: [:show, :edit, :new, :index]
     before_action :set_ebook_formats,    only: [:edit, :new]
+    before_action :set_statuses,         only: [:new, :edit]
 
     def index
       @books = Book.zine.order(slug: :asc).page(params[:page])
@@ -21,6 +22,8 @@ module Admin
     def new
       @book = Book.new(zine: true)
       @title = admin_title
+      @book.status = Status.find_by(name: 'draft')
+
       render 'admin/books/new'
     end
 
@@ -38,6 +41,7 @@ module Admin
       if @book.save
         redirect_to [:admin, @book], notice: 'Zine was successfully created.'
       else
+        set_statuses
         render :new
       end
     end
@@ -58,6 +62,11 @@ module Admin
 
     def set_zine
       @book = Book.find(params[:id])
+    end
+
+    def set_statuses
+      @draft     = Status.find_by(name: 'draft')
+      @published = Status.find_by(name: 'published')
     end
 
     def set_publication_type

--- a/app/views/admin/books/_categories_form.html.erb
+++ b/app/views/admin/books/_categories_form.html.erb
@@ -1,0 +1,29 @@
+<div id="categorization" class="row pt-5">
+  <div class="col-12 col-sm-6">
+
+    <%= form.label :status_id, "Publication Status" %><br>
+    <div class="form-check" id="publication_status">
+
+      <span class="d-inline-block mr-3">
+        <%= form.radio_button :status_id, @draft.id, id: :book_status_id_draft, class: "form-check-input" %>
+
+        <%= form.label :status_id_draft, class: "form-check-label", for: "book_status_id_draft" do %>
+          <b>Draft</b>
+        <% end %>
+      </span>
+
+      <span class="d-inline-block ml-3">
+        <%= form.radio_button :status_id, @published.id, id: :book_status_id_published, class: "form-check-input" %>
+
+        <%= form.label :status_id_published, class: "form-check-label", for: "book_status_id_published" do %>
+          <b>Published</b>
+        <% end %>
+      </span>
+
+    </div>
+    <hr class="my-5">
+
+
+  </div><!-- .col -->
+
+</div><!-- #categorization.row -->

--- a/app/views/admin/books/_form.html.erb
+++ b/app/views/admin/books/_form.html.erb
@@ -51,6 +51,8 @@
     </div>
   </div>
 
+  <%= render "admin/books/categories_form", form: form %>
+
   <%= render "admin/books/downloads_form", form: form, resource: resource %>
 
   <%= render "admin/form_actions", cancel_url: [:admin, @publication_type.pluralize] %>

--- a/app/views/admin/books/index.html.erb
+++ b/app/views/admin/books/index.html.erb
@@ -5,6 +5,7 @@
     <tr>
       <th></th>
       <th>Name</th>
+      <th>Status</th>
 
         <% [
           "Screen Single Page View PDF",
@@ -35,6 +36,11 @@
             <%= book.subtitle %>
           <% end %>
         </td>
+
+        <td>
+          <%= render "/admin/articles/publication_status_badge", article: book %>
+        </td>
+
 
         <% [
             :screen_single_page_view,

--- a/db/seeds/books.rb
+++ b/db/seeds/books.rb
@@ -1,3 +1,6 @@
+# Find the "published" Status
+published_status = Status.find_by(name: "published")
+
 books = []
 
 # bullet books
@@ -20,7 +23,8 @@ books << {
   ink:            "",
   price_in_cents: 1000,
   has_index:      false,
-  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=work&Dest=books"
+  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=work&Dest=books",
+  status_id:      published_status.id
 }
 
 books << {
@@ -42,7 +46,8 @@ books << {
   ink:            "",
   price_in_cents: 1000,
   has_index:      false,
-  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=work&Dest=books"
+  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=work&Dest=books",
+  status_id:      published_status.id
 }
 
 books << {
@@ -64,7 +69,8 @@ books << {
   ink:            "",
   price_in_cents: 1000,
   has_index:      false,
-  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=work&Dest=books"
+  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=work&Dest=books",
+  status_id:      published_status.id
 }
 
 books << {
@@ -86,7 +92,8 @@ books << {
   ink:            "Full-color on cover and black w/ full bleeds throughout.",
   price_in_cents: 1000,
   has_index:      true,
-  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=days&Dest=books"
+  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=days&Dest=books",
+  status_id:      published_status.id
 }
 
 books << {
@@ -109,7 +116,8 @@ books << {
   ink:            "",
   price_in_cents: 800,
   has_index:      false,
-  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=contra&Dest=books"
+  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=contra&Dest=books",
+  status_id:      published_status.id
 }
 
 books << {
@@ -132,7 +140,8 @@ books << {
   ink:            "Full-color on cover and inside cover, two colors throughout text (black + rust)",
   price_in_cents: 1200,
   has_index:      true,
-  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=rfd&Dest=books"
+  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=rfd&Dest=books",
+  status_id:      published_status.id
 }
 
 books << {
@@ -154,7 +163,8 @@ books << {
   ink:            "Five colors on cover and two colors (black and red) w/ full bleeds throughout.",
   price_in_cents: 1000,
   has_index:      false,
-  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=er&Dest=books"
+  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=er&Dest=books",
+  status_id:      published_status.id
 }
 
 
@@ -178,7 +188,8 @@ books << {
   ink:            "Two-color on cover and black throughout.",
   price_in_cents: 400,
   has_index:      false,
-  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=otm&Dest=books"
+  buy_url:        "http://store.crimethinc.com/x/AddToCart?Item=otm&Dest=books",
+  status_id:      published_status.id
 }
 
 


### PR DESCRIPTION
The changes to `publication_status_badge_class` might not be
necessary, but when testing with the books loaded from the `seed`
script I got errors because all of the books had a status of `nil`

I think they all have a status in the prod db and maybe I should just
update the `seed` script to set `published` to all of the books.

thoughts?

# screenshots
## zines
### index
![screen shot 2018-10-28 at 5 49 01 pm](https://user-images.githubusercontent.com/13190980/47624496-9b6ae600-dada-11e8-86fd-0c2b68a7f818.png)
### form
![screen shot 2018-10-28 at 5 38 19 pm](https://user-images.githubusercontent.com/13190980/47624499-a887d500-dada-11e8-86b1-a592af09cd4a.png)


---

## books
### index
![screen shot 2018-10-28 at 6 14 52 pm](https://user-images.githubusercontent.com/13190980/47624886-26011480-dade-11e8-9e0e-f95a7a27e1a1.png)

### form
![screen shot 2018-10-28 at 5 48 51 pm](https://user-images.githubusercontent.com/13190980/47624509-bb020e80-dada-11e8-92c2-0844fc714e26.png)

relates to #541 
