### PR TITLE
[TCE] don't scrub unicode for TCE paths

### DIFF
--- a/app/middlewares/rack/clean_path.rb
+++ b/app/middlewares/rack/clean_path.rb
@@ -73,6 +73,8 @@ module Rack
     end
 
     def transliterate_unicode_to_ascii_in path
+      return path if path.start_with?('/tce')
+
       result = path_pieces(path).map do |path_piece|
         file_pieces(path_piece).map { |f| transliterate_unicode_to_ascii(f) }.join('.')
       end


### PR DESCRIPTION
Some of our *To Change Everything* (TCE) language versions have
unicode in their URLs. Examples are Farsi ands Korean:

- http://crimethinc.com/tce/한국어
- http://crimethinc.com/tce/فارسی

This change just skips the unicode scrubbing logic for TCE paths

---

### demo

- https://crimethinc-staging-pr-1071.herokuapp.com/tce/한국어
- https://crimethinc-staging-pr-1071.herokuapp.com/tce/فارسی
