### PR TITLE
Fix Zine admin form (remove book specific bits)

### DIFF
--- a/app/assets/stylesheets/admin/_articles.scss
+++ b/app/assets/stylesheets/admin/_articles.scss
@@ -18,7 +18,7 @@ label  {
 // Everything below it was published pre-counter.
 .article-counter-genesis { border-bottom: 10px solid #666; }
 
-#admin-article-form-page {
+.toggle {
   // Treat radio buttons as toggle buttons
   input + label {
     @extend .btn;

--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -28,14 +28,12 @@ module Admin
       @article    = Article.new
       prepare_article_for_translation
 
-      @title   = admin_title
-      @html_id = 'admin-article-form-page'
+      @title = admin_title
     end
 
     def edit
       @collection = Article.find(@article.collection_id) if @article.in_collection?
       @title      = admin_title(@article, %i[id title subtitle])
-      @html_id    = 'admin-article-form-page'
     end
 
     def create

--- a/app/views/admin/_publication_status.html.erb
+++ b/app/views/admin/_publication_status.html.erb
@@ -1,9 +1,11 @@
 <div id="publication-status" class="form-group">
   <%= form.label :publication_status, "Publication Status" %><br>
 
-  <% Publishable.publication_statuses_for(user: Current.user).each do |state| %>
-    <%= form.radio_button :publication_status, state, id: "publication_status_#{state}", class: "sr-only" %>
+  <div class="toggle">
+    <% Publishable.publication_statuses_for(user: Current.user).each do |state| %>
+      <%= form.radio_button :publication_status, state, id: "publication_status_#{state}", class: "sr-only" %>
 
-    <%= form.label "publication_status_#{state}", state.capitalize, for: "publication_status_#{state}" %>
-  <% end %>
+      <%= form.label "publication_status_#{state}", state.capitalize, for: "publication_status_#{state}" %>
+    <% end %>
+  </div><!-- .toggle -->
 </div><!-- #publication-status -->

--- a/app/views/admin/articles/form/_featured_status.html.erb
+++ b/app/views/admin/articles/form/_featured_status.html.erb
@@ -1,4 +1,4 @@
-<div id="featured_status" class="form-group">
+<div id="featured_status" class="form-group toggle sr-only">
   <%= form.label :featured_status, "Feature this on homepage?" %><br>
 
   <%= form.radio_button :featured_status, false, class: "sr-only" %>

--- a/app/views/admin/books/_form.html.erb
+++ b/app/views/admin/books/_form.html.erb
@@ -5,13 +5,13 @@
     <div class="row">
       <div class="col-12 col-lg-8">
         <div class="form-group">
-          <%= form.label :journal_id %><br>
+          <%= form.label :journal_id %>
           <%= form.collection_select :journal_id,
                                      Journal.all,
                                      :id,
                                      :name,
                                      { include_blank: true },
-                                     class: "custom-select custom-select-lg" %>
+                                     class: "form-control form-control-lg" %>
 
           <p class="form-text text-muted">
             If it’s not here, you can
@@ -63,16 +63,24 @@
 
   <div class="row">
     <div class="col-6">
-      <%= render "admin/books/form/position", form: form %>
-      <p class="form-text text-muted">This will set the order that
-      this book shows up on <a href="/books">crimethinc.com/books</a>.</p>
+      <%= render "admin/books/form/position", form: form, resource: resource %>
+      <p class="form-text text-muted">
+        This will set the order that this
+        <%= resource.namespace.singularize %>
+        shows up on
+        <%= link_to "crimethinc.com/#{resource.namespace}", resource.namespace %>.
+      </p>
     </div>
 
     <div class="col-6">
       <%= form.check_box :hide_from_index %>
-      <%= form.label :has_index, "Hide this book from the index page?" %><br>
-      <p class="form-text text-muted">This will prevent the book from
-      showing up on <a href="/books">crimethinc.com/books</a>.</p>
+      <%= form.label :has_index, "Hide this #{resource.namespace.singularize} from the index page?" %>
+      <p class="form-text text-muted">
+        This will prevent this
+        <%= resource.namespace.singularize %>
+        from showing up on
+        <%= link_to "crimethinc.com/#{resource.namespace}", resource.namespace %>.
+      </p>
     </div>
   </div>
 
@@ -150,7 +158,7 @@
 
         <div class="row">
           <div class="col-6">
-            <%= form.label :has_index, "Has Index?" %><br>
+            <%= form.label :has_index, "Has Index?" %>
 
             <div class="form-check">
               <span class="d-inline-block mr-3">

--- a/app/views/admin/books/edit.html.erb
+++ b/app/views/admin/books/edit.html.erb
@@ -8,5 +8,5 @@
 
 <%= render "admin/danger_zone",
            thing: @book,
-           label: "book",
+           label: @book.namespace.singularize,
            path: [:admin, @book] %>

--- a/app/views/admin/books/form/_position.html.erb
+++ b/app/views/admin/books/form/_position.html.erb
@@ -1,4 +1,4 @@
 <div id="position" class="form-group">
-  <%= form.label :position, "Position this book on the index page" %>
-  <%= number_field :book, :position, step: 1, class: 'form-control' %>
+  <%= form.label :position, "Position this #{resource.namespace.singularize} on the index page" %>
+  <%= form.number_field :position, step: 1, class: 'form-control' %>
 </div><!-- #position -->


### PR DESCRIPTION
Book and Zine share the same form partial. 
So any reference to Book directly was either the wrong display text or caused an error when submitting the form.