### PR TITLE
Add /languages markdown description

### DIFF
--- a/app/views/2017/languages/index.html.erb
+++ b/app/views/2017/languages/index.html.erb
@@ -5,7 +5,7 @@
 
   <div class="e-content">
     <div class="intro">
-      <p><%= t "views.languages.description" %></p>
+      <p><%= render_markdown t("views.languages.description") %></p>
     </div>
 
     <table id="locales">

--- a/config/locales/cz.yml
+++ b/config/locales/cz.yml
@@ -389,11 +389,15 @@ cz:
     languages:
       heading: Languages
       description: |
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        CrimethInc. material has appeared in over three dozen languages; our introductory
+        primer, [To Change Everything](/tce), is available in 30. We have
+        [long](/2010/08/18/non-english-crimethinc-projects) aspired to collect all the different
+        translations on this site. If you would like to translate our material—or if you can
+        help us to collect translations for this archive or help us maintain communication
+        between related projects around the world—please
+        [contact us](mailto:foreignlegion@crimethinc.com).
+
+        Here, you can find all the articles on this site categorized according to language.
 
   helpers:
     page_entries_info:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -390,11 +390,15 @@ de:
     languages:
       heading: Languages
       description: |
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        CrimethInc. material has appeared in over three dozen languages; our introductory
+        primer, [To Change Everything](/tce), is available in 30. We have
+        [long](/2010/08/18/non-english-crimethinc-projects) aspired to collect all the different
+        translations on this site. If you would like to translate our material—or if you can
+        help us to collect translations for this archive or help us maintain communication
+        between related projects around the world—please
+        [contact us](mailto:foreignlegion@crimethinc.com).
+
+        Here, you can find all the articles on this site categorized according to language.
 
   helpers:
     page_entries_info:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -390,11 +390,15 @@ en:
     languages:
       heading: Languages
       description: |
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        CrimethInc. material has appeared in over three dozen languages; our introductory
+        primer, [To Change Everything](/tce), is available in 30. We have
+        [long](/2010/08/18/non-english-crimethinc-projects) aspired to collect all the different
+        translations on this site. If you would like to translate our material—or if you can
+        help us to collect translations for this archive or help us maintain communication
+        between related projects around the world—please
+        [contact us](mailto:foreignlegion@crimethinc.com).
+
+        Here, you can find all the articles on this site categorized according to language.
 
   helpers:
     page_entries_info:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -387,13 +387,17 @@ es:
           more_help: También puedes responder a este correo si necesitas más ayuda.
 
     languages:
-      heading: Idiomas
+      heading: Languages
       description: |
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        CrimethInc. material has appeared in over three dozen languages; our introductory
+        primer, [To Change Everything](/tce), is available in 30. We have
+        [long](/2010/08/18/non-english-crimethinc-projects) aspired to collect all the different
+        translations on this site. If you would like to translate our material—or if you can
+        help us to collect translations for this archive or help us maintain communication
+        between related projects around the world—please
+        [contact us](mailto:foreignlegion@crimethinc.com).
+
+        Here, you can find all the articles on this site categorized according to language.
 
   helpers:
     page_entries_info:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -389,11 +389,15 @@ fr:
     languages:
       heading: Languages
       description: |
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt
-        ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
-        laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
-        voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-        non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        CrimethInc. material has appeared in over three dozen languages; our introductory
+        primer, [To Change Everything](/tce), is available in 30. We have
+        [long](/2010/08/18/non-english-crimethinc-projects) aspired to collect all the different
+        translations on this site. If you would like to translate our material—or if you can
+        help us to collect translations for this archive or help us maintain communication
+        between related projects around the world—please
+        [contact us](mailto:foreignlegion@crimethinc.com).
+
+        Here, you can find all the articles on this site categorized according to language.
 
   helpers:
     page_entries_info:


### PR DESCRIPTION
# What does this pull request do?

Adds description text to `/languages` 
(English only at the moment, we need to get it translated to de/es/cz/fr/etc)

# How should this be manually tested?

Go to `/languages`. "Lorem ipsum…" should be gone.

