### PR TITLE
Don't redirect en. subdomain anymore

### DIFF
--- a/app/middlewares/rack/apex_redirect.rb
+++ b/app/middlewares/rack/apex_redirect.rb
@@ -5,19 +5,14 @@ module Rack
     end
 
     def call env
-      request = Rack::Request.new(env)
+      request = Rack::Request.new env
 
-      if request.host.start_with?('www.')
+      if request.host.start_with? 'www.'
         location = request.scheme + '://' + request.host.sub('www.', '') + request.path
-        return redirect(location)
+        return redirect location
       end
 
-      if request.host.start_with?('en.')
-        location = request.scheme + '://' + request.host.sub('en.', '') + request.path
-        return redirect(location)
-      end
-
-      @app.call(env)
+      @app.call env
     end
 
     private


### PR DESCRIPTION
This is for people who have the browser / OS language set to something other than EN, but would like to see the site in English. They can't go to the apex domain because then the locale detection / subdomain redirect will kick in.

However, we don't want to redirect all EN apex requests to the `en.` subdomain, though.