### PR TITLE
[BUG] fix tag uniqueness logic 

### DIFF
--- a/app/views/admin/articles/form/_categories.html.erb
+++ b/app/views/admin/articles/form/_categories.html.erb
@@ -5,7 +5,7 @@
       <p class="m-0 font-weight-bold">Categories</p>
 
       <div class="form-check">
-        <% @categories.each do |category| %>
+        <% @categories&.each do |category| %>
           <div>
             <%= form.label "category_ids_#{category.id}", class: "form-check-label" do %>
               <%= category_check_box form: form, category: category %>

--- a/db/migrate/20200601010657_add_uniq_to_tags.rb
+++ b/db/migrate/20200601010657_add_uniq_to_tags.rb
@@ -1,0 +1,5 @@
+class AddUniqToTags < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_30_232342) do
+ActiveRecord::Schema.define(version: 2020_06_01_010657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -422,6 +422,7 @@ ActiveRecord::Schema.define(version: 2020_05_30_232342) do
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.index ["canonical_id"], name: "index_tags_on_canonical_id"
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](giphy link)

# What are the relevant GitHub issues?

n/a

# What does this pull request do?
We have this validation on the `Tag` model:

```ruby
  validates :name, uniqueness: { case_sensitive: false }
```

this is because we want to treat a tag with a name of `"Foo"` the same
as a tag with the name of `"foo"`

however, we already have some tags that are upper-cased, some
lower-cased, etc.

We should do some sort of backfill to normalize all existing tags to
be downcased, but until then using an `lower(name)` postgres query
should make this work as intended

# How should this be manually tested?

on the pr app, try drafting a new article with categories

https://crimethinc-staging-pr-1631.herokuapp.com/admin/articles