### PR TITLE
[BOOKS] use `preferred_localization` on book index

### DIFF
--- a/app/views/2017/books/index.html.erb
+++ b/app/views/2017/books/index.html.erb
@@ -13,7 +13,7 @@
 
   <div class="tool-series tool-series-books">
     <% @books.each do |book| %>
-      <%= render_themed "books/book", book: book %>
+      <%= render_themed "books/book", book: book.preferred_localization %>
     <% end %>
   </div> <!-- .tool-series-books -->
 


### PR DESCRIPTION

### What are the relevant GitHub issues?

related to #1593 

### What does this pull request do?

uses `preferred_localization` for `/books` 

### How should this be manually tested?

see books when you look at `https://pt.crimethinc.com/books`

# Is there any background context you want to provide for reviewers?
:facepalm: 

