### PR TITLE
Use PostgreSQL service for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: trusty
 sudo: false
 language: ruby
 script: "./script/cibuild"
+before_script:
+  - cp config/database.yml.travis config/database.yml
+
+services:
+  - postgresql
 
 addons:
   postgresql: '9.6'

--- a/config/database.yml.travis
+++ b/config/database.yml.travis
@@ -1,0 +1,3 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test


### PR DESCRIPTION
I am not sure what this actually gets us since it seems like more
config for the same behavior we already get from Travis CI

That said, this change makes us match the [postgres TravisvCI documentation][0]

Maybe our current setup is deprecated and will stop working in the
future??

closes #761

[0]:https://docs.travis-ci.com/user/database-setup/#postgresql