### PR TITLE
[i18n] Make all of the links on the language landing page work

### DIFF
--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -1,4 +1,6 @@
 class LanguagesController < ApplicationController
+  before_action :set_articles, only: :show
+
   def index
     @html_id = 'page'
     @body_id = 'languages'
@@ -10,14 +12,20 @@ class LanguagesController < ApplicationController
   def show
     @html_id = 'page'
     @body_id = 'languages'
-    @locale  = Locale.find_by slug: canonical_locale_slug
+    @locale  = Locale.find_by(slug: canonical_locale.canonical)
 
     render "#{Theme.name}/languages/show"
   end
 
   private
 
-  def canonical_locale_slug
-    LocaleService.find(locale: params[:locale]).canonical
+  def canonical_locale
+    @canonical_locale ||= LocaleService.find(locale: params[:locale])
+  end
+
+  def set_articles
+    abbreviation = canonical_locale.lang_code
+    @articles = Article.live.published.where(locale: abbreviation).page(params[:page]).per(25)
+    return redirect_to root_path if @articles.empty?
   end
 end

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -10,8 +10,14 @@ class LanguagesController < ApplicationController
   def show
     @html_id = 'page'
     @body_id = 'languages'
-    @locale  = Locale.find_by slug: params[:locale]
+    @locale  = Locale.find_by slug: canonical_locale_slug
 
     render "#{Theme.name}/languages/show"
+  end
+
+  private
+
+  def canonical_locale_slug
+    LocaleService.find(locale: params[:locale]).canonical
   end
 end

--- a/app/services/locale_service.rb
+++ b/app/services/locale_service.rb
@@ -1,6 +1,7 @@
-# frozen_string_literal: true
-
 class LocaleService
+  require 'locale_service/locale'
+  require 'locale_service/locales'
+
   class << self
     def find locale:, lang_code: nil
       new(locale, lang_code).locale
@@ -26,6 +27,3 @@ class LocaleService
     value.to_s.downcase.strip if value.present?
   end
 end
-
-require_relative 'locale_service/locale'
-require_relative 'locale_service/locales'

--- a/app/services/locale_service.rb
+++ b/app/services/locale_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class LocaleService
+  class << self
+    def find locale:, lang_code: nil
+      new(locale, lang_code).locale
+    end
+  end
+
+  def locale
+    # This will either find a locale defined in locales.rb, or it will
+    # cause an exception to be raised.
+    Locales.canonical(locale: locale_name, lang_code: lang_code)
+  end
+
+  private
+
+  attr_reader :locale_name, :lang_code
+
+  def initialize locale_name, lang_code
+    @lang_code   = normalize_argument(lang_code)&.to_sym
+    @locale_name = normalize_argument(locale_name)
+  end
+
+  def normalize_argument value
+    value.to_s.downcase.strip if value.present?
+  end
+end
+
+require_relative 'locale_service/locale'
+require_relative 'locale_service/locales'

--- a/app/services/locale_service/locale.rb
+++ b/app/services/locale_service/locale.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class LocaleService::Locale # rubocop:disable Style/ClassAndModuleChildren
   attr_reader :locale, :lang_code, :canonical
 

--- a/app/services/locale_service/locale.rb
+++ b/app/services/locale_service/locale.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class LocaleService::Locale # rubocop:disable Style/ClassAndModuleChildren
+  attr_reader :locale, :lang_code, :canonical
+
+  def initialize locale:, lang_code: nil, canonical:
+    @locale = locale
+    @lang_code = lang_code
+    @canonical = canonical
+  end
+
+  def to_h
+    {
+      locale:    locale,
+      lang_code: lang_code,
+      canonical: canonical
+    }
+  end
+end

--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
   Locale = LocaleService::Locale
 
@@ -58,7 +56,7 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
 
   class << self
     def canonical locale:, lang_code: nil
