### PR TITLE
Add spec to lock in current Pages behavior

### DIFF
--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :page do
+    title { 'page title' }
+    content { 'page content' }
+    publication_status { 'published' }
+    published_at { Time.zone.parse '2017-01-01' }
+    sequence(:slug) { |n| "slug#{n}" }
+    image { 'https://cloudfront.crimethinc.com/assets/pages/start/start-header.jpg' }
+  end
+end

--- a/spec/system/special_pages_spec.rb
+++ b/spec/system/special_pages_spec.rb
@@ -39,7 +39,7 @@ describe 'Navigating to special 1-off pages' do
   end
 
   context 'with a non-existing page path' do
-    it 'redirect to thee home page' do
+    it 'redirect to the home page' do
       visit '/blahblahblah'
       expect(page).to have_current_path '/'
     end

--- a/spec/system/special_pages_spec.rb
+++ b/spec/system/special_pages_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+describe 'Navigating to special 1-off pages' do
+  before { %i[about start faq contact].each { |slug| create_page_with slug } }
+
+  shared_examples 'loads correct page' do |slug, content|
+    let(:expected_content) { content }
+    let(:slug) { slug }
+
+    it 'works' do
+      visit "/#{slug}"
+      expect(page).to have_current_path("/#{slug}")
+      expect(page).to have_content expected_content
+    end
+  end
+
+  context 'with path /about' do
+    include_examples 'loads correct page', :about, 'What Is Crimethink?'
+  end
+
+  context 'with path /start' do
+    include_examples 'loads correct page', :start, 'If This Is Your First Time Here'
+  end
+
+  context 'with path /contact' do
+    include_examples 'loads correct page', :contact, 'The best we can offer here is a partial listing—'
+  end
+
+  # The /faq page is different from the other `Pages` because it
+  # appears to be a redirect to `/begin`, which is an actual article
+  context 'with path /faq' do
+    it 'works' do
+      visit '/faq'
+      expect(page).to have_current_path('/2016/09/28/feature-the-secret-is-to-be' \
+                                        'gin-getting-started-further-resources-f' \
+                                        'requently-asked-questions')
+      expect(page).to have_content 'Frequently Asked Questions about Anarchism'
+    end
+  end
+
+  context 'with a non-existing page path' do
+    it 'redirect to thee home page' do
+      visit '/blahblahblah'
+      expect(page).to have_current_path '/'
+    end
+  end
+
+  def create_page_with(slug)
+    if slug == :faq
+      Redirect.create!(
+        source_path: '/faq',
+        target_path: '/2016/09/28/feature-the-secret-is-to-begin-getting' \
+                     '-started-further-resources-frequently-asked-questions#faq'
+      )
+
+      path = Rails.root.join('db', 'seeds', 'articles', 'features', 'begin', 'index.html')
+      slug = 'feature-the-secret-is-to-begin-getting-started-further-resources-frequently-asked-questions'
+
+      article = Article.create!(
+        title:              'a title',
+        subtitle:           '',
+        content:            File.read(path),
+        published_at:       Time.zone.parse('2016-09-28 08:11:00 -0700'),
+        image:              'foo',
+        publication_status: 'published',
+        content_format:     'html',
+        short_path:         SecureRandom.hex
+      )
+      article.slug = slug
+      article.save!
+    end
+
+    create(:page,
+           title: "title for #{slug}",
+           content: "content for #{slug}",
+           publication_status: 'published',
+           published_at: Time.zone.parse('2017-01-01'),
+           slug: slug.to_s,
+           image: 'https://cloudfront.crimethinc.com/assets/pages/start/start-header.jpg')
+  end
+end


### PR DESCRIPTION
This PR adds a system spec that verifies the current behavior of the
`Page`s we have in production

Current Behavior
---------------------
Currently in production we have the following pages
```ruby
#=> [“/about”, “/start”, “/faq”, “/contact”]
```

Also, currently, if a page doesn't exist we currently re-direct to the
homepage instead of throwing a `404`

Why?
-------
We want to deprecate the `Page` feature (it isn't really used) and get
rid of the catchall redirect so that we start showing `404`s again.

The main two reasons for showing `404`s again are:
1. we are pretty stable now, and would be nice to fix broken links in the wild with redirects
2. this should make integrating with `ActiveStorage` easier as there
   is currently some funky behavior with the catchall route

This PR Does Not
----------------
Note that this PR doesn't change any of the current behavior (leaves
the catchall route in place)

This PR just locks in a spec for the current content so that when the
route file is changed in a future PR, we don't regress any of these pages