### PR TITLE
Try MSP-Greg/actions-ruby in place of actions/setup-ruby@v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Ruby
         uses: MSP-Greg/actions-ruby@master
         with:
-          ruby-version: '2.6.5'
+          ruby-version: '2.6.x'
 
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y postgresql-client libpq-dev
 
-      - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+      - name: Install Ruby
+        uses: MSP-Greg/actions-ruby@master
         with:
-          ruby-version: 2.6.3
+          ruby-version: 2.6.5
 
       - name: Checkout
         uses: actions/checkout@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Ruby
         uses: MSP-Greg/actions-ruby@master
         with:
-          ruby-version: 2.6.5
+          ruby-version: '2.6.5'
 
       - name: Checkout
         uses: actions/checkout@master


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

`¯\_(ツ)_/¯ `

# What are the relevant GitHub issues?

n/a

# What does this pull request do?

Replaces the first party `actions/setup-ruby@v1` action with a third party one, `MSP-Greg/actions-ruby@master`.

# How should this be manually tested?

Just see if CI runs/passes.

# Is there any background context you want to provide for reviewers?

This is because the GitHub owned action seems to be abandoned and doesn't have a Ruby version newer than `2.6.3`. We're running `2.6.5` in production, and will likely be on `2.7.0` soon too. And it really makes sense to run the same Ruby in CI as in production.

https://github.com/actions/setup-ruby/issues/42

