### PR TITLE
[CSS] unset the in-line display in instagram embeds

### DIFF
--- a/app/assets/stylesheets/2017/components/_embeds.scss
+++ b/app/assets/stylesheets/2017/components/_embeds.scss
@@ -55,5 +55,5 @@ figcaption {
   }
 }
 
-.video-container {
-}
+figure.video-container > iframe.instagram-media { display: unset !important; }
+


### PR DESCRIPTION


# How does this pull request make you feel (in animated GIF format)?

![css](https://media.giphy.com/media/2rj8VysAig8QE/giphy.gif)

# What are the relevant GitHub issues?

resolves #1449 

# What does this pull request do?

adds some CSS to override the in-line CSS that instagram inserts on embeds

# How should this be manually tested?

- go to https://crimethinc.com/2020/01/06/2019-the-year-in-review-including-a-short-report-on-our-efforts#instagram-embed-0
- make sure the instagram embed is centered
- make sure the instagram embed has a caption under it

# Is there any background context you want to provide for reviewers?

I think the [instagram embed template][0] in markdown_media needs some CSS
love, but in the meantime this (combined with [this PR][1]) will serve our
purposes

[0]:https://github.com/veganstraightedge/markdown_media/blob/14f7691b12a98354055be8ec628c07b357fb1d31/lib/templates/instagram.erb
[1]:https://github.com/veganstraightedge/markdown_media/pull/9

# Questions for the pull request author (delete any that don't apply):
# Acceptance Criteria
## These should be checked by the reviewers

- [x] This pull request does not cause the database export script to become out of sync with the db schema
