### PR TITLE
Handle `publish` with no datetime

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -122,7 +122,7 @@ module Admin
       )
     end
 
-    def handle_published_wo_datetime permitted_params
+    def handle_published_without_datetime permitted_params
       return if @article&.published?
 
       publish_in_100_years = permitted_params[:publication_status] == 'published' &&

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -102,7 +102,7 @@ module Admin
       # to 'published'
       handle_publish_now_situation(permitted_params) if params[:publish_now].present?
 
-      handle_published_wo_datetime(permitted_params)
+      handle_published_without_datetime permitted_params
 
       return permitted_params if current_user.can_publish? || @article&.published?
 

--- a/spec/system/article_datetime_settings_spec.rb
+++ b/spec/system/article_datetime_settings_spec.rb
@@ -89,4 +89,23 @@ describe 'Setting and changing an articles published_at date' do
       expect(article).to be_published
     end
   end
+
+  it 'Sets the publication date/time if article is `published` and fields are blank' do
+    freeze_time do
+      login_user(admin)
+      visit '/admin/articles'
+
+      click_on 'NEW'
+
+      within('#publication_status') { choose 'Published' }
+      find_button('Save', match: :first).click
+
+      expect(page).to have_content 'Article was successfully created'
+      article = Article.last
+
+      expect(article.reload.published_at_tz).to eq('UTC')
+      expect(article.published_at).to eq(Time.now.utc + 100.years)
+      expect(article).to be_published
+    end
+  end
 end


### PR DESCRIPTION
Currently, if you set the `publication_status` to `'published'` for an
article, and then click `Save` **WITHOUT** setting a publication date
and time, you will get a `500` error.

We have decided to treat this scenario by setting the publication date
100 years in the future

