### PR TITLE
Add Arabic to Locales lookup table

### DIFF
--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -2,6 +2,11 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
   Locale = LocaleService::Locale
 
   LOCALES = [
+    # arabic
+    Locale.new(locale: 'arabic',      lang_code: :ar, canonical: 'alarabiyawu'),
+    Locale.new(locale: 'alarabiyawu', lang_code: :ar, canonical: 'alarabiyawu'),
+    Locale.new(locale: 'اَلْعَرَبِيَّةُ‎', lang_code: :ar, canonical: 'alarabiyawu'),
+
     # english
     Locale.new(locale: 'english', lang_code: :en, canonical: 'english'),
 


### PR DESCRIPTION
# What does this pull request do?

Adds Arabic support to https://crimethinc.com/languages

# How should this be manually tested?

- Go to https://crimethinc.com/languages
- Click on the three Arabic links
- None should redirect to https://crimethinc.com/languages

# Is there any background context you want to provide for reviewers?

The link for `اَلْعَرَبِيَّةُ‎` goes to /languages/اَلْعَرَب%D9%90يَّةُ%E2%80%8E then redirects to /languages

