### PR TITLE
Add a codeowners file and PR Template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Migrations must be approved in order to make sure the db export rake
+# task is still scrubbing sensitive info
+/lib/tasks/db/ @veganstraightedge @astronaut-wannabe
+/db/ @veganstraightedge @astronaut-wannabe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# Migrations must be approved in order to make sure the db export rake
+# Migrations must be approved in order to make sure the database export rake
 # task is still scrubbing sensitive info
 /lib/tasks/db/ @veganstraightedge @astronaut-wannabe
 /db/ @veganstraightedge @astronaut-wannabe

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -18,7 +18,7 @@ resolves `[link to github issue]`
 
 ??
 
-# Questions for pull requests author (delete any that don't apply):
+# Questions for the pull request author (delete any that don't apply):
 - [ ] Are any needed README/wiki/documentation updates needed for this pull request?
 - [ ] Does the code you updated have tests? If not, could you add some please?
 - [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,4 +1,5 @@
-# How does this PR make you feel (in animated GIF format)?
+# How does this pull request make you feel (in animated GIF format)?
+
 ![alt text](giphy link)
 
 # What are the relevant GH issues?

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -6,7 +6,8 @@
 
 resolves `[link to github issue]`
 
-# What's this PR do?
+# What does this pull request do?
+
 ??
 # How should this be manually tested?
 ??

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -21,7 +21,7 @@ resolves `[link to github issue]`
 # Questions for pull requests author (delete any that don't apply):
 - [ ] Are any needed README/wiki/documentation updates needed for this pull request?
 - [ ] Does the code you updated have tests?
-- [ ] Requires new server dependencies which need to be added to the build process. If so explain.
+- [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.
 
 # Acceptance Criteria
 ## These should be checked by the reviewer(s).

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -18,7 +18,7 @@ resolves `[link to github issue]`
 
 ??
 
-# Questions for PR author (delete any that don't apply):
+# Questions for pull requests author (delete any that don't apply):
 - [ ] Have any needed readme/wiki/documentation updates been made?
 - [ ] Does the code you updated have tests?
 - [ ] Requires new server dependencies which need to be added to the build process. If so explain.

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -26,4 +26,4 @@ resolves `[link to github issue]`
 # Acceptance Criteria
 ## These should be checked by the reviewers
 
-- [ ] Does not cause the db export script to become out of sync with the db schema
+- [ ] This pull request does not cause the database export script to become out of sync with the db schema

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -9,7 +9,9 @@ resolves `[link to github issue]`
 # What does this pull request do?
 
 ??
+
 # How should this be manually tested?
+
 ??
 # Any background context you want to provide?
 ??

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -23,6 +23,6 @@ resolves `[link to github issue]`
 - [ ] Does the code you updated have tests?
 - [ ] Requires new server dependencies which need to be added to the build process. If so explain.
 
-# Acceptance Criteria:
+# Acceptance Criteria
 ## These should be checked by the reviewer(s).
 - [ ] Does not cause the db export script to become out of sync with the db schema

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -13,7 +13,9 @@ resolves `[link to github issue]`
 # How should this be manually tested?
 
 ??
-# Any background context you want to provide?
+
+# Is there any background context you want to provide for reviewers?
+
 ??
 
 # Questions for PR author (delete any that don't apply):

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -20,7 +20,7 @@ resolves `[link to github issue]`
 
 # Questions for pull requests author (delete any that don't apply):
 - [ ] Are any needed README/wiki/documentation updates needed for this pull request?
-- [ ] Does the code you updated have tests?
+- [ ] Does the code you updated have tests? If not, could you add some please?
 - [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.
 
 # Acceptance Criteria

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -19,7 +19,7 @@ resolves `[link to github issue]`
 ??
 
 # Questions for pull requests author (delete any that don't apply):
-- [ ] Have any needed readme/wiki/documentation updates been made?
+- [ ] Are any needed README/wiki/documentation updates needed for this pull request?
 - [ ] Does the code you updated have tests?
 - [ ] Requires new server dependencies which need to be added to the build process. If so explain.
 

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -24,5 +24,6 @@ resolves `[link to github issue]`
 - [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.
 
 # Acceptance Criteria
-## These should be checked by the reviewer(s).
+## These should be checked by the reviewers
+
 - [ ] Does not cause the db export script to become out of sync with the db schema

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,0 +1,21 @@
+# How does this PR make you feel (in animated GIF format)?
+![alt text](giphy link)
+
+# What are the relevant GH issues?
+resolves `[link to github issue]`
+
+# What's this PR do?
+??
+# How should this be manually tested?
+??
+# Any background context you want to provide?
+??
+
+# Questions for PR author (delete any that don't apply):
+- [ ] Have any needed readme/wiki/documentation updates been made?
+- [ ] Does the code you updated have tests?
+- [ ] Requires new server dependencies which need to be added to the build process. If so explain.
+
+# Acceptance Criteria:
+## These should be checked by the reviewer(s).
+- [ ] Does not cause the db export script to become out of sync with the db schema

--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -2,7 +2,8 @@
 
 ![alt text](giphy link)
 
-# What are the relevant GH issues?
+# What are the relevant GitHub issues?
+
 resolves `[link to github issue]`
 
 # What's this PR do?


### PR DESCRIPTION
# How does this PR make you feel (in animated GIF format)?
![extra](https://media.giphy.com/media/1b9p0KmGHHih2/giphy.gif)

# What are the relevant GH issues?
n/a

# What's this PR do?
## Codeowners File
This will add a check before any code gets merged in that modifies the
db schema or the export rake task

I left the examples from the [github docs][0] in the PR for now in
case anything else comes up during the PR process, but I will remove
all of the commented out examples before merging the PR

## PR Template
I am not super tied to this template or anything, but I did want an
extra reminder for PRs that mentioned the db export script again

# How should this be manually tested?
- open a PR 
  - should see the template populate the PR description
- modify the files covered by the new CODEOWNERS file
  - should see @veganstraightedge auto-assigned as a reviewer
# Any background context you want to provide?
We want to make sure the new db export rake task doesn't get out of
sync with the db/schema (and possibly leaking sensitive info)

We opted for this approach (as opposed to something like securing db
dumps behind ssh keys) in order to keep friction low for people who
would like to jump in and help.

# Acceptance Criteria:
## These should be checked by the reviewer(s).
- [X] Does not cause the db export script to become out of sync with the db schema

[0]:https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file