### PR TITLE
Add Russian to /langs

### DIFF
--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -62,7 +62,7 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
     Locale.new(locale: 'português-brasileiro', lang_code: :pt, canonical: 'portugues-brasileiro'),
     Locale.new(locale: 'portugues-brasileiro', lang_code: :pt, canonical: 'portugues-brasileiro'),
 
-    # swedish
+    # russian
     Locale.new(locale: 'pусский', lang_code: :ru, canonical: 'russkii'),
     Locale.new(locale: 'russian', lang_code: :ru, canonical: 'russkii'),
     Locale.new(locale: 'russkii', lang_code: :ru, canonical: 'russkii'),

--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -63,7 +63,7 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
     Locale.new(locale: 'portugues-brasileiro', lang_code: :pt, canonical: 'portugues-brasileiro'),
 
     # russian
-    Locale.new(locale: 'pусский', lang_code: :ru, canonical: 'russkii'),
+    Locale.new(locale: 'русский', lang_code: :ru, canonical: 'russkii'),
     Locale.new(locale: 'russian', lang_code: :ru, canonical: 'russkii'),
     Locale.new(locale: 'russkii', lang_code: :ru, canonical: 'russkii'),
 

--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -11,12 +11,12 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
     Locale.new(locale: 'czech', lang_code: :cs, canonical: 'czech'),
     Locale.new(locale: 'czech', lang_code: :cz, canonical: 'czech'),
 
-    # english
-    Locale.new(locale: 'english', lang_code: :en, canonical: 'english'),
-
     # danish
     Locale.new(locale: 'danish', lang_code: :da, canonical: 'dansk'),
     Locale.new(locale: 'dansk',  lang_code: :da, canonical: 'dansk'),
+
+    # english
+    Locale.new(locale: 'english', lang_code: :en, canonical: 'english'),
 
     # spanish
     Locale.new(locale: 'espanol', lang_code: :es, canonical: 'espanol'),
@@ -61,6 +61,11 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
     Locale.new(locale: 'português brasileiro', lang_code: :pt, canonical: 'portugues-brasileiro'),
     Locale.new(locale: 'português-brasileiro', lang_code: :pt, canonical: 'portugues-brasileiro'),
     Locale.new(locale: 'portugues-brasileiro', lang_code: :pt, canonical: 'portugues-brasileiro'),
+
+    # swedish
+    Locale.new(locale: 'pусский', lang_code: :ru, canonical: 'russkii'),
+    Locale.new(locale: 'russian', lang_code: :ru, canonical: 'russkii'),
+    Locale.new(locale: 'russkii', lang_code: :ru, canonical: 'russkii'),
 
     # swedish
     Locale.new(locale: 'swedish', lang_code: :sv, canonical: 'svenska'),


### PR DESCRIPTION
For this `Locale` in production.

```
Locale
abbreviation: "ru", 
name_in_english: "Russian", 
name: "Русский", 
language_direction: "ltr", 
slug: "russkii"
```