### PR TITLE
Locale articles count

### DIFF
--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -6,6 +6,12 @@ class LanguagesController < ApplicationController
     @body_id = 'languages'
     @locales = Locale.all
 
+    @locales.each do |locale|
+      locale.articles_count = Article.live.published.where(locale: locale.abbreviation).count
+    end
+
+    @locales = @locales.reject { |locale| locale.articles_count.zero? }
+
     render "#{Theme.name}/languages/index"
   end
 

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -10,7 +10,10 @@ class LanguagesController < ApplicationController
       locale.articles_count = Article.live.published.where(locale: locale.abbreviation).count
     end
 
-    @locales = @locales.reject { |locale| locale.articles_count.zero? }
+    @locales = @locales
+               .reject { |locale| locale.articles_count.zero? }
+               .sort_by(&:articles_count)
+               .reverse
 
     render "#{Theme.name}/languages/index"
   end

--- a/app/views/2017/languages/index.html.erb
+++ b/app/views/2017/languages/index.html.erb
@@ -10,12 +10,9 @@
 
     <table id="locales">
       <% @locales.each do |locale| %>
-        <% articles_count = Article.live.published.where(locale: locale.abbreviation).count %>
-        <% next if articles_count.zero? %>
-
         <tr>
           <td class="articles-count">
-            <%= number_with_delimiter articles_count %>
+            <%= number_with_delimiter locale.articles_count %>
           </td>
 
           <td>

--- a/db/migrate/20191229192638_add_articles_count_to_locales.rb
+++ b/db/migrate/20191229192638_add_articles_count_to_locales.rb
@@ -1,0 +1,5 @@
+class AddArticlesCountToLocales < ActiveRecord::Migration[6.0]
+  def change
+    add_column :locales, :articles_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_15_191508) do
+ActiveRecord::Schema.define(version: 2019_12_29_192638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -226,6 +226,7 @@ ActiveRecord::Schema.define(version: 2019_12_15_191508) do
     t.datetime "updated_at", null: false
     t.integer "language_direction", default: 0
     t.string "slug"
+    t.integer "articles_count", default: 0
   end
 
   create_table "logos", force: :cascade do |t|


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

https://media.giphy.com/media/SUFuaOfn7qXaE/giphy.gif

# What are the relevant GitHub issues?

n/a

# What does this pull request do?

Adds a column to `Locale`: `articles_count`, defaulted to zero.
Populates it on the way out the door in the `languages controller`.
TODO later: update it in a callback when an article is saved.
It calculates `articles_count` on `@locales` in `languages controller` instead of calculating it in the view.
It rejects locales that have an `articles_count` of zero in `languages controller` instead of in the view.

# How should this be manually tested?

View `/languages`. Does it work? Are there any locales with zero articles?

# Is there any background context you want to provide for reviewers?

Nah.

