### PR TITLE
[Translations] Allow article locale to override rtl/ltr html attr

### DIFF
--- a/app/controllers/admin/locales_controller.rb
+++ b/app/controllers/admin/locales_controller.rb
@@ -50,7 +50,7 @@ module Admin
     end
 
     def locale_params
-      params.require(:locale).permit(:abbreviation, :name, :name_in_english)
+      params.require(:locale).permit(:abbreviation, :name, :name_in_english, :language_direction)
     end
   end
 end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,10 +1,10 @@
 module TagsHelper
   def html_dir
-    t 'language_direction'
+    article_locale&.language_direction.presence || t('language_direction')
   end
 
   def html_lang
-    I18n.locale
+    article_locale&.abbreviation.presence || I18n.locale
   end
 
   def html_prefix
@@ -22,5 +22,11 @@ module TagsHelper
 
   def body_id
     @body_id
+  end
+
+  private
+
+  def article_locale
+    @article_locale ||= Locale.find_by(abbreviation: @article&.locale)
   end
 end

--- a/app/models/locale.rb
+++ b/app/models/locale.rb
@@ -6,6 +6,8 @@ class Locale < ApplicationRecord
   validates :name_in_english, uniqueness: true
   validates :name, uniqueness: true
 
+  enum language_direction: %i[ltr rtl]
+
   def display_name
     "#{abbreviation.upcase} : #{name_in_english} / #{name}"
   end

--- a/app/views/admin/locales/_form.html.erb
+++ b/app/views/admin/locales/_form.html.erb
@@ -11,6 +11,11 @@
     <div class="col-12 col-md-5">
       <%= render "admin/label_and_field_form_group", form: form, attr: :name %>
     </div>
+
+    <div class="field">
+      <%= form.label :language_direction %><br>
+      <%= form.select :language_direction, Locale.language_directions.keys %>
+    </div>
   </div>
 
   <%= render "admin/form_actions", cancel_url: [:admin, :locales] %>

--- a/app/views/admin/locales/index.html.erb
+++ b/app/views/admin/locales/index.html.erb
@@ -7,6 +7,7 @@
       <th>Abbreviation</th>
       <th>Name in English</th>
       <th>Name</th>
+      <th>Language Direction</th>
     </tr>
   </thead>
 
@@ -19,6 +20,7 @@
         <td><%= locale.abbreviation %></td>
         <td><%= locale.name_in_english %></td>
         <td><%= locale.name %></td>
+        <td><%= locale.language_direction %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/shared/footer/_newsletter.html.erb
+++ b/app/views/shared/footer/_newsletter.html.erb
@@ -27,7 +27,8 @@
         <%= button_tag t("footer.contact.newsletter.signup_button_text"), name: "subscribe", id: "mc-embedded-subscribe" %>
 
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_cb48383602b7373f496e9ba33_344714b249" tabindex="-1" value=""></div>
+        <% left_or_right = html_dir == 'ltr' ? "position: absolute; left: -5000px;" : "position: absolute; right: -5000px;" %>
+        <div id="a-thing-with-an-id" style="<%= left_or_right %>" aria-hidden="true"><input type="text" name="b_cb48383602b7373f496e9ba33_344714b249" tabindex="-1" value=""></div>
     <% end %>
 
   </div><!--End mc_embed_signup-->

--- a/db/migrate/20190731153550_add_language_direction_to_locale.rb
+++ b/db/migrate/20190731153550_add_language_direction_to_locale.rb
@@ -1,0 +1,5 @@
+class AddLanguageDirectionToLocale < ActiveRecord::Migration[5.2]
+  def change
+    add_column :locales, :language_direction, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_06_193709) do
+ActiveRecord::Schema.define(version: 2019_07_31_153550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -209,6 +209,7 @@ ActiveRecord::Schema.define(version: 2019_07_06_193709) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "language_direction", default: 0
   end
 
   create_table "logos", force: :cascade do |t|


### PR DESCRIPTION
So, it looks like articles can have on-the-fly locales created (this
is separate from having site-wide support for a language)

The mechanism added to do this does not account for `rtl` languages.

This changes adds some (maybe janky) support for `rtl`

### NOTE: an article set `rtl` will show the `admin#edit` page in
RTL (which looks _okay_, but some CSS should probably be re-written to
make it look _good_)