-      return LOCALES.find { |loc| loc.locale == locale } if lang_code.blank?
+      return LOCALES.find { |locale_instance| locale_instance.locale == locale } if lang_code.blank?
 
       @indexed_locales.dig(lang_code) || raise_locale_error(locale)
     end

--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -16,6 +16,7 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
 
     # german
     Locale.new(locale: 'deutsch', lang_code: :de, canonical: 'deutsch'),
+    Locale.new(locale: 'german',  lang_code: :de, canonical: 'deutsch'),
 
     # finnish
     Locale.new(locale: 'suomen',  lang_code: :fi, canonical: 'suomen'),

--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -24,6 +24,7 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
 
     # french
     Locale.new(locale: 'français', lang_code: :fr, canonical: 'francais'),
+    Locale.new(locale: 'francais', lang_code: :fr, canonical: 'francais'),
     Locale.new(locale: 'french',   lang_code: :fr, canonical: 'francais'),
 
     # greek

--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -5,7 +5,7 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
     # english
     Locale.new(locale: 'english', lang_code: :en, canonical: 'english'),
 
-    # english
+    # danish
     Locale.new(locale: 'danish', lang_code: :da, canonical: 'dansk'),
     Locale.new(locale: 'dansk',  lang_code: :da, canonical: 'dansk'),
 

--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
+  Locale = LocaleService::Locale
+
+  LOCALES = [
+    # english
+    Locale.new(locale: 'english', lang_code: :en, canonical: 'english'),
+
+    # english
+    Locale.new(locale: 'danish', lang_code: :da, canonical: 'dansk'),
+    Locale.new(locale: 'dansk',  lang_code: :da, canonical: 'dansk'),
+
+    # spanish
+    Locale.new(locale: 'espanol', lang_code: :es, canonical: 'espanol'),
+    Locale.new(locale: 'spanish', lang_code: :es, canonical: 'espanol'),
+    Locale.new(locale: 'español', lang_code: :es, canonical: 'espanol'),
+
+    # german
+    Locale.new(locale: 'deutsch', lang_code: :de, canonical: 'deutsch'),
+
+    # finnish
+    Locale.new(locale: 'suomen',  lang_code: :fi, canonical: 'suomen'),
+    Locale.new(locale: 'finnish', lang_code: :fi, canonical: 'suomen'),
+
+    # french
+    Locale.new(locale: 'français', lang_code: :fr, canonical: 'francais'),
+    Locale.new(locale: 'french',   lang_code: :fr, canonical: 'francais'),
+
+    # greek
+    Locale.new(locale: 'ελληνικά', lang_code: :gr, canonical: 'ellenika'),
+    Locale.new(locale: 'greek',    lang_code: :gr, canonical: 'ellenika'),
+
+    # hebrew
+    Locale.new(locale: 'hebrew',   lang_code: :he, canonical: 'ibriyt'),
+    Locale.new(locale: 'עִבְרִית', lang_code: :he, canonical: 'ibriyt'),
+
+    # italian
+    Locale.new(locale: 'italian',  lang_code: :it, canonical: 'italiano'),
+    Locale.new(locale: 'italiano', lang_code: :it, canonical: 'italiano'),
+
+    # portuguese
+    Locale.new(locale: 'portuguese', lang_code: :pt, canonical: 'portugues'),
+    Locale.new(locale: 'portugués',  lang_code: :pt, canonical: 'portugues'),
+
+    # brazilian portuguese
+    Locale.new(locale: 'brazilian portuguese', lang_code: :'pt-br', canonical: 'portugues-brasileiro'),
+    Locale.new(locale: 'português brasileiro', lang_code: :'pt-br', canonical: 'portugues-brasileiro'),
+
+    # swedish
+    Locale.new(locale: 'swedish', lang_code: :sv, canonical: 'svenska'),
+    Locale.new(locale: 'svenska', lang_code: :sv, canonical: 'svenska'),
+
+    # turkish
+    Locale.new(locale: 'turkish', lang_code: :tr, canonical: 'turkce'),
+    Locale.new(locale: 'türkçe',  lang_code: :tr, canonical: 'turkce')
+  ].freeze
+
+  class << self
+    def canonical locale:, lang_code: nil
+      return LOCALES.find { |loc| loc.locale == locale } if lang_code.blank?
+
+      @indexed_locales.dig(lang_code) || raise_locale_error(locale)
+    end
+
+    private
+
+    def index_locales
+      @indexed_locales = LOCALES.each_with_object({}) do |locale, hash|
+        hash[locale.lang_code] ||= locale
+      end
+    end
+
+    def raise_locale_error locale
+      raise ArgumentError, "No mapping for the locale #{locale} was found. Maybe a mapping needs to be added?"
+    end
+  end
+
+  index_locales
+end

