### PR TITLE
Add jemalloc buildpack to reduce memory usage

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,6 +38,7 @@
   "environments": {
     "test": {
       "buildpacks": [
+        { "url": "heroku://github.com/gaffneyc/heroku-buildpack-jemalloc" },
         { "url": "heroku/ruby" },
         { "url": "https://github.com/heroku/heroku-buildpack-chromedriver" },
         { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" },


### PR DESCRIPTION
This: https://elements.heroku.com/buildpacks/gaffneyc/heroku-buildpack-jemalloc

Added to `app.json` for when review apps spin up.

Run in CLI:

```
heroku config:set JEMALLOC_ENABLED=true
heroku create --buildpack https://github.com/gaffneyc/heroku-buildpack-jemalloc.git
```