### PR TITLE
Cache bundled gems

### DIFF
--- a/.github/workflows/greeter.yml
+++ b/.github/workflows/greeter.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/first-interaction@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: "That's your first issue in this repo! Thanks and welcome! 🎉"
-        pr-message: "That's your first pull request in this repo! Thanks for contributing! ❤️"
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: "That's your first issue in this repo! Thanks and welcome! 🎉"
+          pr-message: "That's your first pull request in this repo! Thanks for contributing! ❤️"

--- a/.github/workflows/greeter.yml
+++ b/.github/workflows/greeter.yml
@@ -1,4 +1,4 @@
-name: Greetings
+name: Greeter
 
 on: [pull_request, issues]
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@master
 
-      - name: Install dependencies
+      - name: Install Ruby gems
         run: |
           gem install rubocop rubocop-performance rubocop-rspec --no-document
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: Install Ruby gems
         run: |
-          gem install bundler
-          bundle config set path 'vendor/bundle
+          gem install bundler --no-document
+          bundle config set path 'vendor/bundle'
           bundle install --jobs 4 --retry 3
 
       - name: Configure database

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-
     steps:
       - name: Install system libraries
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,18 +32,17 @@ jobs:
         uses: ruby/setup-ruby@master
 
       - name: Cache bundled gems
-        id: gem-cache
         uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gem-
+            ${{ runner.os }}-gems-
 
       - name: Install Ruby gems
         run: |
           gem install bundler --no-document
-          bundle config set path 'vendor/bundle'
+          bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 
       - name: Configure database

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@master
 
+      - name: Cache bundled gems
+        id: gem-cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gem-
+
       - name: Install Ruby gems
         run: |
           gem install bundler

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,8 @@ jobs:
       - name: Install Ruby gems
         run: |
           gem install bundler
-          bundle install --path vendor/bundle --jobs 4 --retry 3
+          bundle config set path 'vendor/bundle
+          bundle install --jobs 4 --retry 3
 
       - name: Configure database
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Ruby gems
         run: |
           gem install bundler
-          bundle install --jobs 4 --retry 3
+          bundle install --path vendor/bundle --jobs 4 --retry 3
 
       - name: Configure database
         env:


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![bunny eating flower](https://media.giphy.com/media/3PbmZWedxyoYU/giphy.gif)

# What are the relevant GitHub issues?

n/a

# What does this pull request do?

Caches the artifact from `bundle install` so that PRs that don't change `Gemfile.lock` run faster.

# How should this be manually tested?

Compare test run times.

This was on a Dependabot PR that did not have caching and did change the `Gemfile.lock`.

<img width="691" alt="Screen Shot 2020-03-22 at 8 50 24 PM" src="https://user-images.githubusercontent.com/4361/77280054-9636aa00-6c80-11ea-9322-1bec38cb8713.png">

PR with caching and no change to `Gemfile.lock`.

`...`

# Is there any background context you want to provide for reviewers?

Faster is better in this case. Vroom vroom.
