### PR TITLE
[#1551] Use Current.theme in place of Theme.name

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ require 'json'
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  before_action :set_locale_from_subdomain
+  before_action :set_current_locale
   before_action :set_site_locale
   before_action :check_for_redirection
   before_action :strip_file_extension
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
     redirect_to [:signin], alert: 'You need to sign in to view that page.' unless signed_in?
   end
 
-  def set_locale_from_subdomain
+  def set_current_locale
     locale = request.subdomain
     I18n.locale = locale if I18n.available_locales.include?(locale.to_sym)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :set_current_locale
+  before_action :set_current_theme
+
   before_action :set_site_locale
   before_action :check_for_redirection
   before_action :strip_file_extension
@@ -57,6 +59,10 @@ class ApplicationController < ActionController::Base
 
       redirect_to({ subdomain: I18n.locale }.merge(params.permit!))
     end
+  end
+
+  def set_current_theme
+    Current.theme = ENV.fetch('THEME') { '2017' }
   end
 
   def check_for_redirection

--- a/app/controllers/article_archives_controller.rb
+++ b/app/controllers/article_archives_controller.rb
@@ -26,7 +26,7 @@ class ArticleArchivesController < ApplicationController
     if path.present?
       redirect_to path
     else
-      render "#{Theme.name}/article_archives/index"
+      render "#{Current.theme}/article_archives/index"
     end
   end
 end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,7 +4,7 @@ class ArticlesController < ApplicationController
   def index
     @articles = Article.includes(:tags, :categories).live.published.root.page(params[:page]).per(10)
 
-    render "#{Theme.name}/articles/index"
+    render "#{Current.theme}/articles/index"
   end
 
   def show
@@ -53,7 +53,7 @@ class ArticlesController < ApplicationController
     if @article.content_in_html?
       render html: @article.content.html_safe, layout: false
     else
-      render "#{Theme.name}/articles/show"
+      render "#{Current.theme}/articles/show"
     end
   end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -9,7 +9,7 @@ class BooksController < ApplicationController
 
     @books = Book.english.for_index
 
-    render "#{Theme.name}/books/index"
+    render "#{Current.theme}/books/index"
   end
 
   def show
@@ -20,7 +20,7 @@ class BooksController < ApplicationController
     @title    = PageTitle.new title_for(:books, @book.slug.underscore)
     @tool     = @book
 
-    render "#{Theme.name}/books/show"
+    render "#{Current.theme}/books/show"
   end
 
   def extras
@@ -28,7 +28,7 @@ class BooksController < ApplicationController
     @body_id = 'tools'
     @title   = PageTitle.new title_for(:books, @book.slug.underscore, :extras)
 
-    render "#{Theme.name}/books/extras"
+    render "#{Current.theme}/books/extras"
   end
 
   def lit_kit
@@ -36,7 +36,7 @@ class BooksController < ApplicationController
     @body_id = 'tools'
     @title   = PageTitle.new title_for(:books, :lit_kit)
 
-    render "#{Theme.name}/books/lit_kit"
+    render "#{Current.theme}/books/lit_kit"
   end
 
   def into_libraries
@@ -44,7 +44,7 @@ class BooksController < ApplicationController
     @body_id = 'tools'
     @title   = PageTitle.new title_for(:books, :into_libraries)
 
-    render "#{Theme.name}/books/into_libraries"
+    render "#{Current.theme}/books/into_libraries"
   end
 
   private

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -8,7 +8,7 @@ class CategoriesController < ApplicationController
     @html_id = 'page'
     @body_id = 'category'
 
-    render "#{Theme.name}/categories/show"
+    render "#{Current.theme}/categories/show"
   end
 
   def index
@@ -17,11 +17,11 @@ class CategoriesController < ApplicationController
     @categories = Category.all
     @title      = PageTitle.new title_for(:categories)
 
-    render "#{Theme.name}/categories/index"
+    render "#{Current.theme}/categories/index"
   end
 
   def feed
-    render "#{Theme.name}/articles/index"
+    render "#{Current.theme}/articles/index"
   end
 
   private

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -8,7 +8,7 @@ class EpisodesController < ApplicationController
     @editable = @episode
     @title    = PageTitle.new title_for :podcasts, @episode.name
 
-    render "#{Theme.name}/episodes/show"
+    render "#{Current.theme}/episodes/show"
   end
 
   def transcript
@@ -17,7 +17,7 @@ class EpisodesController < ApplicationController
     @editable = @episode
     @title    = PageTitle.new title_for :podcasts, @episode.name, :transcript
 
-    render "#{Theme.name}/episodes/show"
+    render "#{Current.theme}/episodes/show"
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,7 @@ class HomeController < ApplicationController
     # Homepage featured article
     @latest_article = articles_for_current_page.first if first_page?
 
-    if Theme.name == '2020'
+    if Current.theme == '2020'
       # Feed artciles, needed for pagination
       @articles = articles_for_current_page.page(params[:page]).per(14).padding(1)
 
@@ -44,7 +44,7 @@ class HomeController < ApplicationController
       @articles = articles_for_current_page.page(params[:page]).per(6).padding(1)
     end
 
-    render "#{Theme.name}/home/index"
+    render "#{Current.theme}/home/index"
   end
 
   private

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -7,6 +7,6 @@ class IssuesController < ToolsController
     @editable = @issue
 
     @title = PageTitle.new title_for :journals, journal.name, @issue.issue
-    render "#{Theme.name}/books/show"
+    render "#{Current.theme}/books/show"
   end
 end

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -2,11 +2,11 @@ class JournalsController < ToolsController
   # See tools_controller.rb for inherited behavior
   def index
     @journals = Journal.includes(:issues)
-    render "#{Theme.name}/journals/index"
+    render "#{Current.theme}/journals/index"
   end
 
   def show
     @journal = Journal.find_by(slug: params[:id])
-    render "#{Theme.name}/journals/show"
+    render "#{Current.theme}/journals/show"
   end
 end

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -7,7 +7,7 @@ class LanguagesController < ApplicationController
     @locales = Locale.live
     @title = PageTitle.new t 'header.languages'
 
-    render "#{Theme.name}/languages/index"
+    render "#{Current.theme}/languages/index"
   end
 
   def show
@@ -16,7 +16,7 @@ class LanguagesController < ApplicationController
     @locale  = Locale.find_by(slug: canonical_locale.canonical)
     @title = PageTitle.new "#{@locale.name} / #{@locale.name_in_english} (#{@locale.slug})"
 
-    render "#{Theme.name}/languages/show"
+    render "#{Current.theme}/languages/show"
   end
 
   private

--- a/app/controllers/logos_controller.rb
+++ b/app/controllers/logos_controller.rb
@@ -5,7 +5,7 @@ class LogosController < ApplicationController
     @tools   = Logo.live.published.page(params[:page]).per(100)
     @title   = PageTitle.new title_for :logos
 
-    render "#{Theme.name}/logos/index"
+    render "#{Current.theme}/logos/index"
   end
 
   def show
@@ -18,6 +18,6 @@ class LogosController < ApplicationController
     @editable = @tool
     @title    = PageTitle.new title_for :logos, @tool.name
 
-    render "#{Theme.name}/logos/show"
+    render "#{Current.theme}/logos/show"
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,34 +16,34 @@ class PagesController < ApplicationController
     @editable = @page
     @title = PageTitle.new I18n.t('page_titles.about.about')
 
-    render "#{Theme.name}/pages/about"
+    render "#{Current.theme}/pages/about"
   end
 
   def contact
     @editable = @page
     @title = PageTitle.new I18n.t('page_titles.about.contact')
 
-    render "#{Theme.name}/pages/contact"
+    render "#{Current.theme}/pages/contact"
   end
 
   def library
     @title = PageTitle.new I18n.t('page_titles.about.library')
 
-    render "#{Theme.name}/pages/library"
+    render "#{Current.theme}/pages/library"
   end
 
   def post_order_success
     @title    = PageTitle.new title_for I18n.t('page_titles.about.store'), I18n.t('page_titles.about.post_order_success')
     @order_id = params[:ordernum]
 
-    render "#{Theme.name}/pages/post_order_success"
+    render "#{Current.theme}/pages/post_order_success"
   end
 
   # TODO: make this view localizable
   def submission_guidelines
     @title = PageTitle.new I18n.t('page_titles.about.submission_guidelines')
 
-    render "#{Theme.name}/pages/submission_guidelines"
+    render "#{Current.theme}/pages/submission_guidelines"
   end
 
   def pgp_public_key

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -6,7 +6,7 @@ class PodcastsController < ApplicationController
     @editable = @podcasts.first
     @title    = PageTitle.new title_for :podcasts
 
-    render "#{Theme.name}/podcasts/index"
+    render "#{Current.theme}/podcasts/index"
   end
 
   def show
@@ -15,7 +15,7 @@ class PodcastsController < ApplicationController
     @podcast = Podcast.find_by(slug: params[:slug])
     @title   = PageTitle.new title_for @podcast.name
 
-    render "#{Theme.name}/podcasts/show"
+    render "#{Current.theme}/podcasts/show"
   end
 
   def feed; end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -14,7 +14,7 @@ class SearchController < ApplicationController
 
     @title = PageTitle.new title_for :search, :results, "“#{@query}”"
 
-    render "#{Theme.name}/search/index"
+    render "#{Current.theme}/search/index"
   end
 
   def advanced
@@ -24,7 +24,7 @@ class SearchController < ApplicationController
 
     @advanced_search = AdvancedSearch.new(params[:q])
 
-    render "#{Theme.name}/search/advanced"
+    render "#{Current.theme}/search/advanced"
   end
 
   def advanced_search

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -6,7 +6,7 @@ class SupportController < ApplicationController
     @body_id = 'support'
     @title   = PageTitle.new t('views.support.new.heading')
 
-    render "#{Theme.name}/support/new"
+    render "#{Current.theme}/support/new"
   end
 
   def create
@@ -28,7 +28,7 @@ class SupportController < ApplicationController
     @body_id = 'support'
     @title   = PageTitle.new t('views.support.thanks.heading')
 
-    render "#{Theme.name}/support/thanks"
+    render "#{Current.theme}/support/thanks"
   end
 
   def create_session
@@ -76,7 +76,7 @@ class SupportController < ApplicationController
       @next_invoice = Stripe::Invoice.upcoming(customer: @customer.id)
     end
 
-    render "#{Theme.name}/support/edit"
+    render "#{Current.theme}/support/edit"
   end
 
   def update_subscription

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -7,11 +7,11 @@ class TagsController < ApplicationController
     @html_id = 'page'
     @body_id = 'tag'
 
-    render "#{Theme.name}/tags/show"
+    render "#{Current.theme}/tags/show"
   end
 
   def feed
-    render "#{Theme.name}/articles/index"
+    render "#{Current.theme}/articles/index"
   end
 
   private

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -16,15 +16,15 @@ class ToolsController < ApplicationController
 
   # GET /tools
   def about
-    render "#{Theme.name}/tools/about"
+    render "#{Current.theme}/tools/about"
   end
 
   def index
-    render "#{Theme.name}/tools/index"
+    render "#{Current.theme}/tools/index"
   end
 
   def show
-    render "#{Theme.name}/tools/show"
+    render "#{Current.theme}/tools/show"
   end
 
   private

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -5,7 +5,7 @@ class VideosController < ApplicationController
     @title   = PageTitle.new title_for :videos
     @videos  = Video.live.published.page(params[:page]).per(20)
 
-    render "#{Theme.name}/videos/index"
+    render "#{Current.theme}/videos/index"
   end
 
   def show
@@ -17,6 +17,6 @@ class VideosController < ApplicationController
     @body_id  = 'video'
     @title    = PageTitle.new title_for :videos, @video.title
 
-    render "#{Theme.name}/videos/show"
+    render "#{Current.theme}/videos/show"
   end
 end

--- a/app/controllers/zines_controller.rb
+++ b/app/controllers/zines_controller.rb
@@ -1,6 +1,6 @@
 class ZinesController < ToolsController
   # See tools_controller.rb for inherited behavior
   def show
-    render "#{Theme.name}/books/show"
+    render "#{Current.theme}/books/show"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,10 +15,10 @@ module ApplicationHelper
   end
 
   def render_themed path, options = {}
-    render "#{Theme.name}/#{path}", options
+    render "#{Current.theme}/#{path}", options
   end
 
   def tt path, options = {}
-    t "#{Theme.name}.#{path}", options
+    t "#{Current.theme}.#{path}", options
   end
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,3 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :user
+  attribute :user, :theme
 end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,7 +1,7 @@
 class Theme
   class << self
     def name
-      ENV.fetch('THEME') { '2017' }
+      Current.theme
     end
   end
 end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,7 +1,0 @@
-class Theme
-  class << self
-    def name
-      Current.theme
-    end
-  end
-end

--- a/app/views/2017/shared/head/_stylesheets.html.erb
+++ b/app/views/2017/shared/head/_stylesheets.html.erb
@@ -1,5 +1,5 @@
 <!-- CSS -->
-<%= stylesheet_link_tag Theme.name, media: "all" unless lite_mode? %>
+<%= stylesheet_link_tag Current.theme, media: "all" unless lite_mode? %>
 
 <style>
   <% if @article.present? && @article.css.present? %>

--- a/app/views/layouts/2020/_application.html.erb
+++ b/app/views/layouts/2020/_application.html.erb
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/milligram/1.3.0/milligram.css">
     <!-- /TEMP: for development only -->
 
-    <%= stylesheet_link_tag Theme.name, media: "all" %>
+    <%= stylesheet_link_tag Current.theme, media: "all" %>
     <%= stylesheet_link_tag "https://fonts.googleapis.com/css?family=Markazi+Text:400,500,600,700&display=swap", media: "all" %>
     <%= render_themed "shared/translation_missing_css" %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,1 +1,1 @@
-<%= render "layouts/#{Theme.name}/application" %>
+<%= render "layouts/#{Current.theme}/application" %>

--- a/app/views/shared/head/_stylesheets.html.erb
+++ b/app/views/shared/head/_stylesheets.html.erb
@@ -1,5 +1,5 @@
 <!-- CSS -->
-<%= stylesheet_link_tag Theme.name, media: "all" unless lite_mode? %>
+<%= stylesheet_link_tag Current.theme, media: "all" unless lite_mode? %>
 
 <style>
   <% if @article.present? && @article.css.present? %>

--- a/app/views/steal_something_from_work_day/head/_stylesheets.html.erb
+++ b/app/views/steal_something_from_work_day/head/_stylesheets.html.erb
@@ -1,5 +1,5 @@
 <!-- CSS -->
-<%= stylesheet_link_tag Theme.name, media: "all" unless lite_mode? %>
+<%= stylesheet_link_tag Current.theme, media: "all" unless lite_mode? %>
 
 <style>
   <% if @article.present? && @article.css.present? %>


### PR DESCRIPTION
# Closes #1551 

Use `CurrentAttributes` for the current theme, which is only read from ENV now but will be set per article in the future.