### PR TITLE
Add DOWNOL Ne Plus Ultra Edition to Books

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,7 +1,7 @@
 class BooksController < ApplicationController
   before_action :set_book, only: %i[show extras]
 
-  BOOK_SLUGS = %w[
+  INDEX_BOOK_SLUGS = %w[
     no-wall-they-can-build
     from-democracy-to-freedom
     contradictionary
@@ -18,18 +18,26 @@ class BooksController < ApplicationController
     dias-de-guerra-noites-de-amor
   ].map(&:freeze).freeze
 
+  NON_INDEX_BOOK_SLUGS = %w[
+    days-of-war-nights-of-love-ne-plus-ultra-edition
+  ].map(&:freeze).freeze
+
+  BOOK_SLUGS = INDEX_BOOK_SLUGS + NON_INDEX_BOOK_SLUGS
+
   def index
     @html_id = 'page'
     @body_id = 'tools'
     @type    = 'books'
     @title   = PageTitle.new title_for(:books)
 
-    @bullet_books = BOOK_SLUGS.map { |slug| Book.find_by(slug: slug) }
+    @bullet_books = INDEX_BOOK_SLUGS.map { |slug| Book.find_by(slug: slug) }
 
     render "#{Theme.name}/books/index"
   end
 
   def show
+    return redirect_to [:books] unless BOOK_SLUGS.include?(@book.slug)
+
     @html_id  = 'page'
     @body_id  = 'tools'
     @type     = 'books'
@@ -68,6 +76,6 @@ class BooksController < ApplicationController
 
   def set_book
     @book = Book.find_by(slug: params[:slug])
-    return redirect_to [:books] if @book.blank? || !BOOK_SLUGS.include?(@book.slug)
+    return redirect_to [:books] if @book.blank?
   end
 end


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![finally](https://media.giphy.com/media/AuwBPJztsEWkw/giphy.gif)

# What are the relevant GitHub issues?

TODO: Create  archival posterity page for DOWNOL Ne Plus Ultra Edition book page

And redirects from these old URLs
- [ ] https://crimethinc.com/main/daysneplus
- [ ] https://crimethinc.com/books/neplus.html


# What does this pull request do?

Adds the special case for books that should not be on `/books`.

# How should this be manually tested?

Go to `/books`. You shouldn't see DOWNOL Ne Plus Ultra Edition.
Go to `/books/days-of-war-nights-of-love-ne-plus-ultra-edition`. You SHOULD see it.

# Is there any background context you want to provide for reviewers?

A page from the old site that never got moved over. 😞 

