### PR TITLE
[i18n] Handle an unfound locale

### DIFF
--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -24,8 +24,8 @@ class LanguagesController < ApplicationController
   end
 
   def set_articles
-    abbreviation = canonical_locale.lang_code
+    abbreviation = canonical_locale&.lang_code
     @articles = Article.live.published.where(locale: abbreviation).page(params[:page]).per(25)
-    return redirect_to root_path if @articles.empty?
+    return redirect_to languages_path if @articles.empty?
   end
 end

--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -29,10 +29,12 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
 
     # greek
     Locale.new(locale: 'ελληνικά', lang_code: :gr, canonical: 'ellenika'),
+    Locale.new(locale: 'ellenika', lang_code: :gr, canonical: 'ellenika'),
     Locale.new(locale: 'greek',    lang_code: :gr, canonical: 'ellenika'),
 
     # hebrew
     Locale.new(locale: 'hebrew',   lang_code: :he, canonical: 'ibriyt'),
+    Locale.new(locale: 'ibriyt',   lang_code: :he, canonical: 'ibriyt'),
     Locale.new(locale: 'עִבְרִית', lang_code: :he, canonical: 'ibriyt'),
 
     # italian
@@ -42,10 +44,12 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
     # portuguese
     Locale.new(locale: 'portuguese', lang_code: :pt, canonical: 'portugues'),
     Locale.new(locale: 'portugués',  lang_code: :pt, canonical: 'portugues'),
+    Locale.new(locale: 'portugues',  lang_code: :pt, canonical: 'portugues'),
 
     # brazilian portuguese
     Locale.new(locale: 'brazilian portuguese', lang_code: :'pt-br', canonical: 'portugues-brasileiro'),
     Locale.new(locale: 'português brasileiro', lang_code: :'pt-br', canonical: 'portugues-brasileiro'),
+    Locale.new(locale: 'portugues-brasileiro', lang_code: :'pt-br', canonical: 'portugues-brasileiro'),
 
     # swedish
     Locale.new(locale: 'swedish', lang_code: :sv, canonical: 'svenska'),
@@ -53,7 +57,12 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
 
     # turkish
     Locale.new(locale: 'turkish', lang_code: :tr, canonical: 'turkce'),
-    Locale.new(locale: 'türkçe',  lang_code: :tr, canonical: 'turkce')
+    Locale.new(locale: 'türkçe',  lang_code: :tr, canonical: 'turkce'),
+    Locale.new(locale: 'turkce',  lang_code: :tr, canonical: 'turkce'),
+
+    # polish
+    Locale.new(locale: 'polski', lang_code: :pl, canonical: 'polski'),
+    Locale.new(locale: 'polish', lang_code: :pl, canonical: 'polski')
   ].freeze
 
   class << self

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -27,5 +27,6 @@ FactoryBot.define do
   trait(:swedish) { locale { 'sv' } }
   trait(:turkish) { locale { 'tr' } }
   trait(:portuguese) { locale { 'pt' } }
+  trait(:polish) { locale { 'pl' } }
   trait(:brazilian_portuguese) { locale { 'pt-br' } }
 end

--- a/spec/system/language_landing_page_spec.rb
+++ b/spec/system/language_landing_page_spec.rb
@@ -14,6 +14,7 @@ describe 'Language Landing Page' do
     create(:article, :swedish)
     create(:article, :turkish)
     create(:article, :portuguese)
+    create(:article, :polish)
     create(:article, :brazilian_portuguese)
   end
 
@@ -50,5 +51,11 @@ describe 'Language Landing Page' do
     visit '/languages'
 
     within('#locales') { expect(page).not_to have_content 'Italian' }
+  end
+
+  it 'redirects to the language index page if a language is not found' do
+    visit '/languages/foo'
+
+    expect(page).to have_current_path languages_path
   end
 end


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/cIzfLxj2BlEn0ET3Mc/giphy.gif)

# What are the relevant GitHub issues?

relates to #1425 
relates to #356 

# What does this pull request do?

The current behavior if you visit a path like
`http://crimethinc.com/languages/foo` is to throw a `500`.

This change makes it so that instead you just get redirected to `/languages`

# How should this be manually tested?
- go to  http://crimethinc-staging-pr-1430.herokuapp.com/languages/foo
- get redirected back to `/languages`

# Questions for the pull request author (delete any that don't apply):
- [X] Does the code you updated have tests? If not, could you add some please?

# Acceptance Criteria
## These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema
