### PR TITLE
Redirect to cwc subdomain urls

### DIFF
--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -18,7 +18,7 @@ class Redirect < ApplicationRecord
 
   def add_leading_slash
     paths.each do |path|
-      path.prepend '/' unless path =~ %r{^\/|https?}
+      path.prepend '/' unless path.starts_with?('/') || path.starts_with?('http')
     end
   end
 

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -57,15 +57,20 @@ class Redirect < ApplicationRecord
 
   def groomed_path_or_url url
     url_pieces = []
-    url_pieces << "#{url.scheme}://#{url.host}" unless url.host.blank? || crimethinc_url?(url)
+    url_pieces << "#{url.scheme}://#{url.host}" unless url.host.blank? || crimethinc_apex_domain_url?(url)
     url_pieces << url.path
     url_pieces << '?' + url.query    if url.query.present?
     url_pieces << '#' + url.fragment if url.fragment.present?
     url_pieces.join
   end
 
-  def crimethinc_url? url
-    url.host =~ /crimethinc.com|cwc.im/
+  def crimethinc_apex_domain_url? url
+    %w[
+      crimethinc.com
+      www.crimethinc.com
+      cwc.im
+      www.cwc.im
+    ].include? url.host
   end
 
   def noncircular_redirect

--- a/spec/models/redirect_spec.rb
+++ b/spec/models/redirect_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Redirect, type: :model do
 
     before { redirect.strip_domain_from_target_path }
 
+    context 'with crimethinc domain and subdomain' do
+      http_target_path = 'https://store.crimethinc.com/x/AddToCart?Item=democracy&Dest=books'
+
+      let(:redirect) { Redirect.new(source_path: 'source', target_path: http_target_path) }
+
+      it { is_expected.to eq(http_target_path) }
+    end
+
     context 'with leading domain' do
       let(:redirect) { Redirect.new(source_path: 'source', target_path: 'http://crimethinc.com/?query=true') }
 


### PR DESCRIPTION
Preserve crimethinc.com URLs with a significant subdomain in the `target_path` of a `Redirect`