### PR TITLE
[API] handle JSON requests with rack middleware

### DIFF
--- a/app/middlewares/rack/json_requests.rb
+++ b/app/middlewares/rack/json_requests.rb
@@ -1,0 +1,31 @@
+module Rack
+  class JsonRequests
+    API_REQUEST_ERROR = {
+      status: '406',
+      title:  'Content Type Not Acceptable',
+      detail: 'Y\'all requested JSON, but we don\'t do that'
+    }.freeze
+
+    def initialize app
+      @app = app
+    end
+
+    def call env
+      request = Rack::Request.new(env)
+      content_type = request.env['HTTP_ACCEPT']
+      return json_406_error if content_type.start_with?('application/json')
+
+      @app.call(env)
+    end
+
+    private
+
+    def json_406_error
+      [
+        406,
+        { 'Content-Type' => 'application/json' },
+        [{ errors: [API_REQUEST_ERROR] }.to_json]
+      ]
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require_relative '../app/middlewares/rack/json_requests'
 require_relative '../app/middlewares/rack/domain_redirect'
 require_relative '../app/middlewares/rack/apex_redirect'
 require_relative '../app/middlewares/rack/clean_path'
@@ -15,6 +16,7 @@ Bundler.require(*Rails.groups)
 
 module Crimethinc
   class Application < Rails::Application
+    config.middleware.use Rack::JsonRequests
     config.middleware.use Rack::DomainRedirect
     config.middleware.use Rack::ApexRedirect
     config.middleware.use Rack::CleanPath

--- a/spec/requests/json_requests_spec.rb
+++ b/spec/requests/json_requests_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe 'JsonRequests', type: :request do
+  let(:json_headers) { { ACCEPT: 'application/json', HTTP_ACCEPT: 'application/json', CONTENT_TYPE: 'application/json' } }
+  let(:expected_error) { "Y'all requested JSON, but we don't do that" }
+
+  it 'returns a 406 response to clients requesting json' do
+    get root_path, headers: json_headers
+
+    expect(response.content_type).to eq 'application/json'
+    expect(status).to eq 406
+  end
+
+  it 'returns an error message in the body' do
+    get root_path, headers: json_headers
+
+    error_message = JSON.parse(body)['errors'].first.dig('detail')
+    expect(error_message).to eq expected_error
+  end
+end


### PR DESCRIPTION
# How does this PR make you feel (in animated GIF format)?
![extra](https://media.giphy.com/media/VeeSaYv0g4rOu9RHQ6/giphy.gif)

# What are the relevant GH issues?
resolves https://github.com/crimethinc/website/issues/1235

# What's this PR do?
This change adds a piece of rack middleware which

1. checks if the requested response type is JSON
2. if JSON is requested, returns a JSON error and a 406

# How should this be manually tested?
I tested by running the following curl againt my local branch:
```sh
curl -v -H "Content-Type: application/json" -H "Accept: application/json" http://localhost:3000
```

# Any background context you want to provide?
we occasionally get API style requests, which just error out due to the fact we do not have an API.

we discussed handling these with a controller `before` action or something, and settled on a small piece of rack middleware

# Questions for PR author (delete any that don't apply):
- [X] Does the code you updated have tests?

# Acceptance Criteria:
## These should be checked by the reviewer(s).
- [x] Does not cause the db export script to become out of sync with the db schema
