### PR TITLE
Reset all Article page_views to zero in db:scrub rake task

### DIFF
--- a/lib/tasks/db/export.rake
+++ b/lib/tasks/db/export.rake
@@ -45,6 +45,9 @@ namespace :db do
       [Article, Book, Issue, Journal, Logo, Page, Poster, Sticker, Video, Zine].each do |klass|
         klass.draft.destroy_all
       end
+
+      puts '==> Scrubbing article page view counts…'
+      Article.update_all(page_views: 0)
     end
 
     desc 'Dump local development DB'


### PR DESCRIPTION
Keeps page view count out of db export.
Not the biggest deal in the world, but not needed for local development.