--- a/app/views/2017/languages/index.html.erb
+++ b/app/views/2017/languages/index.html.erb
@@ -10,7 +10,7 @@
 
     <table id="locales">
       <% @locales.each do |locale| %>
-        <% articles_count = Article.where(locale: locale.abbreviation).count %>
+        <% articles_count = Article.live.published.where(locale: locale.abbreviation).count %>
         <% next if articles_count.zero? %>
 
         <tr>

--- a/app/views/2017/languages/show.html.erb
+++ b/app/views/2017/languages/show.html.erb
@@ -1,18 +1,16 @@
-<article>
-  <header>
-    <nav class="crumbtrail">
-      <%= link_to t("views.languages.heading"), [:languages] %>
-    </nav>
+<% content_for(:head) do %>
+  <%= rel_next_prev_link_tags(@articles) %>
+<% end %>
 
-    <h1>
-      <%= @locale.name %>
+<header>
+  <h1><%=@locale.name%></h1>
+  <% unless @locale.abbreviation == "en" %>
+  <h2>(<%= @locale.name_in_english %>)</h>
+  <% end %>
+</header>
 
-      <% unless @locale.abbreviation == "en" %>
-        (<%= @locale.name_in_english %>)
-      <% end %>
-    </h1>
-  </header>
+<div class="h-feed">
+  <%= render_themed "articles/list", articles: @articles %>
+</div>
 
-  <div class="e-content">
-  </div>
-</article>
+<%= paginate @articles %>

--- a/app/views/2017/languages/show.html.erb
+++ b/app/views/2017/languages/show.html.erb
@@ -4,9 +4,14 @@
 
 <header>
   <h1><%=@locale.name%></h1>
+
   <% unless @locale.abbreviation == "en" %>
-  <h2>(<%= @locale.name_in_english %>)</h>
+    <h2>(<%= @locale.name_in_english %>)</h2 >
   <% end %>
+
+  <nav class="crumbtrail">
+    <%= link_to t("views.languages.heading"), [:languages] %>
+  </nav>
 </header>
 
 <div class="h-feed">

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -26,6 +26,6 @@ FactoryBot.define do
   trait(:italian) { locale { 'it' } }
   trait(:swedish) { locale { 'sv' } }
   trait(:turkish) { locale { 'tr' } }
-  trait(:portuguese)    { locale { 'pt' } }
-  trait(:portuguese_br) { locale { 'pt-br' } }
+  trait(:portuguese) { locale { 'pt' } }
+  trait(:brazilian_portuguese) { locale { 'pt-br' } }
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,8 +1,31 @@
 FactoryBot.define do
   factory :article do
     published_at { Time.now.utc }
-    sequence(:title) { |n| "Article #{n}" }
-    short_path { SecureRandom.hex }
     publication_status { 'published' }
+    sequence(:title) { |n| "Article #{n}" }
+    sequence(:content) { |n| "content for article #{n}" }
+    short_path { SecureRandom.hex }
+    locale { 'en' }
+
+    after(:build) do |article|
+      locale = Locale.find_by(abbreviation: article.locale)
+      if locale.blank?
+        trait_sym = article.locale.underscore.to_sym
+        create(:locale, trait_sym)
+      end
+    end
   end
