### PR TITLE
Add bundler caching to TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: trusty
 sudo: false
 language: ruby
+cache: bundler
 script: "./script/cibuild"
 
 addons:


### PR DESCRIPTION
One of the longest parts of the travis CI build is installing all of
the gems.

Travis CI added the ability to cache the [bundle phase][0]

If things start going wonky in CI builds, we can always remove this
line and go back to no caching, but for now this seems to speed things
up quite a bit

## difference
bottom time is no cache, top is with cache
<img width="672" alt="screen shot 2018-11-16 at 8 08 38 am" src="https://user-images.githubusercontent.com/13190980/48632889-f0ca4280-e976-11e8-85c8-0303993f623b.png">


[0]:https://docs.travis-ci.com/user/caching/#bundler