### PR TITLE
Add redirect from en. to apex domain

### DIFF
--- a/app/middlewares/rack/apex_redirect.rb
+++ b/app/middlewares/rack/apex_redirect.rb
@@ -12,6 +12,11 @@ module Rack
         return redirect(location)
       end
 
+      if request.host.start_with?('en.')
+        location = request.scheme + '://' + request.host.sub('en.', '') + request.path
+        return redirect(location)
+      end
+
       @app.call(env)
     end
 


### PR DESCRIPTION
Just in case someone manually changes `es.` to `en.`, they won't get a DNS error. They'll get the apex domain. Just like the `www.` redirect.