### PR TITLE
Add lite_mode to cache key

### DIFF
--- a/app/views/article_archives/_card.html.erb
+++ b/app/views/article_archives/_card.html.erb
@@ -1,4 +1,4 @@
-<% cache [:story_card, article] do %>
+<% cache [:story_card, article, lite_mode?] do %>
   <% unless article.blank? %>
     <% if lite_mode? %>
       <article class="h-entry" id="article-<%= article.id %>">


### PR DESCRIPTION
pretty sure this is needed.

Without it, people visiting the regular site will prime the cache and the `lite_mode` logic will never be run (or visa-versa, lite_mode could show up on regular site)