### PR TITLE
modify scenic search view

### DIFF
--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -1,5 +1,5 @@
 module Publishable
-  PUBLICATION_STATUSES = %i[draft published].freeze
+  PUBLICATION_STATUSES = { draft: 0, published: 1 }.freeze
   extend ActiveSupport::Concern
 
   included do
@@ -23,9 +23,9 @@ module Publishable
   class << self
     def publication_statuses_for user:
       if user.can_publish?
-        PUBLICATION_STATUSES
+        PUBLICATION_STATUSES.keys
       else
-        PUBLICATION_STATUSES - %i[published]
+        PUBLICATION_STATUSES.keys - %i[published]
       end
     end
   end

--- a/db/migrate/20190612031329_update_search_results_to_version_5.rb
+++ b/db/migrate/20190612031329_update_search_results_to_version_5.rb
@@ -1,0 +1,9 @@
+class UpdateSearchResultsToVersion5 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :search_results,
+                version: 5,
+                revert_to_version: 4,
+                materialized: true
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_22_081347) do
+ActiveRecord::Schema.define(version: 2019_06_12_031329) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "articles", id: :serial, force: :cascade do |t|
@@ -87,13 +86,13 @@ ActiveRecord::Schema.define(version: 2019_05_22_081347) do
     t.integer "gallery_images_count"
     t.boolean "epub_download_present"
     t.boolean "mobi_download_present"
+    t.integer "status_id"
     t.boolean "print_black_and_white_a4_download_present"
     t.boolean "print_color_a4_download_present"
     t.boolean "print_color_download_present"
     t.boolean "print_black_and_white_download_present"
     t.boolean "screen_single_page_view_download_present"
     t.boolean "screen_two_page_view_download_present"
-    t.integer "status_id"
     t.integer "publication_status", default: 0, null: false
   end
 
@@ -476,13 +475,12 @@ ActiveRecord::Schema.define(version: 2019_05_22_081347) do
                       WHEN (count(categories.*) = 0) THEN (ARRAY[]::text[])::character varying[]
                       ELSE array_remove(array_agg(categories.name), NULL::character varying)
                   END AS category_names
