### PR TITLE
Make collections optional

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -9,7 +9,7 @@ class Article < ApplicationRecord
 
   # Collections / Nested Articles, used for live blogs
   has_many   :collection_posts, foreign_key: :collection_id, class_name: 'Article', inverse_of: :collection, dependent: :destroy
-  belongs_to :collection,       foreign_key: :collection_id, class_name: 'Article', inverse_of: :collection_posts, touch: true
+  belongs_to :collection,       foreign_key: :collection_id, class_name: 'Article', inverse_of: :collection_posts, touch: true, optional: true
 
   before_validation :generate_published_dates, on: [:create, :update]
   before_validation :normalize_newlines,       on: [:create, :update]


### PR DESCRIPTION
I the [rails6 upgrade PR][0] all of the specs started failing with this
ActiveRecord validation error:

```sh
Failure/Error: collection = create(:article, title: 'test', publication_status: 'published', published_at: published_at)

      ActiveRecord::RecordInvalid:
        Validation failed: Collection must exist
      # ./spec/models/article_spec.rb:137:in `block (4 levels) in <top (required)>'
```

The issue appears to be that `belongs_to` associations seem to have
been [defaulted to `true` in Rails 5][1] and the validation enforced in
Rails 6

This PR sets `collections` to `optional` since most posts are not collections

[0]:https://github.com/crimethinc/website/pull/1164
[1]:https://github.com/rails/rails/issues/18233