### PR TITLE
Skip rendering an article in the reader's preferred language when on languages#show

### DIFF
--- a/app/views/2017/articles/_list.html.erb
+++ b/app/views/2017/articles/_list.html.erb
@@ -1,5 +1,7 @@
+<% skip_preferred_localization ||= skip_preferred_localization %>
+
 <div class="articles-list">
   <% articles.each do |article| %>
-    <%= render_themed "articles/list_item", article: article.preferred_localization %>
+    <%= render_themed "articles/list_item", article: skip_preferred_localization ? article : article.preferred_localization %>
   <% end %>
 </div>

--- a/app/views/2017/articles/_list_item.html.erb
+++ b/app/views/2017/articles/_list_item.html.erb
@@ -1,18 +1,18 @@
 <% if article.present? %>
   <article class="h-entry">
     <div class="row">
-      <div class="<%= "column" if article.image.present? %> column-one-third">
+      <div class="column column-one-third">
         <% if article.present? && article.image.present? %>
           <%= link_to image_tag(article.image, class: "u-photo header-image", alt: article.image_description), article.path %>
         <% end %>
       </div>
 
-      <div class="<%= "column" if article.image.present? %> column-two-third">
+      <div class="column column-two-third">
         <header>
-          <%= render_themed "articles/titles", header: article, linked: true %>
+          <%= render_themed "articles/titles",       header:  article, linked: true %>
           <%= render_themed "articles/published_on", article: article %>
-          <%= render_themed "articles/categories", article: article %>
-          <%= render_themed "articles/tags", article: article %>
+          <%= render_themed "articles/categories",   article: article %>
+          <%= render_themed "articles/tags",         article: article %>
         </header>
       </div>
     </div>

--- a/app/views/2017/languages/show.html.erb
+++ b/app/views/2017/languages/show.html.erb
@@ -24,7 +24,7 @@
 </header>
 
 <div class="h-feed">
-  <%= render_themed "articles/list", articles: @articles %>
+  <%= render_themed "articles/list", articles: @articles, skip_preferred_localization: true %>
 </div>
 
 <%= paginate @articles %>


### PR DESCRIPTION
[This PR](https://github.com/crimethinc/website/pull/1628) Just Worked™ in all places but one. That one is the exception. It should never be localized. Because it's on a language collection page.

https://github.com/crimethinc/website/pull/1628

https://github.com/crimethinc/website/commit/774fdddbf26f005e6f764115550ef4e406b5cb22#diff-8a12f2af3cd2315aff3cc6c928f6a46aR3

***

My solution was to explicitly skip it if that local is passed in.

```ruby
<% skip_preferred_localization ||= skip_preferred_localization %>
# ...
<%= render_themed "articles/list_item", 
                  article: skip_preferred_localization ? article : article.preferred_localization %>
```