### PR TITLE
Fix locale site-switcher

### DIFF
--- a/app/models/locales.rb
+++ b/app/models/locales.rb
@@ -3,13 +3,7 @@ class Locales
 
   class << self
     def supported
-      @supported ||= supported_locales
-    end
-
-    private
-
-    def supported_locales
-      @supported = SUPPORTED - [I18n.locale]
+      SUPPORTED - [I18n.locale]
     end
   end
 end


### PR DESCRIPTION
If you cache on a `class` method, then it is cached as long as that
`class` is in memory