### PR TITLE
Prune app.json of unused bits

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,8 +37,6 @@
     "test": {
       "buildpacks": [
         { "url": "heroku/ruby" },
-        { "url": "https://github.com/heroku/heroku-buildpack-chromedriver" },
-        { "url": "https://github.com/heroku/heroku-buildpack-google-chrome" },
         { "url": "https://github.com/heroku/heroku-buildpack-apt" },
         { "url": "https://github.com/heroku/heroku-buildpack-activestorage-preview" }
       ]

--- a/app.json
+++ b/app.json
@@ -33,8 +33,6 @@
     "heroku-postgresql:hobby-dev"
   ],
 
-  "image": "heroku/cedar",
-
   "environments": {
     "test": {
       "buildpacks": [


### PR DESCRIPTION
AFAIK, we don't need the `image` bit anymore (ever?) because we don't use Docker style app setup.

AFAIK, we don't need those chromedriver/google-chrome buildpacks anymore because we aren't using Heroku CI anymore.
