### PR TITLE
 Move `Publish Now!` feature to the backend

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -22,41 +22,6 @@ $(function() {
   });
 });
 
-// pad 0s (or whatever) on the left of strings
-$(function() {
-  function rjust(str, width, padding) {
-    padding = padding || " ";
-    padding = padding.substr(0, 1);
-
-    if (str.length < width) {
-      return padding.repeat(width - str.length) + str;
-    } else {
-      return str;
-    }
-  }
-
-  $("#js-admin-article #publish-now").click(function() {
-    var now    = new Date();
-    var year   = now.getUTCFullYear();
-    var month  = rjust((now.getUTCMonth() + 1).toString(), 2, "0");
-    var day    = rjust(now.getUTCDate().toString(),        2, "0");
-    var hour   = rjust(now.getUTCHours().toString(),       2, "0");
-    var minute = rjust(now.getUTCMinutes().toString(),     2, "0");
-
-    // set published_at date to utc.now
-    $("#article_published_at_tz").val("UTC");
-    $("#publication_date").val(year + "-" + month + "-" + day);
-    $("#publication_time").val(hour+":"+minute);
-
-    // set publication status to published
-    $("#publication_status_published").attr("checked", "checked");
-
-    // submit form to publish article
-    $("#article-form").submit();
-    return false;
-  });
-});
-
 $(function() {
   var date_and_time_supported = (Modernizr.inputtypes.time && Modernizr.inputtypes.date);
   // not-supported, so polyfill

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -34,7 +34,7 @@ module Admin
     end
 
     def create
-      @article = Article.new(updated_article_params)
+      @article = Article.new(article_params)
 
       if @article.save
         redirect_to [:admin, @article], notice: 'Article was successfully created.'
@@ -46,7 +46,7 @@ module Admin
     def update
       @article.tags.destroy_all
 
-      if @article.update(updated_article_params)
+      if @article.update(article_params)
         # Bust the article cache to update list of translations on articles
         @article.localizations.each(&:touch)
 
@@ -88,21 +88,36 @@ module Admin
     end
 
     def article_params
-      params.require(:article).permit(:title, :subtitle, :content, :year, :month, :day,
-                                      :tweet, :slug, :draft_code, :summary, :published_at,
-                                      :tags, :collection_id, :short_path, :image, :css,
-                                      :image_description, :image_mobile, :published_at_tz,
-                                      :locale, :canonical_id,
-                                      :publication_status, category_ids: [])
-    end
+      permitted_params = params.require(:article).permit(
+        :title, :subtitle, :content, :year, :month, :day, :tweet, :slug,
+        :draft_code, :summary, :published_at, :tags, :collection_id,
+        :short_path, :image, :css, :image_description, :image_mobile,
+        :published_at_tz, :locale, :canonical_id, :publication_status,
+        category_ids: []
+      )
 
-    def updated_article_params
-      return article_params if current_user.can_publish?
-      return article_params if @article&.published?
+      # if the `publish_now` submit button was used, we should see
+      # that name show up in the raw params, we will set the
+      # `published_at` to `Time.zone.now` and the `publication_status`
+      # to 'published'
+      handle_publish_now_situation(permitted_params) if params[:publish_now].present?
+
+      return permitted_params if current_user.can_publish? || @article&.published?
 
       # Override publication_status from the submitted for,
       # to prevent authors and editors from publishing a draft article
-      article_params.merge(publication_status: 'draft') if @article.blank? || @article.draft?
+      permitted_params.merge(publication_status: 'draft') if @article.blank? || @article.draft?
+    end
+
+    def handle_publish_now_situation permitted_params
+      return permitted_params unless current_user.can_publish?
+      return permitted_params if @article&.published?
+
+      permitted_params.merge!(
+        publication_status: 'published',
+        published_at:       Time.zone.now,
+        published_at_tz:    Time.zone.name
+      )
     end
   end
 end

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -102,6 +102,8 @@ module Admin
       # to 'published'
       handle_publish_now_situation(permitted_params) if params[:publish_now].present?
 
+      handle_published_without_datetime permitted_params
+
       return permitted_params if current_user.can_publish? || @article&.published?
 
       # Override publication_status from the submitted for,
@@ -109,15 +111,27 @@ module Admin
       permitted_params.merge(publication_status: 'draft') if @article.blank? || @article.draft?
     end
 
-    def handle_publish_now_situation permitted_params
+    def handle_publish_now_situation permitted_params, time: Time.zone.now, zone: Time.zone.name
       return permitted_params unless current_user.can_publish?
       return permitted_params if @article&.published?
 
       permitted_params.merge!(
         publication_status: 'published',
-        published_at:       Time.zone.now,
-        published_at_tz:    Time.zone.name
+        published_at:       time,
+        published_at_tz:    zone
       )
+    end
+
+    def handle_published_without_datetime permitted_params
+      return if @article&.published?
+
+      publish_in_100_years = permitted_params[:publication_status] == 'published' &&
+                             permitted_params[:published_at].blank?
+
+      time = Time.zone.now + 100.years
+      tz = Time.zone.name
+
+      handle_publish_now_situation(permitted_params, time: time, zone: tz) if publish_in_100_years
     end
   end
 end

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -59,16 +59,12 @@
               <div class="card-body">
                 <p class="card-text">
                   If you want to publish this article <b>right now</b>, you can with one click.
-                  If you click the <b>Publish NOW!</b> button, the <code>published_at</code>
-                  will be set to now and the <code>publication_status</code> will be set to
-                  <i>Published</i>. This article will immediately show up in
-                  the homepage feed.
-
-                  <noscript><p><b>Requires Javascript</b> to be turned on to work.</p></noscript>
+                  If you click the <b>Publish NOW!</b> button, this article will immediately
+                  show up in the homepage feed.
                 </p>
 
                 <div class="text-right">
-                  <%= link_to "Publish NOW!", "#", id: "publish-now", class: "btn btn-warning btn-lg" %>
+                  <%= form.submit 'Publish NOW!', :name => 'publish_now', id: "publish-now", class: "btn btn-warning btn-lg" %>
                 </div>
               </div>
             </div>

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -64,7 +64,7 @@
                 </p>
 
                 <div class="text-right">
-                  <%= form.submit 'Publish NOW!', :name => 'publish_now', id: "publish-now", class: "btn btn-warning btn-lg" %>
+                  <%= form.submit "Publish NOW!", name: 'publish_now', id: "publish-now", class: "btn btn-warning btn-lg" %>
                 </div>
               </div>
             </div>

--- a/db/migrate/20191109234653_attempt_to_fix_500_publish_error.rb
+++ b/db/migrate/20191109234653_attempt_to_fix_500_publish_error.rb
@@ -1,0 +1,12 @@
+class AttemptToFix500PublishError < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :articles, :publication_status, from: 'draft', to: 0
+    change_column_default :issues,   :publication_status, from: 'draft', to: 0
+    change_column_default :books,    :publication_status, from: 'draft', to: 0
+    change_column_default :journals, :publication_status, from: 'draft', to: 0
+    change_column_default :logos,    :publication_status, from: 'draft', to: 0
+    change_column_default :pages,    :publication_status, from: 'draft', to: 0
+    change_column_default :posters,  :publication_status, from: 'draft', to: 0
+    change_column_default :videos,   :publication_status, from: 'draft', to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_03_083559) do
+ActiveRecord::Schema.define(version: 2019_11_09_234653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"

--- a/spec/system/article_datetime_settings_spec.rb
+++ b/spec/system/article_datetime_settings_spec.rb
@@ -89,4 +89,23 @@ describe 'Setting and changing an articles published_at date' do
       expect(article).to be_published
     end
   end
+
+  it 'Sets the publication date/time if article is `published` and fields are blank' do
+    freeze_time do
+      login_user(admin)
+      visit '/admin/articles'
+
+      click_on 'NEW'
+
+      within('#publication_status') { choose 'Published' }
+      find_button('Save', match: :first).click
+
+      expect(page).to have_content 'Article was successfully created'
+      article = Article.last
+
+      expect(article.reload.published_at_tz).to eq('UTC')
+      expect(article.published_at).to eq(Time.now.utc + 100.years)
+      expect(article).to be_published
+    end
+  end
 end

--- a/spec/system/article_datetime_settings_spec.rb
+++ b/spec/system/article_datetime_settings_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Setting and changing an articles published_at date' do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:admin) do
     create(:user, username: 'user1', password: 'c' * 31, role: 'publisher')
   end
@@ -70,31 +72,21 @@ describe 'Setting and changing an articles published_at date' do
     expect(article.published_at).to be_nil
   end
 
-  it 'uses ‘PUBLISH NOW’ feature', :js do
-    # TODO: the 'publish now' feature relies on a JavaScript in
-    # the front-end to automatically set the form fields and submit the
-    # form. This makes testing time hard since we cannot
-    # Timecop.freeze the front-end. Consider making the 'Publish Now!'
-    # feature a back-end feature
-    login_user(admin)
-    visit '/admin/articles'
+  it 'uses ‘PUBLISH NOW’ feature' do
+    freeze_time do
+      login_user(admin)
+      visit '/admin/articles'
 
-    click_on 'NEW'
+      click_on 'NEW'
 
-    time = Time.now.utc
+      within('#datetime') { click_on 'Publish NOW!' }
 
-    within('#datetime') { click_on 'Publish NOW!' }
+      expect(page).to have_content 'Article was successfully created'
+      article = Article.last
 
-    expect(page).to have_content 'Article was successfully created'
-    article = Article.last
-
-    # rough approximation of 'now'
-    expect(article.published_at.day).to eq(time.day)
-    expect(article.published_at.month).to eq(time.month)
-    expect(article.published_at.year).to eq(time.year)
-    expect(article.published_at.hour).to eq(time.hour)
-    expect(article).to be_published
-
-    expect(article.reload.published_at_tz).to eq('UTC')
+      expect(article.reload.published_at_tz).to eq('UTC')
+      expect(article.published_at).to eq(Time.now.utc)
+      expect(article).to be_published
+    end
   end
 end


### PR DESCRIPTION


We have very little JS in the app, and the `Publish Now!` feature is
one of the few areas.

It is possible to move this to the backend, so we figured why not?