### PR TITLE
Add simple locale switcher to header nav

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -44,12 +44,17 @@
 .header-logo a {
   @include image-replacement-graphic("crimethinc-logo-type-white.svg", "crimethinc-logo-type-white.svg", 15rem, 3rem);
   @include size(15rem, 3rem);
-  display: block;
+  display: inline-block;
 
   @media screen and (max-width: $small-tablet) {
     @include image-replacement-graphic("crimethinc-logo-type-white.svg", "crimethinc-logo-type-white.svg", 10rem, 2rem);
     @include size(10rem, 2rem);
   }
+}
+
+.language-switcher a,
+.language-switcher {
+  color: white !important;
 }
 
 .bulb-and-bones-logo {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,6 +75,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def url_for_localized_path locale = :en
+    locale = locale == I18n.default_locale ? nil : "#{locale}."
+    port   = ":#{request.port}" if request.port.present?
+
+    [request.protocol, locale, request.domain, port, request.path].join
+  end
+  helper_method :url_for_localized_path
+
   def check_for_redirection
     redirect = Redirect.where(source_path: request.path.downcase).last
     redirect = Redirect.where(source_path: "#{request.path.downcase}/").last if redirect.blank?

--- a/app/models/locales.rb
+++ b/app/models/locales.rb
@@ -1,0 +1,15 @@
+class Locales
+  SUPPORTED = %i[en es].freeze
+
+  class << self
+    def supported
+      @supported ||= supported_locales
+    end
+
+    private
+
+    def supported_locales
+      @supported = SUPPORTED - [I18n.locale]
+    end
+  end
+end

--- a/app/views/shared/header/_masthead.html.erb
+++ b/app/views/shared/header/_masthead.html.erb
@@ -1,5 +1,17 @@
 <header class="site-header" id="header">
-  <h1 class="header-logo"><%= link_to t("site_name"), [:root] %></h1>
+  <div>
+     <span class="header-logo"><%= link_to t("site_name"), [:root] %></span>
+
+     <% unless Rails.env.production? %>
+       <p class="language-switcher">
+         <%= t 'header.languages' %>:
+
+         <% Locales.supported.each do |locale| %>
+           <%= link_to t(:name, locale: locale), url_for_localized_path(locale) %>
+         <% end %>
+       </p>
+     <% end %>
+   </div>
 
   <%= render "shared/header/nav" %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
     meta_description: CrimethInc. is a decentralized network pledged to anonymous collective action. We strive to reinvent our lives and our world according to the principles of self-determination and mutual aid.
 
   header:
+    languages: Languages
     books: Books
     library: Library
     tools: Tools

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -9,6 +9,7 @@
 #  9. Markdown examples: [link text](url), **bold**, _italics_, %{dynamic variable}, etc.
 # 10. If a value has <b>HTML</b> syntax characters in it, please keep those in your translation.
 es:
+  name: Español
   language_direction: ltr
   site_name: CrimethInc.
   site_author: CrimethInc. Colectivo de Ex-trabajadores
@@ -20,6 +21,7 @@ es:
     meta_description: CrimethInc. es una red descentralizada dedicada a la acción colectiva anónima. Luchamos por reinventar nuestras vidas y nuestro mundo de acuerdo con los principios de la autodeterminación y el apoyo mutuo.
 
   header:
+    languages: Idiomas
     books: Libros
     library: Biblioteca
     tools: Herramientas


### PR DESCRIPTION
I messed up https://github.com/crimethinc/website/pull/886 by merging master in and then KABLAMMO. This is to redo that.

Only difference is I wrapped the locale switcher links (in the header) in a guard against working in production. So we can test in on staging. But not deploy it until we're happy with the `es.` story.