### PR TITLE
Debiggen seeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ISSUES.md
 .idea/
 TAGS
 .env
+database-dumps

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,7 +70,7 @@ Security/Eval:
 
 Security/Open:
   Exclude:
-    - 'lib/tasks/db.rake'
+    - 'lib/tasks/db/import.rake'
 
 Style/AsciiComments:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,6 +68,10 @@ Security/Eval:
   Exclude:
     - 'db/seeds.rb'
 
+Security/Open:
+  Exclude:
+    - 'lib/tasks/db.rake'
+
 Style/AsciiComments:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'logstash-event'
 # dev and testing
 group :development, :test do
   gem 'awesome_print'
+  gem 'aws-sdk-s3'
   gem 'byebug', platform: :mri
   gem 'capybara'
   gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,22 @@ GEM
     autoprefixer-rails (9.7.1)
       execjs
     awesome_print (1.8.0)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.240.0)
+    aws-sdk-core (3.78.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.25.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.56.0)
+      aws-sdk-core (~> 3, >= 3.77.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.13)
     bindex (0.8.1)
     bootstrap (4.3.1)
@@ -126,6 +142,7 @@ GEM
     jaro_winkler (1.5.4)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
+    jmespath (1.4.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -349,6 +366,7 @@ PLATFORMS
 DEPENDENCIES
   autoprefixer-rails
   awesome_print
+  aws-sdk-s3
   bcrypt (~> 3.1.13)
   bootstrap (~> 4.3.1)
   bugsnag

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The `server` script starts the Rails server on port `3000` (which uses **Puma**)
 #### Site’s running but no articles?
 
 Stop the server, [seed the database](#database-seed-script), then run the server script again.
+This will import (scrubbed) production data into your local development database.
 
 ```
 ./script/seed

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,9 @@
 puts '==> Downloading DB dump from S3…'
-sh 'rails db:dump:download'
+sh 'rake db:dump:download'
 puts
 
 puts '==> Importing pg dump into local development DB…'
-sh 'rails db:dump:import'
+sh 'rake db:dump:import'
 puts
 
 puts '==> All done!'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,30 +1,9 @@
-test_user = User.new(username:              'tester',
-                     password:              '123456789012345678901234567890',
-                     password_confirmation: '123456789012345678901234567890')
+puts '==> Downloading DB dump from S3…'
+sh 'rails db:dump:download'
+puts
 
-test_user.save!(validate: false)
+puts '==> Importing pg dump into local development DB…'
+sh 'rails db:dump:import'
+puts
 
-puts 'Trying dev seeds for each post-type...'
-%w[
-  books
-  pages
-  redirects
-  videos
-  podcasts
-  episodes
-  issues
-  featured_issues
-  articles
-].each do |post_type|
-  file_path = File.expand_path("../seeds/#{post_type}.rb", __FILE__)
-
-  puts "  Trying: #{post_type}"
-  puts
-
-  next unless File.exist?(file_path)
-
-  puts "  Found: #{post_type}"
-  eval(File.open(file_path).read)
-  puts '...done'
-  puts
-end
+puts '==> All done!'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,9 @@
 puts '==> Downloading DB dump from S3…'
-sh 'rake db:dump:download'
+sh 'rake db:import:download'
 puts
 
 puts '==> Importing pg dump into local development DB…'
-sh 'rake db:dump:import'
+sh 'rake db:import:populate'
 puts
 
 puts '==> All done!'

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,5 +1,3 @@
-require 'fileutils'
-
 namespace :db do
   namespace :dump do
     desc 'Download DB dump from S3'

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -43,15 +43,21 @@ namespace :db do
   task scrub: :environment do
     puts '==> Scrubbing DB…'
     puts '==> Scrubbing Users…'
-    User.destroy_all
 
+    # delete all users except User ID #1, to reuse that ID
+    User.all.each do |user|
+      user.id == 1 ? next : user.destroy
+    end
+
+    # update the first user instead of creating a new one,
+    # so to not reveal how many production users there are
     password = '1234567890' * 3
     publisher_role = User::ROLES.index :publisher
 
-    User.create! username:              :publisher,
-                 password:              password,
-                 password_confirmation: password,
-                 role:                  publisher_role
+    User.find(1).update username:              :publisher,
+                        password:              password,
+                        password_confirmation: password,
+                        role:                  publisher_role
     puts
 
     puts '==> Scrubbing drafts…'

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -12,6 +12,10 @@ namespace :db do
       sh 'rails db:create'
       puts
 
+      puts '==> Migrating DB…'
+      sh 'rails db:migrate'
+      puts
+
       puts '==> Populate DB from pg dump file…'
       sh 'psql crimethinc_development < database-dumps/crimethinc_production_db_dump.sql'
     end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -20,15 +20,15 @@ namespace :db do
     desc 'Import pg dump into local development DB'
     task import: :environment do
       puts '==> Dropping local development DB…'
-      sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop'
+      sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rake db:drop'
       puts
 
       puts '==> Creating local test DB…'
-      sh 'rails db:create'
+      sh 'rake db:create'
       puts
 
       puts '==> Migrating DB…'
-      sh 'rails db:migrate'
+      sh 'rake db:migrate'
       puts
 
       puts '==> Populate DB from pg dump file…'
@@ -44,7 +44,7 @@ namespace :db do
       puts
 
       puts '==> Dropping local development DB…'
-      sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop'
+      sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rake db:drop'
       puts
 
       puts '==> Pulling remote production DB…'
@@ -52,7 +52,7 @@ namespace :db do
       puts
 
       puts '==> Creating local test DB…'
-      sh 'rails db:create'
+      sh 'rake db:create'
     end
 
     desc 'Scrub private production data from DB'

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,139 +1,145 @@
 require 'fileutils'
 
 namespace :db do
-  desc 'Import pg dump into local development DB'
-  task import: :environment do
-    puts '==> Dropping local development DB…'
-    sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop'
-    puts
+  namespace :dump do
+    desc 'Import pg dump into local development DB'
+    task import: :environment do
+      puts '==> Dropping local development DB…'
+      sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop'
+      puts
 
-    puts '==> Creating local test DB…'
-    sh 'rails db:create'
-    puts
+      puts '==> Creating local test DB…'
+      sh 'rails db:create'
+      puts
 
-    puts '==> Populate DB from pg dump file…'
-    sh 'psql crimethinc_development < database-dumps/crimethinc_production_db_dump.sql'
-    puts
-
-    puts '==> All done!'
-  end
-
-  desc 'Pull production DB'
-  task export: %i[pull scrub dump upload]
-
-  desc 'Pull production DB'
-  task pull: :environment do
-    puts '==> This requires that you have Heroku access to this production app'
-    puts
-
-    puts '==> Dropping local development DB…'
-    sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop'
-    puts
-
-    puts '==> Pulling remote production DB…'
-    sh 'heroku pg:pull DATABASE_URL crimethinc_development --app crimethinc'
-    puts
-
-    puts '==> Creating local test DB…'
-    sh 'rails db:create'
-    puts
-  end
-
-  desc 'Scrub private production data from DB'
-  task scrub: :environment do
-    puts '==> Scrubbing DB…'
-    puts '==> Scrubbing Users…'
-
-    # delete all users except User ID #1, to reuse that ID
-    User.all.each do |user|
-      user.id == 1 ? next : user.destroy
+      puts '==> Populate DB from pg dump file…'
+      sh 'psql crimethinc_development < database-dumps/crimethinc_production_db_dump.sql'
     end
 
-    # update the first user instead of creating a new one,
-    # so to not reveal how many production users there are
-    password = '1234567890' * 3
-    publisher_role = User::ROLES.index :publisher
+    desc 'Pull production DB'
+    task export: %i[pull scrub dump upload]
 
-    User.find(1).update username:              :publisher,
-                        password:              password,
-                        password_confirmation: password,
-                        role:                  publisher_role
-    puts
+    desc 'Pull production DB'
+    task pull: :environment do
+      puts '==> This requires that you have Heroku access to this production app'
+      puts
 
-    puts '==> Scrubbing drafts…'
-    # TODO: add #publication_status to these models: Definition Episode Podcast
-    [Article, Book, Issue, Journal, Logo, Page, Poster, Sticker, Video, Zine].each do |klass|
-      klass.draft.destroy_all
-    end
-    puts
-  end
+      puts '==> Dropping local development DB…'
+      sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop'
+      puts
 
-  desc 'Dump local development DB'
-  task dump: :environment do
-    # ensure that the db dumps directory is present
-    FileUtils.mkdir_p Rails.root.join 'database-dumps'
+      puts '==> Pulling remote production DB…'
+      sh 'heroku pg:pull DATABASE_URL crimethinc_development --app crimethinc'
+      puts
 
-    puts '==> Dumping local development DB…'
-    # create a PG dump and save it to the db dumps directory
-    sh 'pg_dump --dbname=crimethinc_development --file=database-dumps/crimethinc_production_db_dump.sql'
-    puts
-
-    puts '==> All done!'
-  end
-
-  desc 'Upload DB dump to S3'
-  task upload: :environment do
-    puts '==> Uploading local development DB dump to S3…'
-
-    # check for required env vars
-    env_vars = [
-      aws_access_key_id     = ENV.fetch('AWS_ACCESS_KEY_ID')     { 'TODO' },
-      aws_secret_access_key = ENV.fetch('AWS_SECRET_ACCESS_KEY') { 'TODO' },
-      s_3_bucket = ENV.fetch('S3_BUCKET') { 'TODO' }
-    ]
-
-    # exit if any env vars aren't set
-    if env_vars.include? 'TODO'
-      puts 'You need to set these as environment variables or in a .env file:'
-      puts 'AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET'
-      exit
+      puts '==> Creating local test DB…'
+      sh 'rails db:create'
     end
 
-    # config AWS
-    Aws.config.update(
-      region:      'us-east-1',
-      credentials: Aws::Credentials.new(aws_access_key_id, aws_secret_access_key)
-    )
+    desc 'Scrub private production data from DB'
+    task scrub: :environment do
+      puts '==> Scrubbing DB…'
+      puts '==> Scrubbing Users…'
 
-    # client is for making file public. s_3 is for file upload.
-    client = Aws::S3::Client.new
-    s_3    = Aws::S3::Resource.new
+      # delete all users except User ID #1, to reuse that ID
+      User.all.each do |user|
+        user.id == 1 ? next : user.destroy
+      end
 
-    # reference an existing bucket by name
-    bucket_name = s_3_bucket
-    bucket      = s_3.bucket(bucket_name)
-    bucket_url  = bucket.url
+      # update the first user instead of creating a new one,
+      # so to not reveal how many production users there are
+      password = '1234567890' * 3
+      publisher_role = User::ROLES.index :publisher
 
-    # Get just the file name
-    file_name = 'database-dumps/crimethinc_production_db_dump.sql'
+      User.find(1).update username:              :publisher,
+                          password:              password,
+                          password_confirmation: password,
+                          role:                  publisher_role
+      puts
 
-    # Create the object to upload
-    obj = s_3.bucket(bucket_name).object(file_name)
+      puts '==> Scrubbing drafts…'
+      # TODO: add #publication_status to these models: Definition Episode Podcast
+      [Article, Book, Issue, Journal, Logo, Page, Poster, Sticker, Video, Zine].each do |klass|
+        klass.draft.destroy_all
+      end
+    end
 
-    # Upload it
-    obj.upload_file file_name
+    desc 'Dump local development DB'
+    task dump: :environment do
+      # ensure that the db dumps directory exists
+      FileUtils.mkdir_p Rails.root.join 'database-dumps'
 
-    # Setting the object to public-read
-    client.put_object_acl(
-      acl:    'public-read',
-      bucket: bucket_name,
-      key:    file_name
-    )
+      puts '==> Dumping local development DB…'
+      # create a PG dump and save it to the db dumps directory
+      sh 'pg_dump --dbname=crimethinc_development --file=database-dumps/crimethinc_production_db_dump.sql'
+    end
 
-    download_url = [bucket_url, file_name].join('/')
-    puts "SUCCESS! File written to S3: #{download_url}"
-    puts
+    desc 'Upload DB dump to S3'
+    task upload: :environment do
+      puts '==> Uploading local development DB dump to S3…'
 
-    puts '==> All done!'
+      # check for required env vars
+      env_vars = [
+        aws_access_key_id     = ENV.fetch('AWS_ACCESS_KEY_ID')     { 'TODO' },
+        aws_secret_access_key = ENV.fetch('AWS_SECRET_ACCESS_KEY') { 'TODO' },
+        s_3_bucket = ENV.fetch('S3_BUCKET') { 'TODO' }
+      ]
+
+      # exit if any env vars aren't set
+      if env_vars.include? 'TODO'
+        puts 'You need to set these as environment variables or in a .env file:'
+        puts 'AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET'
+        exit
+      end
+
+      # config AWS
+      Aws.config.update(
+        region:      'us-east-1',
+        credentials: Aws::Credentials.new(aws_access_key_id, aws_secret_access_key)
+      )
+
+      # client is for making file public. s_3 is for file upload.
+      client = Aws::S3::Client.new
+      s_3    = Aws::S3::Resource.new
+
+      # reference an existing bucket by name
+      bucket_name = s_3_bucket
+      bucket      = s_3.bucket(bucket_name)
+      bucket_url  = bucket.url
+
+      # Get just the file name
+      file_name = 'database-dumps/crimethinc_production_db_dump.sql'
+
+      # Create the object to upload
+      obj = s_3.bucket(bucket_name).object(file_name)
+
+      # Upload it
+      obj.upload_file file_name
+
+      # Setting the object to public-read
+      client.put_object_acl(
+        acl:    'public-read',
+        bucket: bucket_name,
+        key:    file_name
+      )
+
+      download_url = [bucket_url, file_name].join('/')
+      puts "SUCCESS! File written to S3: #{download_url}"
+    end
+
+    desc 'Download DB dump from S3'
+    task download: :environment do
+      # ensure that the db dump directory and file exist
+      FileUtils.mkdir_p Rails.root.join 'database-dumps'
+      FileUtils.touch Rails.root.join 'database-dumps', 'crimethinc_production_db_dump.sql'
+
+      # URL to download from
+      url = 'https://s3.amazonaws.com/thecloud.crimethinc.com/database-dumps/crimethinc_production_db_dump.sql'
+
+      puts '==> Downloading remote production DB dump from S3…'
+      open('database-dumps/crimethinc_production_db_dump.sql', 'wb') do |file|
+        file << open(url).read
+      end
+    end
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 namespace :db do
   desc 'Pull production DB'
   task export: %i[pull scrub dump upload]
@@ -45,8 +47,12 @@ namespace :db do
 
   desc 'Dump local development DB'
   task dump: :environment do
+    # ensure that the db dumps directory is present
+    FileUtils.mkdir_p Rails.root.join 'database-dumps'
+
     puts '==> Dumping local development DB…'
-    sh 'pg_dump --dbname=crimethinc_development --file=tmp/crimethinc_production_db_dump.sql'
+    # create a PG dump and save it to the db dumps directory
+    sh 'pg_dump --dbname=crimethinc_development --file=database-dumps/crimethinc_production_db_dump.sql'
     puts
 
     puts '==> All done!'
@@ -55,7 +61,61 @@ namespace :db do
   desc 'Upload DB dump to S3'
   task upload: :environment do
     puts '==> Uploading local development DB dump to S3…'
-    # TODO: upload to S3
+
+    # check for required env vars
+    env_vars = [
+      aws_access_key_id     = ENV.fetch('AWS_ACCESS_KEY_ID')     { 'TODO' },
+      aws_secret_access_key = ENV.fetch('AWS_SECRET_ACCESS_KEY') { 'TODO' },
+      s_3_bucket = ENV.fetch('S3_BUCKET') { 'TODO' }
+    ]
+
+    # exit if any env vars aren't set
+    if env_vars.include? 'TODO'
+      puts 'You need to set these as environment variables or in a .env file:'
+      puts 'AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET'
+      exit
+    end
+
+    # config AWS
+    Aws.config.update(
+      region:      'us-east-1',
+      credentials: Aws::Credentials.new(aws_access_key_id, aws_secret_access_key)
+    )
+
+    # client is for making file public. s_3 is for file upload.
+    client = Aws::S3::Client.new
+    s_3    = Aws::S3::Resource.new
+
+    # reference an existing bucket by name
+    bucket_name = s_3_bucket
+    bucket      = s_3.bucket(bucket_name)
+    bucket_url  = bucket.url
+
+    # Sets a bucket to public-read
+    # puts 'Setting S3 bucket to public'
+    # client.put_bucket_acl(
+    #   acl:    'public-read',
+    #   bucket: bucket_name
+    # )
+
+    # Get just the file name
+    file_name = 'database-dumps/crimethinc_production_db_dump.sql'
+
+    # Create the object to upload
+    obj = s_3.bucket(bucket_name).object(file_name)
+
+    # Upload it
+    obj.upload_file file_name
+
+    # Setting the object to public-read
+    client.put_object_acl(
+      acl:    'public-read',
+      bucket: bucket_name,
+      key:    file_name
+    )
+
+    download_url = [bucket_url, file_name].join('/')
+    puts "SUCCESS! File written to S3: #{download_url}"
     puts
 
     puts '==> All done!'

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -108,13 +108,6 @@ namespace :db do
     bucket      = s_3.bucket(bucket_name)
     bucket_url  = bucket.url
 
-    # Sets a bucket to public-read
-    # puts 'Setting S3 bucket to public'
-    # client.put_bucket_acl(
-    #   acl:    'public-read',
-    #   bucket: bucket_name
-    # )
-
     # Get just the file name
     file_name = 'database-dumps/crimethinc_production_db_dump.sql'
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -2,6 +2,21 @@ require 'fileutils'
 
 namespace :db do
   namespace :dump do
+    desc 'Download DB dump from S3'
+    task download: :environment do
+      # ensure that the db dump directory and file exist
+      FileUtils.mkdir_p Rails.root.join 'database-dumps'
+      FileUtils.touch Rails.root.join 'database-dumps', 'crimethinc_production_db_dump.sql'
+
+      # URL to download from
+      url = 'https://s3.amazonaws.com/thecloud.crimethinc.com/database-dumps/crimethinc_production_db_dump.sql'
+
+      puts '==> Downloading remote production DB dump from S3…'
+      open('database-dumps/crimethinc_production_db_dump.sql', 'wb') do |file|
+        file << open(url).read
+      end
+    end
+
     desc 'Import pg dump into local development DB'
     task import: :environment do
       puts '==> Dropping local development DB…'
@@ -129,21 +144,6 @@ namespace :db do
 
       download_url = [bucket_url, file_name].join('/')
       puts "SUCCESS! File written to S3: #{download_url}"
-    end
-
-    desc 'Download DB dump from S3'
-    task download: :environment do
-      # ensure that the db dump directory and file exist
-      FileUtils.mkdir_p Rails.root.join 'database-dumps'
-      FileUtils.touch Rails.root.join 'database-dumps', 'crimethinc_production_db_dump.sql'
-
-      # URL to download from
-      url = 'https://s3.amazonaws.com/thecloud.crimethinc.com/database-dumps/crimethinc_production_db_dump.sql'
-
-      puts '==> Downloading remote production DB dump from S3…'
-      open('database-dumps/crimethinc_production_db_dump.sql', 'wb') do |file|
-        file << open(url).read
-      end
     end
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,23 @@
 require 'fileutils'
 
 namespace :db do
+  desc 'Import pg dump into local development DB'
+  task import: :environment do
+    puts '==> Dropping local development DB…'
+    sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop'
+    puts
+
+    puts '==> Creating local test DB…'
+    sh 'rails db:create'
+    puts
+
+    puts '==> Populate DB from pg dump file…'
+    sh 'psql crimethinc_development < database-dumps/crimethinc_production_db_dump.sql'
+    puts
+
+    puts '==> All done!'
+  end
+
   desc 'Pull production DB'
   task export: %i[pull scrub dump upload]
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,41 @@
+namespace :db do
+  desc "Dump production db, scrub private stuff, upload to S3. Used by 'rake db:seed'"
+  task export: :environment do
+    puts '==> This requires that you have Heroku access to this production app'
+    puts
+
+    puts '==> Dropping local development DB…'
+    sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rails db:drop'
+    puts
+
+    puts '==> Pulling remote production DB…'
+    sh 'heroku pg:pull DATABASE_URL crimethinc_development --app crimethinc'
+    puts
+
+    puts '==> Creating local test DB…'
+    sh 'rails db:create'
+    puts
+
+    puts '==> Scrubbing DB…'
+    puts '==> Scrubbing Users…'
+    User.destroy_all
+
+    password = '1234567890' * 3
+    publisher_role = User::ROLES.index :publisher
+
+    User.create! username:              :publisher,
+                 password:              password,
+                 password_confirmation: password,
+                 role:                  publisher_role
+    puts
+
+    puts '==> Scrubbing drafts…'
+    # TODO: add #publication_status to these models: Definition Episode Podcast
+    [Article, Book, Issue, Journal, Logo, Page, Poster, Sticker, Video, Zine].each do |klass|
+      klass.draft.destroy_all
+    end
+    puts
+
+    puts '==> All done!'
+  end
+end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -74,7 +74,6 @@ namespace :db do
                           password:              password,
                           password_confirmation: password,
                           role:                  publisher_role
-      puts
 
       puts '==> Scrubbing drafts…'
       # TODO: add #publication_status to these models: Definition Episode Podcast

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,6 +1,9 @@
 namespace :db do
-  desc "Dump production db, scrub private stuff, upload to S3. Used by 'rake db:seed'"
-  task export: :environment do
+  desc 'Pull production DB'
+  task export: %i[pull scrub dump upload]
+
+  desc 'Pull production DB'
+  task pull: :environment do
     puts '==> This requires that you have Heroku access to this production app'
     puts
 
@@ -15,7 +18,10 @@ namespace :db do
     puts '==> Creating local test DB…'
     sh 'rails db:create'
     puts
+  end
 
+  desc 'Scrub private production data from DB'
+  task scrub: :environment do
     puts '==> Scrubbing DB…'
     puts '==> Scrubbing Users…'
     User.destroy_all
@@ -34,6 +40,22 @@ namespace :db do
     [Article, Book, Issue, Journal, Logo, Page, Poster, Sticker, Video, Zine].each do |klass|
       klass.draft.destroy_all
     end
+    puts
+  end
+
+  desc 'Dump local development DB'
+  task dump: :environment do
+    puts '==> Dumping local development DB…'
+    sh 'pg_dump --dbname=crimethinc_development --file=tmp/crimethinc_production_db_dump.sql'
+    puts
+
+    puts '==> All done!'
+  end
+
+  desc 'Upload DB dump to S3'
+  task upload: :environment do
+    puts '==> Uploading local development DB dump to S3…'
+    # TODO: upload to S3
     puts
 
     puts '==> All done!'

--- a/lib/tasks/db/export.rake
+++ b/lib/tasks/db/export.rake
@@ -1,41 +1,8 @@
 namespace :db do
-  namespace :dump do
-    desc 'Download DB dump from S3'
-    task download: :environment do
-      # ensure that the db dump directory and file exist
-      FileUtils.mkdir_p Rails.root.join 'database-dumps'
-      FileUtils.touch Rails.root.join 'database-dumps', 'crimethinc_production_db_dump.sql'
+  desc 'Export (scrubbed) production DB to S3'
+  task export: %i[db:export:pull db:export:scrub db:export:dump db:export:upload]
 
-      # URL to download from
-      url = 'https://s3.amazonaws.com/thecloud.crimethinc.com/database-dumps/crimethinc_production_db_dump.sql'
-
-      puts '==> Downloading remote production DB dump from S3…'
-      open('database-dumps/crimethinc_production_db_dump.sql', 'wb') do |file|
-        file << open(url).read
-      end
-    end
-
-    desc 'Import pg dump into local development DB'
-    task import: :environment do
-      puts '==> Dropping local development DB…'
-      sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rake db:drop'
-      puts
-
-      puts '==> Creating local test DB…'
-      sh 'rake db:create'
-      puts
-
-      puts '==> Migrating DB…'
-      sh 'rake db:migrate'
-      puts
-
-      puts '==> Populate DB from pg dump file…'
-      sh 'psql crimethinc_development < database-dumps/crimethinc_production_db_dump.sql'
-    end
-
-    desc 'Pull production DB'
-    task export: %i[pull scrub dump upload]
-
+  namespace :export do
     desc 'Pull production DB'
     task pull: :environment do
       puts '==> This requires that you have Heroku access to this production app'

--- a/lib/tasks/db/import.rake
+++ b/lib/tasks/db/import.rake
@@ -1,0 +1,39 @@
+namespace :db do
+  desc 'Export (scrubbed) production DB to S3'
+  task import: %i[db:import:download db:import:populate]
+
+  namespace :import do
+    desc 'Download DB dump from S3'
+    task download: :environment do
+      # ensure that the db dump directory and file exist
+      FileUtils.mkdir_p Rails.root.join 'database-dumps'
+      FileUtils.touch Rails.root.join 'database-dumps', 'crimethinc_production_db_dump.sql'
+
+      # URL to download from
+      url = 'https://s3.amazonaws.com/thecloud.crimethinc.com/database-dumps/crimethinc_production_db_dump.sql'
+
+      puts '==> Downloading remote production DB dump from S3…'
+      open('database-dumps/crimethinc_production_db_dump.sql', 'wb') do |file|
+        file << open(url).read
+      end
+    end
+
+    desc 'Import pg dump into local development DB'
+    task populate: :environment do
+      puts '==> Dropping local development DB…'
+      sh 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 rake db:drop'
+      puts
+
+      puts '==> Creating local test DB…'
+      sh 'rake db:create'
+      puts
+
+      puts '==> Migrating DB…'
+      sh 'rake db:migrate'
+      puts
+
+      puts '==> Populate DB from pg dump file…'
+      sh 'psql crimethinc_development < database-dumps/crimethinc_production_db_dump.sql'
+    end
+  end
+end

--- a/script/seed
+++ b/script/seed
@@ -21,11 +21,11 @@ chdir APP_ROOT do
   system! 'bundle exec rails db:create'
 
   puts '==> Downloading DB dump from S3…'
-  system! 'bundle exec rake db:dump:download'
+  system! 'bundle exec rake db:import:download'
   puts
 
   puts '==> Importing pg dump into local development DB…'
-  system! 'bundle exec rake db:dump:import'
+  system! 'bundle exec rake db:import:populate'
   puts
 
   puts '==> All done!'

--- a/script/seed
+++ b/script/seed
@@ -14,8 +14,6 @@ def system! *args
 end
 
 chdir APP_ROOT do
-  system! 'script/bootstrap'
-
   puts '==> Dropping DB…'
   system! 'bundle exec rails db:drop'
 

--- a/script/seed
+++ b/script/seed
@@ -20,11 +20,13 @@ chdir APP_ROOT do
   puts '==> Creating DB…'
   system! 'bundle exec rails db:create'
 
-  puts '==> Migrating DB…'
-  system! 'bundle exec rails db:migrate'
+  puts '==> Downloading DB dump from S3…'
+  system! 'bundle exec rake db:dump:download'
+  puts
 
-  puts '==> Seeding DB…'
-  system! 'bundle exec rails db:seed'
+  puts '==> Importing pg dump into local development DB…'
+  system! 'bundle exec rake db:dump:import'
+  puts
 
-  puts '==> DB is now ready to go!'
+  puts '==> All done!'
 end


### PR DESCRIPTION
- Add rake tasks to create pull production db, scrub private data, create a pg dump, and upload it to S3. For now, these are run manually by someone who has production Heroku access.
- Add rake tasks to download said pg dump, and import into local development db
- Update `db:seed` and `./script/seed` to use the download and import tasks

If this all works out, local development will be able to use production data, and we can delete the very big `db/seeds` folder (in a separate PR)