### PR TITLE
Add publish status to video

### DIFF
--- a/app/controllers/admin/videos_controller.rb
+++ b/app/controllers/admin/videos_controller.rb
@@ -3,6 +3,7 @@ module Admin
     before_action :authorize
     before_action :set_video,        only: [:show, :edit, :update, :destroy]
     before_action :set_published_at, only: [:create, :update]
+    before_action :set_statuses,     only: [:new, :edit]
 
     # /admin/videos
     def index
@@ -18,6 +19,7 @@ module Admin
     # /admin/videos/new
     def new
       @video = Video.new
+      @video.status = Status.find_by(name: 'draft')
       @title = admin_title
     end
 
@@ -33,6 +35,7 @@ module Admin
       if @video.save
         redirect_to [:admin, @video], notice: 'Video was successfully created.'
       else
+        set_statuses
         render :new
       end
     end
@@ -56,6 +59,11 @@ module Admin
 
     def set_video
       @video = Video.find(params[:id])
+    end
+
+    def set_statuses
+      @draft     = Status.find_by(name: 'draft')
+      @published = Status.find_by(name: 'published')
     end
 
     def video_params

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -3,11 +3,11 @@ class VideosController < ApplicationController
     @html_id = 'page'
     @body_id = 'watch'
     @title   = title_for :videos
-    @videos  = Video.published.page(params[:page]).per(20)
+    @videos  = Video.live.published.page(params[:page]).per(20)
   end
 
   def show
-    @video = Video.where(slug: params[:slug]).first
+    @video = Video.live.published.where(slug: params[:slug]).first
     return redirect_to [:videos] if @video.blank?
 
     @editable = @video

--- a/app/views/admin/videos/_form.html.erb
+++ b/app/views/admin/videos/_form.html.erb
@@ -55,6 +55,7 @@
     </div>
   </div>
 
+  <%= render "admin/books/categories_form", form: form %>
   <%= render "admin/datetime_group", form: form, post: @video, type: :video %>
 
   <%= render "admin/form_actions", cancel_url: [:admin, :videos] %>

--- a/app/views/admin/videos/index.html.erb
+++ b/app/views/admin/videos/index.html.erb
@@ -5,7 +5,7 @@
     <tr>
       <th></th>
       <th>Title / Subtitle</th>
-      <th></th>
+      <th>Status</th>
     </tr>
   </thead>
 
@@ -20,6 +20,9 @@
             <b><%= video.title %></b><br>
             <%= video.subtitle %>
           <% end %>
+        </td>
+        <td>
+          <%= render "/admin/articles/publication_status_badge", article: video %>
         </td>
       </tr>
     <% end %>

--- a/db/seeds/videos.rb
+++ b/db/seeds/videos.rb
@@ -8,6 +8,9 @@ require "nokogiri"
 # Videos
 filepath = File.expand_path("../db/seeds/videos/", __FILE__)
 
+# Find the "published" Status
+published_status = Status.find_by(name: "published")
+
 Dir.glob("#{filepath}/*").each do |f|
   path_pieces = f.strip.split("/")
   filename    = path_pieces.last
@@ -37,7 +40,9 @@ Dir.glob("#{filepath}/*").each do |f|
       duration:       duration,
       vimeo_id:       vimeo_id,
       published_at:   published_at,
-      content_format: "html"
+      content_format: "html",
+      status_id:      published_status.id,
+      published_at:   1.year.ago
     )
 
     puts "movies/#{filename}"

--- a/spec/controllers/videos_controller_spec.rb
+++ b/spec/controllers/videos_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe VideosController, type: :controller do
 
   describe 'GET show' do
     it 'renders the video' do
-      video = Video.create(title: 'A Video')
+      status =  create(:status, :published)
+      video = Video.create(title: 'A Video', status_id: status.id, published_at: 1.day.ago)
 
       get :show, params: { slug: video.slug }
 

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -103,6 +103,12 @@ describe 'Tools Pages' do
   it 'Renders published videos calling /videos' do
     FactoryBot.create(:video,
                       title: 'published',
+                      published_at: 1.day.ago,
+                      status_id: Status.find_by(name: 'published').id)
+
+    FactoryBot.create(:video,
+                      title: 'not live',
+                      published_at: 1.day.from_now,
                       status_id: Status.find_by(name: 'published').id)
 
     FactoryBot.create(:video,
@@ -112,6 +118,7 @@ describe 'Tools Pages' do
     visit '/videos'
 
     expect(page).to have_content 'published'
+    expect(page).not_to have_content 'not live'
     expect(page).not_to have_content 'draft'
   end
 end


### PR DESCRIPTION
This shouldn't be deployed to production until a `published_at` date
is set for all of the videos.

Otherwise, the videos will not be considered *live* and will disappear
from the website due to this code change:

```diff
modified   app/controllers/videos_controller.rb
@@ -3,11 +3,11 @@ class VideosController < ApplicationController
     @html_id = 'page'
     @body_id = 'watch'
     @title   = title_for :videos
-    @videos  = Video.published.page(params[:page]).per(20)
+    @videos  = Video.live.published.page(params[:page]).per(20)
   end

   def show
-    @video = Video.where(slug: params[:slug]).first
+    @video = Video.live.published.where(slug: params[:slug]).first
     return redirect_to [:videos] if @video.blank?

     @editable = @video
```
To unblock the deploy we could always run this in production to set a
placeholder value until the content team updates the videos:

```ruby
Video.all.update_all(published_at: 1.year.ago)
```

relates to: [#541][0]

[0]:https://github.com/crimethinc/website/issues/541