### PR TITLE
Add 'position' and 'hide_from_index' to the other tools

### DIFF
--- a/app/controllers/admin/issues_controller.rb
+++ b/app/controllers/admin/issues_controller.rb
@@ -64,7 +64,8 @@ module Admin
                                     :print_black_and_white_a4_download_present, :print_color_a4_download_present,
                                     :print_color_download_present, :print_black_and_white_download_present,
                                     :screen_single_page_view_download_present, :screen_two_page_view_download_present,
-                                    :publication_status, :journal_id, :issue, :featured_status, :featured_at)
+                                    :publication_status, :journal_id, :issue, :featured_status, :featured_at,
+                                    :position, :hide_from_index)
     end
   end
 end

--- a/app/controllers/admin/journals_controller.rb
+++ b/app/controllers/admin/journals_controller.rb
@@ -50,7 +50,7 @@ module Admin
     end
 
     def journal_params
-      params.require(:journal).permit(:title, :subtitle, :description, :locale)
+      params.require(:journal).permit(:title, :subtitle, :description, :locale, :position, :hide_from_index)
     end
   end
 end

--- a/app/controllers/admin/logos_controller.rb
+++ b/app/controllers/admin/logos_controller.rb
@@ -53,7 +53,8 @@ module Admin
       params.require(:logo).permit(:title, :subtitle, :description, :slug, :height,
                                    :width, :summary, :published_at, :locale,
                                    :jpg_url_present, :png_url_present, :pdf_url_present,
-                                   :svg_url_present, :tif_url_present, :publication_status)
+                                   :svg_url_present, :tif_url_present, :publication_status,
+                                   :position, :hide_from_index)
     end
   end
 end

--- a/app/controllers/admin/posters_controller.rb
+++ b/app/controllers/admin/posters_controller.rb
@@ -59,7 +59,7 @@ module Admin
                                      :back_black_and_white_image_present, :front_color_download_present,
                                      :front_black_and_white_download_present, :back_color_download_present,
                                      :back_black_and_white_download_present, :publication_status,
-                                     :featured_status, :featured_at, :canonical_id)
+                                     :featured_status, :featured_at, :canonical_id, :position, :hide_from_index)
     end
   end
 end

--- a/app/controllers/admin/stickers_controller.rb
+++ b/app/controllers/admin/stickers_controller.rb
@@ -61,7 +61,7 @@ module Admin
                                       :back_black_and_white_image_present, :front_color_download_present,
                                       :front_black_and_white_download_present, :back_color_download_present,
                                       :back_black_and_white_download_present, :publication_status,
-                                      :featured_status, :featured_at, :canonical_id)
+                                      :featured_status, :featured_at, :canonical_id, :position, :hide_from_index)
     end
   end
 end

--- a/app/controllers/admin/zines_controller.rb
+++ b/app/controllers/admin/zines_controller.rb
@@ -64,7 +64,7 @@ module Admin
                                    :print_black_and_white_a4_download_present, :print_color_a4_download_present,
                                    :print_color_download_present, :print_black_and_white_download_present,
                                    :screen_single_page_view_download_present, :screen_two_page_view_download_present,
-                                   :publication_status, :featured_status, :featured_at)
+                                   :publication_status, :featured_status, :featured_at, :position, :hide_from_index)
     end
   end
 end

--- a/db/migrate/20200530232342_add_position_to_zines.rb
+++ b/db/migrate/20200530232342_add_position_to_zines.rb
@@ -1,0 +1,17 @@
+class AddPositionToZines < ActiveRecord::Migration[6.0]
+  def change
+    add_column :zines,    :position, :integer
+    add_column :journals, :position, :integer
+    add_column :issues,   :position, :integer
+    add_column :posters,  :position, :integer
+    add_column :stickers, :position, :integer
+    add_column :logos,    :position, :integer
+
+    add_column :zines,    :hide_from_index, :boolean, default: false
+    add_column :journals, :hide_from_index, :boolean, default: false
+    add_column :issues,   :hide_from_index, :boolean, default: false
+    add_column :posters,  :hide_from_index, :boolean, default: false
+    add_column :stickers, :hide_from_index, :boolean, default: false
+    add_column :logos,    :hide_from_index, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_11_024239) do
+ActiveRecord::Schema.define(version: 2020_05_30_232342) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -205,6 +205,8 @@ ActiveRecord::Schema.define(version: 2020_05_11_024239) do
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
     t.datetime "featured_at"
+    t.integer "position"
+    t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_issues_on_canonical_id"
   end
 
@@ -224,6 +226,8 @@ ActiveRecord::Schema.define(version: 2020_05_11_024239) do
     t.integer "price_in_cents"
     t.string "locale", default: "en"
     t.integer "canonical_id"
+    t.integer "position"
+    t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_journals_on_canonical_id"
   end
 
@@ -258,6 +262,8 @@ ActiveRecord::Schema.define(version: 2020_05_11_024239) do
     t.integer "publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
+    t.integer "position"
+    t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_logos_on_canonical_id"
   end
 
@@ -343,6 +349,8 @@ ActiveRecord::Schema.define(version: 2020_05_11_024239) do
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
     t.datetime "featured_at"
+    t.integer "position"
+    t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_posters_on_canonical_id"
   end
 
@@ -387,6 +395,8 @@ ActiveRecord::Schema.define(version: 2020_05_11_024239) do
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
     t.datetime "featured_at"
+    t.integer "position"
+    t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_stickers_on_canonical_id"
   end
 
@@ -497,6 +507,8 @@ ActiveRecord::Schema.define(version: 2020_05_11_024239) do
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
     t.datetime "featured_at"
+    t.integer "position"
+    t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_zines_on_canonical_id"
   end
 


### PR DESCRIPTION
We can make them sortable in the future, but this was at least needed for Zines because they share the form with Books.