### PR TITLE
  Use headless Firefox for specs instead of chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ services:
   - postgresql
 
 addons:
-  chrome: stable
   postgresql: "10"
+  firefox: latest
   apt:
     packages:
       - postgresql-10
@@ -19,14 +19,9 @@ env:
     - CODECLIMATE_REPO_TOKEN: 70b1a0a5ca106d965eb0570c0e4b7577d76c352305fb5719aa984eeae4941bdf
     - CC_TEST_REPORTER_ID: 70b1a0a5ca106d965eb0570c0e4b7577d76c352305fb5719aa984eeae4941bdf
     - PGPORT: 5433
+    - MOZ_HEADLESS: 1
 
 before_install:
-  - wget -N http://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip -P ~/
-  - unzip ~/chromedriver_linux64.zip -d ~/
-  - rm ~/chromedriver_linux64.zip
-  - sudo mv -f ~/chromedriver /usr/local/share/
-  - sudo chmod +x /usr/local/share/chromedriver
-  - sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
   - gem install bundler
 
 before_script:

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,13 +18,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 end
 
-Capybara.register_driver :chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
-
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
-end
-
-Capybara.javascript_driver = :chrome
+Capybara.javascript_driver = :selenium_headless
 
 # from https://github.com/rspec/rspec-rails/issues/1897
 Capybara.server = :puma, { Silent: true }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ SimpleCov.start 'rails'
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :chrome
+    driven_by :selenium_headless, using: :firefox
   end
 
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Travis CI build id breaking with this error.

```
Selenium::WebDriver::Error::SessionNotCreatedError:
session not created exception: Chrome version must be >= 67.0.3396.0
(Driver info: chromedriver=2.41.578700 (2f1ed5f9343c13f73144538f15c00b370eda6706),platform=Linux 4.4.0-101-generic x86_64)
```

This PR replaces chrome with headless Firefox for specs