### PR TITLE
DRY use .ruby-version as source of truth, from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
-ruby '~> 2.6.5'
+
+ruby File.read('.ruby-version').chomp
 
 # app server
 gem 'rails', '~> 6.0.2'


### PR DESCRIPTION
# What does this pull request do?

Reads the contents of `.ruby-version` when evaluating `ruby <version>` in `Gemfile`.

This eliminates the duplication of setting our Ruby version. Now it's only in `.ruby-version`.