### PR TITLE
Add the link in header for locale specific articles

### DIFF
--- a/app/views/2017/shared/_header.html.erb
+++ b/app/views/2017/shared/_header.html.erb
@@ -15,7 +15,14 @@
       <li class="nav-link"><%= link_to t("header.search"),  "/search" %></li>
       <li class="nav-link"><%= link_to t("header.about"),   "/about" %></li>
     </ul>
+    <% unless I18n.locale == I18n.default_locale %>
+      <ul>
+        <% @locale = LocaleService.find(locale: nil, lang_code: I18n.locale) %>
+        <li class="nav-link"><%= link_to t('header.locale_articles'), "languages/#{@locale.canonical}" %></li>
+      </ul>
+    <% end %>
   </nav>
+
 
   <%= link_to t("header.support"), [:support], class: "button" %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,7 @@ en:
     support: Support Us
     search: Search
     about: About
+    locale_articles: "English's articles"
 
     first_time: First Time? Start Here →
     site_mode: Switch to the full version of the site →

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -32,6 +32,7 @@ fr:
     support: Support Us
     search: Search
     about: About
+    locale_articles: 'Articles en français'
 
     first_time: First Time? Start Here →
     site_mode: Switch to the full version of the site →


### PR DESCRIPTION
# What are the relevant GitHub issues?

resolves #1454 

# What does this pull request do?

It add a link in the header to the `languages/foo` articles where `foo` is the locale and `locale != 'en'`.

# How should this be manually tested?

Test this on staging with a different languages and the link should show up.
