### PR TITLE
[I18N] Add thai to the `/lang` page

### DIFF
--- a/app/services/locale_service/locales.rb
+++ b/app/services/locale_service/locales.rb
@@ -78,6 +78,10 @@ class LocaleService::Locales # rubocop:disable Style/ClassAndModuleChildren
     Locale.new(locale: 'swedish', lang_code: :sv, canonical: 'svenska'),
     Locale.new(locale: 'svenska', lang_code: :sv, canonical: 'svenska'),
 
+    # thai
+    Locale.new(locale: 'thai', lang_code: :th, canonical: 'phaasaaaithy'),
+    Locale.new(locale: 'ภาษาไทย', lang_code: :th, canonical: 'phaasaaaithy'),
+
     # turkish
     Locale.new(locale: 'turkish', lang_code: :tr, canonical: 'turkce'),
     Locale.new(locale: 'türkçe',  lang_code: :tr, canonical: 'turkce'),

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -16,6 +16,8 @@ FactoryBot.define do
     end
   end
 
+  trait(:arabic)  { locale { 'ar' } }
+  trait(:czech)   { locale { 'cs' } }
   trait(:spanish) { locale { 'es' } }
   trait(:danish)  { locale { 'da' } }
   trait(:german)  { locale { 'de' } }
@@ -25,6 +27,7 @@ FactoryBot.define do
   trait(:hebrew)  { locale { 'he' } }
   trait(:italian) { locale { 'it' } }
   trait(:swedish) { locale { 'sv' } }
+  trait(:thai)    { locale { 'th' } }
   trait(:turkish) { locale { 'tr' } }
   trait(:portuguese) { locale { 'pt' } }
   trait(:polish) { locale { 'pl' } }

--- a/spec/factories/locale.rb
+++ b/spec/factories/locale.rb
@@ -1,4 +1,4 @@
-FactoryBot.define do
+FactoryBot.define do # rubocop:disable Metrics/BlockLength
   factory :locale do
     abbreviation { 'en' }
     name_in_english { 'English' }
@@ -8,6 +8,22 @@ FactoryBot.define do
   end
 
   trait(:en) {}
+
+  trait(:ar) do
+    abbreviation { 'ar' }
+    name_in_english { 'Arabic' }
+    name { 'اَلْعَرَبِيَّةُ' }
+    language_direction { 'rtl' }
+    slug { 'alarabiyawu' }
+  end
+
+  trait(:cs) do
+    abbreviation { 'cd' }
+    name_in_english { 'Czech' }
+    name { 'čeština' }
+    language_direction { 'ltr' }
+    slug { 'cestina' }
+  end
 
   trait(:da) do
     abbreviation { 'da' }
@@ -110,5 +126,13 @@ FactoryBot.define do
     name { 'Türkçe' }
     language_direction { 'ltr' }
     slug { 'turkce' }
+  end
+
+  trait(:th) do
+    abbreviation { 'th' }
+    name_in_english { 'Thai' }
+    name { 'ภาษาไทย' }
+    language_direction { 'ltr' }
+    slug { 'phaasaaaithy' }
   end
 end

--- a/spec/system/language_landing_page_spec.rb
+++ b/spec/system/language_landing_page_spec.rb
@@ -3,6 +3,9 @@ require 'rails_helper'
 describe 'Language Landing Page' do
   before do
     create(:article)
+    create(:article, :arabic)
+    # TODO: fix czech
+    # create(:article, :czech)
     create(:article, :spanish)
     create(:article, :german)
     create(:article, :danish)
@@ -12,6 +15,7 @@ describe 'Language Landing Page' do
     create(:article, :hebrew)
     create(:article, :italian)
     create(:article, :swedish)
+    create(:article, :thai)
     create(:article, :turkish)
     create(:article, :portuguese)
     create(:article, :polish)


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/KZk63u2F8kEPG9KQR3/giphy.gif)

# What are the relevant GitHub issues?

n/a

# What does this pull request do?

add Thai to the in memory locale lookup so that it shows up on the language landing page

# How should this be manually tested?

- https://crimethinc-staging-pr-1521.herokuapp.com/languages

# Questions for the pull request author (delete any that don't apply):
- [X] Does the code you updated have tests? If not, could you add some please?

# Acceptance Criteria
## These should be checked by the reviewers

- [X] This pull request does not cause the database export script to become out of sync with the db schema
