### PR TITLE
Separate system tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 on: [push]
 
-name: Tests
+name: (Non-system) Tests
 
 jobs:
   run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,4 +55,4 @@ jobs:
         env:
           PGUSER: postgres
         run: |
-          bundle exec rspec
+          bundle exec rspec --exclude-pattern="spec/system/*"

--- a/.github/workflows/tests_system.yml
+++ b/.github/workflows/tests_system.yml
@@ -1,0 +1,58 @@
+on: [push]
+
+name: System Tests
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:11.6-alpine
+        ports: ['5432:5432']
+        env:
+          PGUSER: postgres
+          PGPASSWORD: ''
+        # Ensure Postgres container passes a health check
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Install system libraries
+        run: |
+          sudo apt-get -y install libpq-dev
+
+      - name: Checkout repository
+        uses: actions/checkout@master
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@master
+
+      - name: Cache bundled gems
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Install Ruby gems
+        run: |
+          gem install bundler --no-document
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Configure database
+        env:
+          PGUSER: postgres
+        run: |
+          bundle exec rails db:create
+
+      - name: Run tests
+        env:
+          PGUSER: postgres
+        run: |
+          bundle exec rspec spec/system


### PR DESCRIPTION
Separating system tests from unit/etc tests allows them to run in parallel and fail faster, if either is going to fail.

<img width="687" alt="Screen Shot 2020-03-23 at 1 22 41 AM" src="https://user-images.githubusercontent.com/4361/77296389-d019a780-6ca4-11ea-82d0-0ce53f178544.png">
