### PR TITLE
[API] Allow certain endpoints to return JSON

### DIFF
--- a/app/middlewares/rack/json_requests.rb
+++ b/app/middlewares/rack/json_requests.rb
@@ -12,13 +12,21 @@ module Rack
 
     def call env
       request = Rack::Request.new(env)
-      content_type = request.env['HTTP_ACCEPT']
-      return json_406_error if content_type.start_with?('application/json')
+      return json_406_error if invalid_api_request? request
 
       @app.call(env)
     end
 
     private
+
+    def invalid_api_request? request
+      return false if request.path.include?('collection_posts') ||
+                      request.path.include?('manifest.json') ||
+                      request.path.include?('feed.json')
+
+      http_accept = request.env['HTTP_ACCEPT']
+      http_accept&.start_with?('application/json')
+    end
 
     def json_406_error
       [

--- a/spec/requests/json_requests_spec.rb
+++ b/spec/requests/json_requests_spec.rb
@@ -17,4 +17,51 @@ describe 'JsonRequests', type: :request do
     error_message = JSON.parse(body)['errors'].first.dig('detail')
     expect(error_message).to eq expected_error
   end
+
+  context 'when there is no HTTP_ACCEPT header' do
+    let(:json_headers) { { HTTP_ACCEPT: nil } }
+
+    it 'continues through to the regular app' do
+      get root_path, headers: json_headers
+
+      expect(response.content_type).to eq 'text/html'
+      expect(status).to eq 301
+    end
+  end
+
+  context 'when hitting the article polling endpoint' do
+    let(:published_at) { 5.minutes.ago }
+    let(:collection) { create(:article, title: 'test', publication_status: 'published', published_at: published_at) }
+    let!(:article) do
+      create(:article, title: 'collection', collection_id: collection.id, publication_status: 'published', published_at: published_at)
+    end
+
+    it 'still returns collections' do
+      get "/articles/#{collection.id}/collection_posts", params: { published_at: published_at.to_i }, headers: json_headers
+      follow_redirect!
+
+      article_title = JSON.parse(response.body)['posts'].first['title']
+      expect(article_title).to eq article.title
+    end
+  end
+
+  context 'when hitting the json manifet path' do
+    it 'returns the manifest' do
+      get '/manifest.json', headers: json_headers
+      follow_redirect!
+      expect(status).to eq 200
+    end
+  end
+
+  context 'when hitting the JSON RSS feed' do
+    before { create(:article, content: 'foo') }
+
+    it 'returns the feed' do
+      get '/feed.json', headers: json_headers
+      follow_redirect!
+
+      expect(status).to eq 200
+      expect(response.body).to include 'foo'
+    end
+  end
 end


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![MY B](https://media.giphy.com/media/jyDNsJnUpdtFS/giphy.gif)

# What are the relevant GitHub issues?

relates to #1235 

# What does this pull request do?

In [Pull Request #1418][0] I blocked ALL json requests

We actually have a few endpoints we want to let through

[0]:https://github.com/crimethinc/website/pull/1418

# How should this be manually tested?

- make sure the live polling articles still work
- https://crimethinc-staging-pr-1427.herokuapp.com/manifest.json works
- https://crimethinc-staging-pr-1427.herokuapp.com/feed.json works
  - https://crimethinc-staging-pr-1427.herokuapp.com/feed.json?page=3 works

# Questions for the pull request author (delete any that don't apply):
- [X] Does the code you updated have tests? If not, could you add some please?

# Acceptance Criteria
## These should be checked by the reviewers

- [x] This pull request does not cause the database export script to become out of sync with the db schema
