### PR TITLE
Migrate asset precompile to manifest.js

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,16 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+
+//= link jquery.js
+//= link live_blog.js
+//= link support.js
+//= link tochangeeverything.css
+//= link admin.js
+//= link admin.css
+//= link steal-something-from-work-day.css
+//= link steal-something-from-work-day.js
+//= link 2017.css
+//= link 2020.css
+
+// ??? lite_mode.css

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,7 +2,6 @@
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
 
-//= link jquery.js
 //= link live_blog.js
 //= link support.js
 //= link tochangeeverything.css

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,24 +7,3 @@ Rails.application.config.assets.version = '1.0'
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in the app/assets
-# folder are already added.
-Rails.application.config.assets.precompile += %w[
-  jquery.js
-
-  live_blog.js
-  support.js
-  lite_mode.css
-  tochangeeverything.css
-
-  admin.js
-  admin.css
-
-  steal-something-from-work-day.css
-  steal-something-from-work-day.js
-
-  2017.css
-  2020.css
-]


### PR DESCRIPTION
Sprockets 4 and rails 6 defaults to using the manifest file to
compile assets

https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs

I moved the files from the old `assets.precompile` config to the new
style, but the `lite_mode` CSS was a weird one (it is and html file,
not a CSS file)

Need to make sure lite mode still works after this change (and maybe
make it a CSS file instead of html/erb??)