### PR TITLE
Change japanese TCE url to use japanese characters

### DIFF
--- a/app/assets/stylesheets/to_change_everything/_nihongo.scss
+++ b/app/assets/stylesheets/to_change_everything/_nihongo.scss
@@ -1,5 +1,5 @@
 
-.nihongo {
+.日本人 {
   @import "common/font_styling";
   @import "nihongo/font_overrides";
   /*--- Highlight language in mobile language menu ---*/

--- a/app/controllers/to_change_everything_controller.rb
+++ b/app/controllers/to_change_everything_controller.rb
@@ -1,7 +1,7 @@
 class ToChangeEverythingController < ApplicationController
   layout 'to_change_everything', only: [:show]
 
-  TO_CHANGE_ANYTHING_YAMLS = %w[nihongo portugues quebecois espanol-america-latina lietuvos 한국어 english espanol فارسی].freeze
+  TO_CHANGE_ANYTHING_YAMLS = %w[日本人 portugues quebecois espanol-america-latina lietuvos 한국어 english espanol فارسی].freeze
 
   def show
     @locale = params[:lang]

--- a/app/views/layouts/to_change_everything.html.erb
+++ b/app/views/layouts/to_change_everything.html.erb
@@ -120,7 +120,7 @@
               <li><a href="http://www.crimethinc.com/blog/2016/09/21/to-change-everything-in-11-more-languages/#malay">Malay</a></li>
               <li><a href="http://www.crimethinc.com/blog/2016/09/21/to-change-everything-in-11-more-languages/#maltese">Malti</a></li>
               <li><a href="http://www.crimethinc.com/blog/2016/09/21/to-change-everything-in-11-more-languages/#dutch">Nederlands</a></li>
-              <li><a href="/tce/nihongo">Nihongo</a></li>
+              <li><a href="/tce/日本人">日本人</a></li>
               <li><a href="/tce/polski">Polski</a></li>
               <li><a href="/tce/portugues">Português</a></li>
               <li><a href="http://www.crimethinc.com/blog/2016/01/25/to-change-everything-in-ten-more-languages/#romanian">Română</a></li>
@@ -191,7 +191,7 @@
         <li><a href="http://www.crimethinc.com/blog/2016/09/21/to-change-everything-in-11-more-languages/#malay">Malay</a></li>
         <li><a href="http://www.crimethinc.com/blog/2016/09/21/to-change-everything-in-11-more-languages/#maltese">Malti</a></li>
         <li><a href="http://www.crimethinc.com/blog/2016/09/21/to-change-everything-in-11-more-languages/#dutch">Nederlands</a></li>
-        <li><a href="/tce/nihongo">nihongo <span class="check check-nihongo"></span></a></li>
+        <li><a href="/tce/日本人">日本人 <span class="check check-nihongo"></span></a></li>
         <li><a href="/tce/polski">Polski  <span class="check check-polski"></span></a></li>
         <li><a href="/tce/portugues">Português  <span class="check check-portugues"></span></a></li>
         <li><a href="http://www.crimethinc.com/blog/2016/01/25/to-change-everything-in-ten-more-languages/#romanian">Română</a></li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,7 @@ module Crimethinc
     config.i18n.default_locale = :en
 
     # Whitelist locales available for the application
-    config.i18n.available_locales = %i[nihongo cz de en es fr portugues quebecois espanol-america-latina lietuvos 한국어 english espanol فارسی]
+    config.i18n.available_locales = %i[日本人 cz de en es fr portugues quebecois espanol-america-latina lietuvos 한국어 english espanol فارسی]
 
     # Allow nested diretories in locales
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]

--- a/config/locales/to_change_everything/ja.yml
+++ b/config/locales/to_change_everything/ja.yml
@@ -1,4 +1,4 @@
-nihongo:
+日本人:
   layouts:
     to_change_everything:
       language_direction: ltr
@@ -12,7 +12,7 @@ nihongo:
           url: http://tochangeeverything.com/nihongo
       menu:
         toc: "目次"
-        language: nihongo
+        language: 日本人
         share: "シェア"
       toc:
         introduction: 前書き # google translate


### PR DESCRIPTION
I just realized I used latin characters for the japanese URL, but other languages (e.g. farsi, korean) used their native character sets...

should probably go with japanese characters for the url

---

demo: https://crimethinc-staging-pr-1215.herokuapp.com/tce/日本人