### PR TITLE
Fix the pages 404 spec

### DIFF
--- a/spec/system/special_pages_spec.rb
+++ b/spec/system/special_pages_spec.rb
@@ -40,7 +40,7 @@ describe 'Navigating to special 1-off pages' do
 
   context 'with a non-existing page path' do
     it 'shows the 404 page' do
-      expect { get '/blahblahblah' }.to raise_error(ActionController::RoutingError)
+      expect { get '/blahblahblah' }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 


### PR DESCRIPTION
We added back in the catch-all route, so the 404 is no longer
triggered at the router layer.

Update the exception in the spec as the 404 will now be triggered in
the controller level