+
+  trait(:spanish) { locale { 'es' } }
+  trait(:danish)  { locale { 'da' } }
+  trait(:german)  { locale { 'de' } }
+  trait(:finnish) { locale { 'fi' } }
+  trait(:french)  { locale { 'fr' } }
+  trait(:greek)   { locale { 'gr' } }
+  trait(:hebrew)  { locale { 'he' } }
+  trait(:italian) { locale { 'it' } }
+  trait(:swedish) { locale { 'sv' } }
+  trait(:turkish) { locale { 'tr' } }
+  trait(:portuguese)    { locale { 'pt' } }
+  trait(:portuguese_br) { locale { 'pt-br' } }
 end

--- a/spec/factories/locale.rb
+++ b/spec/factories/locale.rb
@@ -1,0 +1,114 @@
+FactoryBot.define do
+  factory :locale do
+    abbreviation { 'en' }
+    name_in_english { 'English' }
+    name { 'English' }
+    language_direction { 'ltr' }
+    slug { 'english' }
+  end
+
+  trait(:en) {}
+
+  trait(:da) do
+    abbreviation { 'da' }
+    name_in_english { 'Danish' }
+    name { 'Dansk' }
+    language_direction { 'ltr' }
+    slug { 'dansk' }
+  end
+
+  trait(:de) do
+    abbreviation { 'de' }
+    name_in_english { 'German' }
+    name { 'Deutsch' }
+    language_direction { 'ltr' }
+    slug { 'deutsch' }
+  end
+
+  trait(:es) do
+    abbreviation { 'es' }
+    name_in_english { 'Spanish' }
+    name { 'Español' }
+    language_direction { 'ltr' }
+    slug { 'espanol' }
+  end
+
+  trait(:fi) do
+    abbreviation { 'fi' }
+    name_in_english { 'Finnish' }
+    name { 'Suomen' }
+    language_direction { 'ltr' }
+    slug { 'suomen' }
+  end
+
+  trait(:fr) do
+    abbreviation { 'fr' }
+    name_in_english { 'French' }
+    name { 'Français' }
+    language_direction { 'ltr' }
+    slug { 'francais' }
+  end
+
+  trait(:gr) do
+    abbreviation { 'gr' }
+    name_in_english { 'Greek' }
+    name { 'Ελληνικά' }
+    language_direction { 'ltr' }
+    slug { 'ellenika' }
+  end
+
+  trait(:he) do
+    abbreviation { 'he' }
+    name_in_english { 'Hebrew' }
+    name { 'עִבְרִית' }
+    language_direction { 'rtl' }
+    slug { 'ibriyt' }
+  end
+
+  trait(:it) do
+    abbreviation { 'it' }
+    name_in_english { 'Italian' }
+    name { 'Italiano' }
+    language_direction { 'ltr' }
+    slug { 'italiano' }
+  end
+  trait(:pl) do
+    abbreviation { 'pl' }
+    name_in_english { 'Polish' }
+    name { 'Polski' }
+    language_direction { 'ltr' }
+    slug { 'polski' }
+  end
+
+  trait(:pt) do
+    abbreviation { 'pt' }
+    name_in_english { 'Portuguese' }
+    name { 'Portugués' }
+    language_direction { 'ltr' }
+    slug { 'portugues' }
+  end
+
+  trait(:pt_br) do
+    abbreviation { 'pt-br' }
+    name_in_english { 'Brazilian Portuguese' }
+    name { 'Português Brasileiro' }
+    language_direction { 'ltr' }
+    slug { 'portugues-brasileiro' }
+  end
+
+  trait(:sv) do
+    abbreviation { 'sv' }
+    name_in_english { 'Swedish' }
+    name { 'Svenska' }
+    language_direction { 'ltr' }
+    slug { 'svenska' }
+  end
+
+  trait(:tr) do
+    abbreviation { 'tr' }
+    name_in_english { 'Turkish' }
+    name { 'Türkçe' }
+    language_direction { 'ltr' }
+    slug { 'turkce' }
+  end
+end

