### PR TITLE
Delete jquery.js from public site [fixes #1260]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,10 @@ gem 'puma'
 # assets
 gem 'autoprefixer-rails'
 gem 'bootstrap', '~> 4.3.1'
-gem 'jquery-rails'
-gem 'jquery-ui-rails'   # used for polyfilling forms in admin/articles
+gem 'jquery-rails'      # for bootstrap pages (admin, steal-something-from-work-day)
+gem 'jquery-ui-rails'   # for polyfilling forms in admin/articles
 gem 'sassc-rails'
-gem 'sitemap_generator' # generates compliant xml sitemap
+gem 'sitemap_generator' # for generating a compliant xml sitemap
 gem 'uglifier'
 
 # JSON views

--- a/app/assets/javascripts/jquery.js
+++ b/app/assets/javascripts/jquery.js
@@ -1,2 +1,0 @@
-//= require jquery3
-//= require jquery_ujs

--- a/app/views/shared/head/_javascripts.html.erb
+++ b/app/views/shared/head/_javascripts.html.erb
@@ -1,13 +1,5 @@
 <%# JS for /support %>
-<%  if controller_name == 'support' %>
-  <!-- JS -->
-  <%= javascript_include_tag 'jquery' %>
-  <%= javascript_include_tag 'support' %>
-<% end %>
+<%= javascript_include_tag 'support' if controller_name == 'support' %>
 
 <%# JS for live blog articles %>
-<%  if live_blog_article? %>
-  <!-- JS -->
-  <%= javascript_include_tag 'jquery' %>
-  <%= javascript_include_tag 'live_blog' %>
-<% end %>
+<%= javascript_include_tag 'live_blog' if live_blog_article? %>


### PR DESCRIPTION
Deletes final vestige of jQuery from the main part of the site.

Exceptions are:

- `/admin` (bootstrap and `publish now` button, which should move to the backend)
- https://crimethinc.com/steal-something-from-work-day
- the old site "Features" https://crimethinc.com/categories/features
- https://crimethinc.com/tce

In time, most/all of those can probably get removed too. We'll get two of them for free when Bootstrap v5 ships (whenever that is), because they're removing jQuery.