### PR TITLE
Add pagination to tools

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -37,7 +37,7 @@ class ToolsController < ApplicationController
   end
 
   def set_tools
-    @tools = tool_class.english.reorder(position: :asc).order(published_at: :desc).live.published
+    @tools = tool_class.english.reorder(position: :asc).order(published_at: :desc).live.published.page(params[:page]).per(10)
   end
 
   def tool_class

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -6,7 +6,6 @@ class ToolsController < ApplicationController
   before_action :set_type
 
   before_action :set_tool,           except: :about
-  before_action :set_featured_tools, except: :about
   before_action :set_tools,          except: :about
 
   before_action :set_title
@@ -37,16 +36,8 @@ class ToolsController < ApplicationController
     @body_id = 'tools'
   end
 
-  def tools
-    tool_class.order(published_at: :desc).live.published
-  end
-
-  def set_featured_tools
-    @featured_tools = tools.english.where.not(buy_url: nil).map { |tool| tool if tool.buy_url.present? }.compact
-  end
-
   def set_tools
-    @tools = tools.english.map { |tool| tool if tool.buy_url.blank? }.compact
+    @tools = tool_class.order(position: :desc).live.published
   end
 
   def tool_class

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -37,7 +37,7 @@ class ToolsController < ApplicationController
   end
 
   def set_tools
-    @tools = tool_class.english.reorder(position: :desc).order(published_at: :desc).live.published
+    @tools = tool_class.english.reorder(position: :asc).order(published_at: :desc).live.published
   end
 
   def tool_class

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -37,7 +37,7 @@ class ToolsController < ApplicationController
   end
 
   def set_tools
-    @tools = tool_class.english.reorder(position: :asc).order(published_at: :desc).live.published.page(params[:page]).per(10)
+    @tools = tool_class.english.reorder(position: :desc).order(published_at: :desc).live.published.page(params[:page]).per(10)
   end
 
   def tool_class

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -37,7 +37,7 @@ class ToolsController < ApplicationController
   end
 
   def set_tools
-    @tools = tool_class.english.reorder(position: :desc).order(published_at: :desc).live.published.page(params[:page]).per(10)
+    @tools = tool_class.english.reorder(position: :asc).order(published_at: :desc).live.published.page(params[:page]).per(10)
   end
 
   def tool_class

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -37,7 +37,7 @@ class ToolsController < ApplicationController
   end
 
   def set_tools
-    @tools = tool_class.reorder(position: :desc).order(published_at: :desc).live.published
+    @tools = tool_class.english.reorder(position: :desc).order(published_at: :desc).live.published
   end
 
   def tool_class

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -37,7 +37,7 @@ class ToolsController < ApplicationController
   end
 
   def set_tools
-    @tools = tool_class.order(position: :desc).live.published
+    @tools = tool_class.reorder(position: :desc).order(published_at: :desc).live.published
   end
 
   def tool_class

--- a/app/views/2017/tools/index.html.erb
+++ b/app/views/2017/tools/index.html.erb
@@ -15,3 +15,15 @@
     <hr style="margin-bottom: 5rem">
   <% end %>
 </article>
+
+<div class="pagination-container">
+  <ul class="pagination">
+    <li class="page">
+      <%= link_to_previous_page @tools, t("views.pagination.previous_page").html_safe %>
+    </li>
+
+    <li class="page">
+      <%= link_to_next_page @tools, t("views.pagination.next_page").html_safe %>
+    </li>
+  </ul>
+</div>

--- a/app/views/2017/tools/index.html.erb
+++ b/app/views/2017/tools/index.html.erb
@@ -9,10 +9,8 @@
     <%= render_markdown t("views.tools.#{@type}_intro_text") %>
   </div>
 
-  <% [@featured_tools, @tools].each do |collection| %>
-    <% collection.each do |tool| %>
-      <%= render_themed "tools/tool", tool: tool.preferred_localization %>
-    <% end %>
+  <% @tools.each do |tool| %>
+    <%= render_themed "tools/tool", tool: tool.preferred_localization %>
 
     <hr style="margin-bottom: 5rem">
   <% end %>