--- a/spec/services/locale_service/locale_spec.rb
+++ b/spec/services/locale_service/locale_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 require 'locale_service'
 

--- a/spec/services/locale_service/locale_spec.rb
+++ b/spec/services/locale_service/locale_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'locale_service'
+
+describe LocaleService::Locale do
+  let(:args) { {} }
+
+  context 'when given no locale' do
+    it 'raises' do
+      expect { described_class.new(**args) }.to raise_error ArgumentError
+    end
+  end
+
+  context 'when given no canonical name' do
+    let(:args) { super().merge(locale: 'spanish') }
+
+    it 'raises' do
+      expect { described_class.new(**args) }.to raise_error ArgumentError
+    end
+  end
+
+  context 'when given a locale and a canonical name' do
+    subject { described_class.new(**args).to_h }
+
+    let(:args) { super().merge(locale: 'spanish', canonical: 'espanol') }
+    let(:expected_hash) { { locale: 'spanish', lang_code: nil, canonical: 'espanol' } }
+
+    it { is_expected.to eq expected_hash }
+  end
+end

--- a/spec/services/locale_service/locales_spec.rb
+++ b/spec/services/locale_service/locales_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 require 'locale_service'
 

--- a/spec/services/locale_service/locales_spec.rb
+++ b/spec/services/locale_service/locales_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'locale_service'
+
+describe LocaleService::Locales do
+  subject { described_class.canonical(**args).canonical }
+
+  let(:args) { { locale: 'spanish', lang_code: :es } }
+  let(:unfrozen_locales) { LocaleService::Locales::LOCALES.dup }
+
+  before do
+    stub_const('LocaleService::Locales::LOCALES', unfrozen_locales)
+    allow(LocaleService::Locales::LOCALES).to receive(:find).and_call_original
+  end
+
+  context 'when given an existing lang_code' do
+    it { is_expected. to eq 'espanol' }
+
+    it 'skips the long lookup and uses the precomputed hash' do
+      expect(LocaleService::Locales::LOCALES).not_to have_received(:find)
+    end
+  end
+
+  context 'without a lang_code' do
+    subject(:service) { described_class.canonical(**args) }
+
+    let(:args) { super().merge(lang_code: nil) }
+
+    it 'searches across all of the locales' do
+      expect(service.canonical).to eq('espanol')
+      expect(LocaleService::Locales::LOCALES).to have_received(:find).once
+    end
+  end
+
+  context 'when given an unknown locale' do
+    subject(:service) { described_class.canonical(**args) }
+
+    let(:args) { super().merge(locale: 'foo', lang_code: :bar) }
+
+    it 'raises' do
+      expect { service.canonical }.to raise_error ArgumentError
+    end
+  end
+end

--- a/spec/services/locale_service_spec.rb
+++ b/spec/services/locale_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'locale_service'
+
+describe LocaleService do
+  describe '#find' do
+    subject(:found_locale) { described_class.find(locale: locale, lang_code: lang_code) }
+
+    let(:locale) { 'spanish' }
+    let(:lang_code) { :es }
+
+    shared_examples 'it returns the expected canonical name' do
+      it 'returns the expected result' do
+        expect(found_locale.canonical).to eq('espanol')
+      end
+    end
+
+    it_behaves_like 'it returns the expected canonical name'
+
+    context 'when locale is not found' do
+      let(:lang_code) { :foo }
+
+      it 'raises' do
+        expect { found_locale.locale }.to raise_error ArgumentError
+      end
+    end
+
+    context 'when searching without a lang_code' do
+      let(:lang_code) { nil }
+
+      it_behaves_like 'it returns the expected canonical name'
+    end
+  end
+end

