### PR TITLE
[#1194] Make tag name uniqueness case insensitive

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -11,7 +11,7 @@ class Tag < ApplicationRecord
 
   before_validation :strip_whitespace, on: %i[create update]
 
-  validates :name, uniqueness: true
+  validates :name, uniqueness: { case_sensitive: false }
 
   def strip_whitespace
     self.name = name.strip

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -3,6 +3,17 @@ require 'rails_helper'
 describe Tag do
   subject(:tag) { described_class.new(name: 'test') }
 
+  describe 'validation' do
+    context 'when two tag has the same name with case difference' do
+      it 'makes the second tag invalid' do
+        described_class.create!(name: 'anarchism')
+        second_tag = described_class.new(name: 'Anarchism')
+
+        expect(second_tag).to be_invalid
+      end
+    end
+  end
+
   describe 'assigned_to?' do
     let(:page) { Page.create(title: 'about') }
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -4,7 +4,7 @@ describe Tag do
   subject(:tag) { described_class.new(name: 'test') }
 
   describe 'validation' do
-    context 'when two tag has the same name with case difference' do
+    context 'when two tags have the same name with case difference' do
       it 'makes the second tag invalid' do
         described_class.create!(name: 'anarchism')
         second_tag = described_class.new(name: 'Anarchism')


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

Didn't find the right gif.. :/

# What are the relevant GitHub issues?

Make #1194 better

# What does this pull request do?

It makes the tag validation case-insensitive. This way, anarchism and Anarchism will be the same and it will avoid some tag duplication.

# How should this be manually tested?

There is a unit test for it. Otherwise, you can create a resource with a tag named `Anarchism` and other one with the tag `anarchism` and the to resources will be link to the same tag.

# Questions for the pull request author (delete any that don't apply):
- [x] Does the code you updated have tests? If not, could you add some please?

# Acceptance Criteria
## These should be checked by the reviewers

- [x] This pull request does not cause the database export script to become out of sync with the db schema
