### PR TITLE
[CODE VAULT] Do not process MD with markdown_media

### DIFF
--- a/app/lib/code_archiver.rb
+++ b/app/lib/code_archiver.rb
@@ -34,6 +34,14 @@ class CodeArchiver
       end
 
       puts '**********************************************************************'
+      if ENV['STATIC_EXPORT_IMAGES'].present?
+        puts 'downloading local copies of article images. this will take a while...'
+        download_article_images
+      else
+        puts 'SKIPPING IMAGE DOWNLOADS: use env variable STATIC_EXPORT_IMAGES=1 to include images'
+      end
+
+      puts '**********************************************************************'
       puts 'here are some git commands that might work for updating the archive repo:'
       puts git_steps
     end
@@ -122,6 +130,26 @@ class CodeArchiver
 
     def pages_prefix
       'website-content/pages'
+    end
+
+    def download_article_images
+      files = `grep -hrioE '"http[s]?:\/\/cloudfront\.crimethinc\.com.*"' website-content/articles/ | sort | uniq`
+      count = `grep -hrioE '"http[s]?:\/\/cloudfront\.crimethinc\.com.*"' website-content/articles/ | sort | uniq| wc -l`.to_i
+
+      files = files.tr('\"', '').split("\n")
+
+      files.each_with_index do |url, index|
+        puts "#{count - index} files left"
+        uri = URI.parse(url)
+        next unless uri.path.start_with?('/assets/articles/')
+
+        filepath = uri.path.split('/')[2..].join('/')
+        `curl -s --create-dirs -o "website-content/#{filepath}" "#{url}"`
+      rescue URI::InvalidURIError
+        puts "#{url} is not a valid asset URL"
+      end
+
+      :done
     end
   end
 end

--- a/app/lib/code_archiver.rb
+++ b/app/lib/code_archiver.rb
@@ -86,7 +86,7 @@ class CodeArchiver
 
     def to_html article
       Kramdown::Document.new(
-        MarkdownMedia.parse(article.content, include_media: false),
+        MarkdownMedia.parse(article.content, include_media: true),
         input:                     :kramdown,
         remove_block_html_tags:    false,
         transliterated_header_ids: true
@@ -95,7 +95,7 @@ class CodeArchiver
 
     def to_markdown article
       Kramdown::Document.new(
-        MarkdownMedia.parse(article.content, include_media: false),
+        MarkdownMedia.parse(article.content, include_media: true),
         input:                     :kramdown,
         remove_block_html_tags:    false,
         transliterated_header_ids: true


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/muAhZqHWt0bv2/giphy.gif)

# What are the relevant GitHub issues?

related to #1447 

# What does this pull request do?
We wanted to keep the media tags in the static
markdown files in case we get to downloading the images locally

this change results in an archive diff like this:
```diff
--- a/articles/1999/07/30/punk-shows.md
+++ b/articles/1999/07/30/punk-shows.md
@@ -34,10 +34,14 @@ shows.

 # THE ATOM AND HIS PACKAGE SHOW WAS JUST A WARNING SHOT

-<a
-href="https://cloudfront.crimethinc.com/assets/articles/1999/07/30/atom-and-his-package.jpg"
-class=""> From
-[http://atomandhispackage.com/news.html](atomandhispackage.com) </a>
+<figure class="">
+
+      <img src="https://cloudfront.crimethinc.com/assets/articles/1999/07/30/atom-and-his-package.jpg" />
+
+
+    <figcaption><p>From <a href="atomandhispackage.com">http://atomandhispackage.com/news.html</a></p>
+</figcaption>
+  </figure>
```

# How should this be manually tested?

- test image downloading with `STATIC_EXPORT_IMAGES=1 bundle exec rails static:export`
- example run here: https://github.com/crimethinc/website-content/pull/4

# Acceptance Criteria
## These should be checked by the reviewers

- [X] This pull request does not cause the database export script to become out of sync with the db schema
