### PR TITLE
remove route catch-all and hardcode pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -29,12 +29,10 @@ class PagesController < ApplicationController
   def set_page
     @page =
       if params[:draft_code].present?
-        Page.find_by(draft_code: params[:draft_code])
+        Page.find_by!(draft_code: params[:draft_code])
       else
-        Page.find_by(slug: params[:path])
+        Page.find_by!(slug: request.path.split('/').last)
       end
-
-    redirect_to [:root] if @page.blank?
   end
 
   def page_redirects

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,5 +175,8 @@ Rails.application.routes.draw do
   get 'opensearch.xml', to: 'misc#opensearch_xml'
 
   # Pages
-  get '*path', to: 'pages#show', as: :page, via: :all
+  get '/faq', to: 'pages#show', as: :faq, via: :all
+  get '/about', to: 'pages#show', as: :about, via: :all
+  get '/start', to: 'pages#show', as: :start, via: :all
+  get '/contact', to: 'pages#show', as: :contact, via: :all
 end

--- a/db/seeds/pages.rb
+++ b/db/seeds/pages.rb
@@ -1,5 +1,5 @@
 Page.create!(
-  title: "If This Is Your First Time Here&hellip;",
+  title: 'If This Is Your First Time Here&hellip;',
   content: %q{
 - [Who we are and what we do](/about)
 - [A basic introduction to anarchist values](/tce)
@@ -9,7 +9,36 @@ Page.create!(
 - [For more coverage of anarchist activity in North America](https://itsgoingdown.org)
   },
   publication_status: 'published',
-  published_at: Time.parse("2017-01-01"),
-  slug: "start",
-  image: "https://cloudfront.crimethinc.com/assets/pages/start/start-header.jpg",
+  published_at: Time.parse('2017-01-01'),
+  slug: 'start',
+  image: 'https://cloudfront.crimethinc.com/assets/pages/start/start-header.jpg',
 )
+
+Page.find_or_create_by!(slug: 'contact') do |page|
+  page.title = 'Contact'
+  page.content = 'a placeholder /contact page'
+  page.publication_status = 'published'
+  page.published_at = Time.zone.parse('2017-01-01')
+  page.image = ''
+end
+
+Page.find_or_create_by!(slug: 'about') do |page|
+  page.title = 'About'
+  page.content = 'a placeholder /about page'
+  page.publication_status = 'published'
+  page.published_at = Time.zone.parse('2017-01-01')
+  page.image = ''
+end
+
+Page.find_or_create_by!(slug: 'faq') do |page|
+  page.title = 'FAQ'
+  page.content = 'a placeholder /FAQ page'
+  page.publication_status = 'published'
+  page.published_at = Time.zone.parse('2017-01-01')
+  page.image = ''
+end
+# FAQ requires a redirect to the `begin` feature
+slug = 'feature-the-secret-is-to-begin-getting-started-further-resources-frequently-asked-questions'
+Redirect.find_or_create_by!(source_path: '/faq') do |redirect|
+  redirect.target_path = "/2016/09/28/#{slug}#faq"
+end

--- a/spec/system/special_pages_spec.rb
+++ b/spec/system/special_pages_spec.rb
@@ -39,9 +39,8 @@ describe 'Navigating to special 1-off pages' do
   end
 
   context 'with a non-existing page path' do
-    it 'redirect to the home page' do
-      visit '/blahblahblah'
-      expect(page).to have_current_path '/'
+    it 'shows the 404 page' do
+      expect { get '/blahblahblah' }.to raise_error(ActionController::RoutingError)
     end
   end
 


### PR DESCRIPTION
This relates to [PR #1162][0].

This removes the catch-all route mentioned in that PR

[0]:https://github.com/crimethinc/website/pull/1162