### PR TITLE
[I18N] Show `.preferred_localization` on the `/tags` page

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -28,7 +28,7 @@ class TagsController < ApplicationController
   end
 
   def set_articles
-    @articles = @tag.articles.live.published.page(params[:page]).per(25)
+    @articles = @tag.articles.english.live.published.page(params[:page]).per(25)
     return redirect_to root_path if @articles.empty?
   end
 end

--- a/app/views/2017/articles/_list.html.erb
+++ b/app/views/2017/articles/_list.html.erb
@@ -1,5 +1,5 @@
 <div class="articles-list">
   <% articles.each do |article| %>
-    <%= render_themed "articles/list_item", article: article %>
+    <%= render_themed "articles/list_item", article: article.preferred_localization %>
   <% end %>
 </div>


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![just-works](https://user-images.githubusercontent.com/13190980/83334167-72cc4480-a259-11ea-8a24-64c7b29d08b6.gif)


# What are the relevant GitHub issues?

n/a

# What does this pull request do?

Makes the `/tags` index page behave like the articles (in that it shows the preferred locale if available, and fall back to english)

# How should this be manually tested?

https://crimethinc-staging-pr-1628.herokuapp.com/tags/hong-kong

# Acceptance Criteria
## These should be checked by the reviewers

- [X] This pull request does not cause the database export script to become out of sync with the db schema
