### PR TITLE
[BUG] Force UTF-8 encoding for social meta tags

### DIFF
--- a/app/views/2017/shared/head/_social_media_meta_tags.html.erb
+++ b/app/views/2017/shared/head/_social_media_meta_tags.html.erb
@@ -8,7 +8,7 @@
 <meta name="twitter:site:id" content="14884161">
 <meta name="twitter:creator" content="@crimethinc">
 <meta name="twitter:creator:id" content="14884161">
-<meta name="twitter:url" content="<%= request.url %>" property="og:url">
+<meta name="twitter:url" content="<%= request.url.force_encoding('UTF-8') %>" property="og:url">
 <meta name="twitter:title" content="<%= meta_title find_the_thing %>" property="og:title">
 <meta name="twitter:description" content="<%= meta_description find_the_thing %>" property="og:description">
 <meta name="twitter:image" content="<%= meta_image find_the_thing %>" property="og:image">


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/13SYTDifJqy2Ck/giphy.gif)

# What are the relevant GitHub issues?

resolves bug

# What does this pull request do?

So, in the meta things were getting mucked up by using a url that include an `ñ`

I don't know why FB is appending this param. Maybe it is to generate a meta tag with a unique url..for tracking or something like that?

here's what it looked like:
```sh
[11] pry(#<#<Class:0x00007ff8826ce418>>)> request.url
=> "http://localhost:3000/2020/08/12/belarus-anarchists-in-the-uprising-against-the-dictatorship-an-interview?\xC3\xB1"
```

with the change it will render as:

```sh
12] pry(#<#<Class:0x00007ff8826ce418>>)> request.url.force_encoding('UTF-8')
=> "http://localhost:3000/2020/08/12/belarus-anarchists-in-the-uprising-against-the-dictatorship-an-interview?ñ"

```
# How should this be manually tested?

run this curl command:
```sh
curl --request GET   --header 'Accept: */*'   --header 'Accept-Encoding: deflate, gzip'   --header 'User-Agent: facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)'   --header 'Range: bytes=0-524287'   --header 'Connect-Time: 1'   --header 'X-Request-Start: 1597965732888'   --header 'Total-Route-Time: 0'   'https://crimethinc.com/2020/08/12/belarus-anarchists-in-the-uprising-against-the-dictatorship-an-interview?ñ'
```
- should get a `200`
- should see no error in the logs