--- a/spec/services/locale_service_spec.rb
+++ b/spec/services/locale_service_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 require 'locale_service'
 

--- a/spec/system/language_landing_page_spec.rb
+++ b/spec/system/language_landing_page_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'Language Landing Page' do
+  before do
+    create(:article)
+    create(:article, :spanish)
+    create(:article, :german)
+    create(:article, :danish)
+    create(:article, :finnish)
+    create(:article, :french)
+    create(:article, :greek)
+    create(:article, :hebrew)
+    create(:article, :italian)
+    create(:article, :swedish)
+    create(:article, :turkish)
+    create(:article, :portuguese)
+    create(:article, :portuguese_br)
+  end
+
+  it 'has a link for every language' do
+    visit '/languages'
+
+    within '#locales' do
+      links = all('a')
+      expect(links.count).to eq Article.count
+    end
+  end
+
+  it 'Renders the landig page with counts and links to specific languages' do
+    visit '/languages'
+    link_matcher = 'a[href*="languages/"]'
+    links = all(link_matcher)
+    links_text = links.map(&:text)
+
+    links_text.each do |text|
+      click_on text, match: :first
+      expect(page).to have_content text
+      visit '/languages'
+    end
+  end
+end

--- a/spec/system/language_landing_page_spec.rb
+++ b/spec/system/language_landing_page_spec.rb
@@ -26,7 +26,7 @@ describe 'Language Landing Page' do
     end
   end
 
-  it 'Renders the landig page with counts and links to specific languages' do
+  it 'Renders the landing page with counts and links to specific languages' do
     visit '/languages'
     link_matcher = 'a[href*="languages/"]'
     links = all(link_matcher)

--- a/spec/system/language_landing_page_spec.rb
+++ b/spec/system/language_landing_page_spec.rb
@@ -14,7 +14,7 @@ describe 'Language Landing Page' do
     create(:article, :swedish)
     create(:article, :turkish)
     create(:article, :portuguese)
-    create(:article, :portuguese_br)
+    create(:article, :brazilian_portuguese)
   end
 
   it 'has a link for every language' do
@@ -37,5 +37,18 @@ describe 'Language Landing Page' do
       expect(page).to have_content text
       visit '/languages'
     end
+  end
+
+  it 'does NOT show a language if there are no published articles' do
+    visit '/languages'
+
+    within('#locales') { expect(page).to have_content 'Italian' }
+
+    # unpublish the italian article
+    Article.where(locale: 'it').first.update!(publication_status: 'draft')
+
+    visit '/languages'
+
+    within('#locales') { expect(page).not_to have_content 'Italian' }
   end
 end


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![specs](https://media.giphy.com/media/viYy85in6LVS0/giphy.gif)

# What are the relevant GitHub issues?

resolves #356 

# What does this pull request do?
This constructs a in-memory lookup table for translating locales that
come in via URL params into the canonical URL slug we have in the DB.

This allows both english-ified names, local names, unicode names,
etc. to all vbe used in the URL just work.

For example, both of these work:
- https://crimethinc-staging-pr-1425.herokuapp.com/languages/ελληνικά
- https://crimethinc-staging-pr-1425.herokuapp.com/languages/greek

The specs make sure that all of the links in `/languages` `200` (prior
to this change some of them would `500`)

# How should this be manually tested?

- go to https://crimethinc-staging-pr-1425.herokuapp.com/languages
- click all of the links and make sure there are no `500`s

# Is there any background context you want to provide for reviewers?
I don't really like how many layers of redirects we have already so
didn't want to add another


# Questions for the pull request author (delete any that don't apply):
- [X] Are any needed README/wiki/documentation updates needed for this pull request?
- [X] Does the code you updated have tests? If not, could you add some please?

# Acceptance Criteria
## These should be checked by the reviewers

- [x] This pull request does not cause the database export script to become out of sync with the db schema