-             FROM (((((articles
-               JOIN statuses ON (((statuses.id = articles.status_id) AND ((statuses.name)::text = 'published'::text))))
+             FROM ((((articles
                LEFT JOIN taggings ON (((taggings.taggable_id = articles.id) AND ((taggings.taggable_type)::text = 'Article'::text))))
                LEFT JOIN tags ON ((tags.id = taggings.tag_id)))
                LEFT JOIN categorizations ON ((categorizations.article_id = articles.id)))
                LEFT JOIN categories ON ((categories.id = categorizations.category_id)))
-            WHERE (articles.published_at < now())
+            WHERE ((articles.published_at < now()) AND (articles.publication_status = 1))
             GROUP BY articles.id, 'Article'::text
           UNION
            SELECT pages.id AS searchable_id,
@@ -495,11 +493,10 @@ ActiveRecord::Schema.define(version: 2019_05_22_081347) do
                       ELSE array_agg(tags.name)
                   END AS tag_names,
               ARRAY[]::text[] AS category_names
-             FROM (((pages
-               JOIN statuses ON (((statuses.id = pages.status_id) AND ((statuses.name)::text = 'published'::text))))
+             FROM ((pages
                LEFT JOIN taggings ON (((taggings.taggable_id = pages.id) AND ((taggings.taggable_type)::text = 'Page'::text))))
                LEFT JOIN tags ON ((tags.id = taggings.tag_id)))
-            WHERE (pages.published_at < now())
+            WHERE ((pages.published_at < now()) AND (pages.publication_status = 1))
             GROUP BY pages.id, 'Page'::text
           UNION
            SELECT episodes.id AS searchable_id,

--- a/db/views/search_results_v05.sql
+++ b/db/views/search_results_v05.sql
@@ -24,7 +24,7 @@ SELECT
     LEFT JOIN tags ON tags.id = taggings.tag_id
     LEFT JOIN categorizations ON categorizations.article_id = articles.id
     LEFT JOIN categories ON categories.id = categorizations.category_id
-    WHERE articles.published_at < now() AND articles.   publication_status = 1
+    WHERE articles.published_at < now() AND articles.publication_status = 1
     GROUP BY searchable_id, searchable_type
 
     UNION

--- a/db/views/search_results_v05.sql
+++ b/db/views/search_results_v05.sql
@@ -1,0 +1,58 @@
+SELECT
+  searchable_id, searchable_type, title, subtitle, content,
+  tag_names AS tag,
+  category_names AS category,
+
+  setweight(title, 'A') ||
+  setweight(subtitle, 'B') ||
+  setweight(content, 'C') ||
+  setweight(array_to_tsvector(tag_names), 'D') ||
+  setweight(array_to_tsvector(category_names), 'D') AS document
+
+  FROM (
+    SELECT
+      articles.id AS searchable_id,
+      'Article' AS searchable_type,
+      to_tsvector(coalesce(articles.title, '')) AS title,
+      to_tsvector(coalesce(articles.subtitle, '')) AS subtitle,
+      to_tsvector(coalesce(articles.content, '')) AS content,
+      CASE WHEN COUNT(tags) = 0 THEN ARRAY[]::text[] ELSE array_remove(array_agg(tags.name), NULL) END AS tag_names,
+      CASE WHEN COUNT(categories) = 0 THEN ARRAY[]::text[] ELSE array_remove(array_agg(categories.name), NULL) END AS category_names
+
+    FROM articles
+    LEFT JOIN taggings ON taggings.taggable_id = articles.id AND taggings.taggable_type = 'Article'
+    LEFT JOIN tags ON tags.id = taggings.tag_id
+    LEFT JOIN categorizations ON categorizations.article_id = articles.id
+    LEFT JOIN categories ON categories.id = categorizations.category_id
+    WHERE articles.published_at < now() AND articles.   publication_status = 1
+    GROUP BY searchable_id, searchable_type
+
+    UNION
+
+    SELECT
+      pages.id AS searchable_id,
+      'Page' AS searchable_type,
+      to_tsvector(coalesce(pages.title, '')) AS title,
+      to_tsvector(coalesce(pages.subtitle, '')) AS subtitle,
+      to_tsvector(coalesce(pages.content, '')) AS content,
+      CASE WHEN COUNT(tags) = 0 THEN ARRAY[]::text[] ELSE array_agg(tags.name) END AS tag_names,
+      ARRAY[]::text[] AS category_names
+    FROM pages
+    LEFT JOIN taggings ON taggings.taggable_id = pages.id AND taggings.taggable_type = 'Page'
+    LEFT JOIN tags ON tags.id = taggings.tag_id
+    WHERE pages.published_at < now() AND pages.publication_status = 1
+    GROUP BY searchable_id, searchable_type
+
+    UNION
+
+    SELECT
+      episodes.id AS searchable_id,
+      'Episode' AS searchable_type,
+      to_tsvector(coalesce(episodes.title, '')) AS title,
+      to_tsvector(coalesce(episodes.subtitle, '')) AS subtitle,
+      to_tsvector(coalesce(episodes.content, '')) AS content,
+      ARRAY[]::text[] AS tag_names,
+      ARRAY[]::text[] AS category_names
+    FROM episodes
+    GROUP BY searchable_id, searchable_type
+  ) AS a;


### PR DESCRIPTION
@veganstraightedge @guitsaru I followed the scenic docs to [update  a view][0]

the main change i made to the view is i deleted this `JOIN`:
```sql
INNER JOIN statuses ON statuses.id = articles.status_id AND statuses.name='published'
```

and then I modified the `WHERE` clause to check for published articles/pages:

```sql
WHERE pages.published_at < now() AND pages.publication_status = 1
```

~the last thing to do was run `rails db:migrate`, but I got this error:~

```sh
ActiveRecord::StatementInvalid: PG::WrongObjectType: ERROR:  "search_results" is not a view
```
~not sure if that is just due to my local DB not having the scenic views in it. thoughts??~

@guitsaru fixed it. needed to add `materialized: true` to the migration 


[0]:https://github.com/scenic-views/scenic#cool-but-what-if-i-need-to-change-that-view