### PR TITLE
Debiggen logo image size on /logos

### DIFF
--- a/app/views/2017/logos/_logo.html.erb
+++ b/app/views/2017/logos/_logo.html.erb
@@ -9,7 +9,13 @@
       <div class="row">
         <div class="column column-one-quarter logo-first-column">
           <div class="tool-front">
-            <%= link_to image_tag(tool.front_image, alt: tool.front_image_description, class: "u-image"), tool.path %>
+            <% if tool.image_jpg.present? %>
+              <%= link_to tool.path do %>
+                <%= image_tag url_for(image_variant_by_width(tool.image_jpg, 240)), class: "u-image" %>
+              <% end %>
+            <% else %>
+              <%= link_to image_tag(tool.front_image, alt: tool.front_image_description, class: "u-image"), tool.path %>
+            <% end %>
           </div> <!-- tool-front -->
         </div> <!-- logo-first-column -->
 


### PR DESCRIPTION
# Updates #773

Uses smaller variant on `/logos` (index and show).