### PR TITLE
[BUG] Throw 404 on `podcast#show`

### DIFF
--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -12,7 +12,7 @@ class PodcastsController < ApplicationController
   def show
     @html_id = 'page'
     @body_id = 'podcast'
-    @podcast = Podcast.find_by(slug: params[:slug])
+    @podcast = Podcast.find_by! slug: params[:slug]
     @title   = PageTitle.new title_for @podcast.name
 
     render "#{Current.theme}/podcasts/show"


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/54u9PXmw1zU8U/giphy.gif)

# What are the relevant GitHub issues?

resolves a bug in the logs

# What does this pull request do?

We are getting a `NoMethodError` on `podcasts#show`

To prevemt this, I am just replacing `find_by` with `find_by!`

This will still error, but will provide the requester with a `404`,
rather than a misleading `500`
# How should this be manually tested?

- go to https://crimethinc.com/podcasts/the-e
- get a `404` (rather than a `500`)
