### PR TITLE
Add links to language collection pages in footer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,6 +48,22 @@ class ApplicationController < ActionController::Base
     redirect_to [:signin], alert: 'You need to sign in to view that page.' unless signed_in?
   end
 
+  def live_locales
+    return @live_locales if @live_locales.present?
+
+    @live_locales = Locale.all
+
+    @live_locales.each do |locale|
+      locale.articles_count = Article.live.published.where(locale: locale.abbreviation).count
+    end
+
+    @live_locales = @live_locales
+                    .reject { |locale| locale.articles_count.zero? }
+                    .sort_by(&:articles_count)
+                    .reverse
+  end
+  helper_method :live_locales
+
   def set_locale_from_subdomain
     locale = request.subdomain
     I18n.locale = locale if I18n.available_locales.include?(locale.to_sym)

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -4,16 +4,7 @@ class LanguagesController < ApplicationController
   def index
     @html_id = 'page'
     @body_id = 'languages'
-    @locales = Locale.all
-
-    @locales.each do |locale|
-      locale.articles_count = Article.live.published.where(locale: locale.abbreviation).count
-    end
-
-    @locales = @locales
-               .reject { |locale| locale.articles_count.zero? }
-               .sort_by(&:articles_count)
-               .reverse
+    @locales = live_locales
 
     render "#{Theme.name}/languages/index"
   end

--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -49,6 +49,7 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
     # brazilian portuguese
     Locale.new(locale: 'brazilian portuguese', lang_code: :'pt-br', canonical: 'portugues-brasileiro'),
     Locale.new(locale: 'português brasileiro', lang_code: :'pt-br', canonical: 'portugues-brasileiro'),
+    Locale.new(locale: 'português-brasileiro', lang_code: :'pt-br', canonical: 'portugues-brasileiro'),
     Locale.new(locale: 'portugues-brasileiro', lang_code: :'pt-br', canonical: 'portugues-brasileiro'),
 
     # swedish

--- a/app/views/2017/shared/footer/_nav.html.erb
+++ b/app/views/2017/shared/footer/_nav.html.erb
@@ -45,11 +45,11 @@
         <%= link_to t("footer.nav.store.description"), "/store" %>
       </dd>
 
-      <dt class="nav-label nav-label-languages" id="languages"><%= link_to t("header.languages"), "#languages" %></dt>
+      <dt class="nav-label nav-label-languages" id="languages"><%= link_to t("header.languages"), [:languages] %></dt>
       <dd>
-        <% Locales.supported.each do |locale| %>
-          <%= link_to t(:name, locale: locale),
-                      url_for_current_path_with_subdomain(subdomain: locale) %>
+        <% live_locales.each do |locale| %>
+          <% next if locale.abbreviation == I18n.locale.to_s %>
+          <%= link_to locale.name, [:language, locale: locale.name.downcase] %>
         <% end %>
       </dd>
     </dl>

--- a/app/views/2017/shared/footer/_nav.html.erb
+++ b/app/views/2017/shared/footer/_nav.html.erb
@@ -49,7 +49,7 @@
       <dd>
         <% live_locales.each do |locale| %>
           <% next if locale.abbreviation == I18n.locale.to_s %>
-          <%= link_to locale.name, [:language, locale: locale.name.downcase] %>
+          <%= link_to locale.name, [:language, locale: locale.name.downcase.gsub(' ', '-')] %>
         <% end %>
       </dd>
     </dl>


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![explosions in the sky](https://media.giphy.com/media/H7Lzlf4NI2kj6/giphy.gif)

# What are the relevant GitHub issues?

updates https://github.com/crimethinc/website/issues/1064

# What does this pull request do?

## Before:

<img width="284" alt="Screen Shot 2019-12-29 at 7 12 52 PM" src="https://user-images.githubusercontent.com/4361/71565002-542a0d80-2a6f-11ea-879c-38ae1df92b7e.png">

## After:

<img width="383" alt="Screen Shot 2019-12-29 at 7 13 08 PM" src="https://user-images.githubusercontent.com/4361/71565007-5be9b200-2a6f-11ea-92a8-37d783039db3.png">

Changes footer `Languages` links section from links to subdomains to links to language collection pages.

It also adds a special case for `pt-br`, keeping the Unicode name, but adding a hyphen instead of the `%20` space.

# How should this be manually tested?

Click on all the links in the footer section for `Languages`, they should all work.
https://crimethinc-staging-pr-1434.herokuapp.com/


