### PR TITLE
Duplicate book model into zine model and create zines table

### DIFF
--- a/app/models/zine.rb
+++ b/app/models/zine.rb
@@ -1,0 +1,118 @@
+class Zine < ApplicationRecord
+  include Name
+  include Slug
+  include Publishable
+
+  scope :book, -> { where(zine: false) }
+  scope :zine, -> { where(zine: true)  }
+
+  has_many :taggings, dependent: :destroy, as: :taggable
+  has_many :tags, through: :taggings
+
+  default_scope { order(slug: :asc) }
+
+  ASSET_BASE_URL = 'https://cloudfront.crimethinc.com/assets'.freeze
+
+  def namespace
+    zine? ? 'zines' : 'books'
+  end
+
+  def book?
+    !zine?
+  end
+
+  def path
+    [nil, namespace, slug].join('/')
+  end
+
+  def image(side: :front, count: 0)
+    case side
+    when :front
+      [ASSET_BASE_URL, namespace, slug, "#{slug}_front.jpg"].join('/')
+    when :back
+      [ASSET_BASE_URL, namespace, slug, "#{slug}_back.jpg"].join('/')
+    when :gallery
+      [ASSET_BASE_URL, namespace, slug, 'gallery', "#{slug}-#{count}.jpg"].join('/')
+    when :header
+      [ASSET_BASE_URL, namespace, slug, 'gallery', "#{slug}_header.jpg"].join('/')
+    else
+      [ASSET_BASE_URL, namespace, slug, 'photo.jpg'].join('/')
+    end
+  end
+
+  def image_description
+    "Photo of ‘#{title}’ front cover"
+  end
+  alias front_image_description image_description
+
+  def back_image_description
+    "Photo of ‘#{title}’ back cover"
+  end
+
+  def front_image
+    image side: :front
+  end
+
+  def back_image
+    image side: :back
+  end
+
+  def header_image
+    image side: :header
+  end
+
+  def download_url(type = nil, extension: 'pdf')
+    case type
+    when :epub
+      type = nil
+      extension = 'epub'
+    when :mobi
+      type = nil
+      extension = 'mobi'
+    end
+
+    filename = [slug]
+    filename << "_#{type}" if type.present?
+    filename << '.'
+    filename << extension
+    filename = filename.join
+    [ASSET_BASE_URL, namespace, slug, filename].join('/')
+  end
+
+  def meta_description
+    if summary.blank?
+      html = Kramdown::Document.new(
+        content,
+        input: :kramdown,
+        remove_block_html_tags: false,
+        transliterated_header_ids: true
+      ).to_html.to_s
+
+      doc = Nokogiri::HTML(html)
+      doc.css('body').text.truncate(200)
+    else
+      summary
+    end
+  end
+
+  def meta_image
+    image side: :front
+  end
+
+  def downloads_available?
+     downloads = []
+     I18n.t('downloads.formats').keys.each do |format, _|
+       downloads << send("#{format}_download_present")
+     end
+     downloads.compact.any?
+  end
+
+  def gallery_images
+    if gallery_images_count.present? && gallery_images_count.positive?
+      biggest_image = gallery_images_count.to_s.rjust(2, '0')
+      ('01'..biggest_image).to_a
+    else
+      []
+    end
+  end
+end

--- a/db/migrate/20181120011802_create_zines.rb
+++ b/db/migrate/20181120011802_create_zines.rb
@@ -1,0 +1,53 @@
+class CreateZines < ActiveRecord::Migration[5.2]
+  def change
+    create_table :zines do |t|
+
+      t.text "title"
+      t.text "subtitle"
+      t.text "content"
+      t.text "tweet"
+      t.text "summary"
+      t.text "description"
+      t.text "buy_url"
+      t.text "buy_info"
+      t.string "content_format", default: "kramdown"
+      t.string "slug"
+      t.string "series"
+      t.datetime "published_at"
+      t.integer "price_in_cents"
+      t.string "height"
+      t.string "width"
+      t.string "depth"
+      t.string "weight"
+      t.string "pages"
+      t.string "words"
+      t.string "illustrations"
+      t.string "photographs"
+      t.string "printing"
+      t.string "ink"
+      t.string "definitions"
+      t.string "recipes"
+      t.boolean "has_index"
+      t.text "cover_style"
+      t.text "binding_style"
+      t.text "table_of_contents"
+      t.boolean "zine", default: true
+      t.boolean "back_image_present", default: false
+      t.boolean "front_image_present", default: false
+      t.boolean "lite_download_present", default: false
+      t.integer "gallery_images_count"
+      t.boolean "epub_download_present"
+      t.boolean "mobi_download_present"
+      t.integer "status_id"
+      t.boolean "print_black_and_white_a4_download_present"
+      t.boolean "print_color_a4_download_present"
+      t.boolean "print_color_download_present"
+      t.boolean "print_black_and_white_download_present"
+      t.boolean "screen_single_page_view_download_present"
+      t.boolean "screen_two_page_view_download_present"
+      t.integer "publication_status", default: 0, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_04_000207) do
+ActiveRecord::Schema.define(version: 2018_11_20_011802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -368,6 +368,55 @@ ActiveRecord::Schema.define(version: 2018_11_04_000207) do
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.integer "status_id"
     t.integer "publication_status", default: 0, null: false
+  end
+
+  create_table "zines", force: :cascade do |t|
+    t.text "title"
+    t.text "subtitle"
+    t.text "content"
+    t.text "tweet"
+    t.text "summary"
+    t.text "description"
+    t.text "buy_url"
+    t.text "buy_info"
+    t.string "content_format", default: "kramdown"
+    t.string "slug"
+    t.string "series"
+    t.datetime "published_at"
+    t.integer "price_in_cents"
+    t.string "height"
+    t.string "width"
+    t.string "depth"
+    t.string "weight"
+    t.string "pages"
+    t.string "words"
+    t.string "illustrations"
+    t.string "photographs"
+    t.string "printing"
+    t.string "ink"
+    t.string "definitions"
+    t.string "recipes"
+    t.boolean "has_index"
+    t.text "cover_style"
+    t.text "binding_style"
+    t.text "table_of_contents"
+    t.boolean "zine", default: true
+    t.boolean "back_image_present", default: false
+    t.boolean "front_image_present", default: false
+    t.boolean "lite_download_present", default: false
+    t.integer "gallery_images_count"
+    t.boolean "epub_download_present"
+    t.boolean "mobi_download_present"
+    t.integer "status_id"
+    t.boolean "print_black_and_white_a4_download_present"
+    t.boolean "print_color_a4_download_present"
+    t.boolean "print_color_download_present"
+    t.boolean "print_black_and_white_download_present"
+    t.boolean "screen_single_page_view_download_present"
+    t.boolean "screen_two_page_view_download_present"
+    t.integer "publication_status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
 

--- a/spec/factories/zines.rb
+++ b/spec/factories/zines.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :zine do
+  end
+end

--- a/spec/models/zine_spec.rb
+++ b/spec/models/zine_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Zine, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# #941 

- duplicate `book` model to make `zine` model
- run migration to create zines table
- create separate script in gist to populate zines table