--- a/lib/tasks/data/update_position_on_tools.rake
+++ b/lib/tasks/data/update_position_on_tools.rake
@@ -2,18 +2,12 @@ namespace :data do
   desc 'Update position on tools'
   task :update_position_on_tools => :environment do |_, args|
     puts 'Updating zines position'
-    Zine.all.update_all(position: 10)
-    Zine.where(buy_url: nil).or(Zine.where(buy_url: "")).update_all(position: 0)
+    Zine.where.not(buy_url: [nil, ""]).update_all(position: 1)
 
     puts 'Updating posters position'
-    Poster.all.update_all(position: 10)
-    Poster.where(buy_url: nil).or(Poster.where(buy_url: "")).update_all(position: 0)
+    Poster.where.not(buy_url: [nil, ""]).update_all(position: 1)
 
     puts 'Updating stickers position'
-    Sticker.all.update_all(position: 10)
-    Sticker.where(buy_url: nil).or(Sticker.where(buy_url: "")).update_all(position: 0)
-
-    puts 'Updating logos position'
-    Logo.all.update_all(position: 0)
+    Sticker.where.not(buy_url: [nil, ""]).update_all(position: 1)
   end
 end

--- a/lib/tasks/data/update_position_on_tools.rake
+++ b/lib/tasks/data/update_position_on_tools.rake
@@ -1,13 +1,13 @@
 namespace :data do
   desc 'Update position on tools'
-  task :update_position_on_tools => :environment do |_, args|
+  task :update_position_on_tools do
     puts 'Updating zines position'
-    Zine.where.not(buy_url: [nil, ""]).update_all(position: 1)
+    Zine.where.not(buy_url: [nil, '']).update_all(position: 1)
 
     puts 'Updating posters position'
-    Poster.where.not(buy_url: [nil, ""]).update_all(position: 1)
+    Poster.where.not(buy_url: [nil, '']).update_all(position: 1)
 
     puts 'Updating stickers position'
-    Sticker.where.not(buy_url: [nil, ""]).update_all(position: 1)
+    Sticker.where.not(buy_url: [nil, '']).update_all(position: 1)
   end
 end

--- a/lib/tasks/data/update_position_on_tools.rake
+++ b/lib/tasks/data/update_position_on_tools.rake
@@ -1,0 +1,19 @@
+namespace :data do
+  desc 'Update position on tools'
+  task :update_position_on_tools => :environment do |_, args|
+    puts 'Updating zines position'
+    Zine.all.update_all(position: 10)
+    Zine.where(buy_url: nil).or(Zine.where(buy_url: "")).update_all(position: 0)
+
+    puts 'Updating posters position'
+    Poster.all.update_all(position: 10)
+    Poster.where(buy_url: nil).or(Poster.where(buy_url: "")).update_all(position: 0)
+
+    puts 'Updating stickers position'
+    Sticker.all.update_all(position: 10)
+    Sticker.where(buy_url: nil).or(Sticker.where(buy_url: "")).update_all(position: 0)
+
+    puts 'Updating logos position'
+    Logo.all.update_all(position: 0)
+  end
+end


### PR DESCRIPTION
This PR aim at adding pagination to the tools pages, but first we have some refactor to do before we can paginate our tools.

# What are the relevant GitHub issues?

resolves #1752 

# What does this pull request do?

This add pagination to tools pages

# How should this be manually tested?

The pagination work when you visit the different tools page.


# Questions for the pull request author (delete any that don't apply):
- [ ] Are any needed README/wiki/documentation updates needed for this pull request?
- [ ] Does the code you updated have tests? If not, could you add some please?
- [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.

# Acceptance Criteria
## These should be checked by the reviewers

The pagination is working on the tools pages

- [x] This pull request does not cause the database export script to become out of sync with the db schema
