### PR TITLE
Add `position` to all the tools edit forms (except journals)

### DIFF
--- a/app/views/admin/books/_form.html.erb
+++ b/app/views/admin/books/_form.html.erb
@@ -61,28 +61,7 @@
 
   <%= render "admin/books/categories_form", form: form %>
 
-  <div class="row">
-    <div class="col-6">
-      <%= render "admin/books/form/position", form: form, resource: resource %>
-      <p class="form-text text-muted">
-        This will set the order that this
-        <%= resource.namespace.singularize %>
-        shows up on
-        <%= link_to "crimethinc.com/#{resource.namespace}", resource.namespace %>.
-      </p>
-    </div>
-
-    <div class="col-6">
-      <%= form.check_box :hide_from_index %>
-      <%= form.label :has_index, "Hide this #{resource.namespace.singularize} from the index page?" %>
-      <p class="form-text text-muted">
-        This will prevent this
-        <%= resource.namespace.singularize %>
-        from showing up on
-        <%= link_to "crimethinc.com/#{resource.namespace}", resource.namespace %>.
-      </p>
-    </div>
-  </div>
+  <%= render "admin/shared/position", form: form, resource: resource %>
 
   <%= render "admin/books/downloads_form", form: form, resource: resource %>
 

--- a/app/views/admin/books/form/_position.html.erb
+++ b/app/views/admin/books/form/_position.html.erb
@@ -1,4 +1,0 @@
-<div id="position" class="form-group">
-  <%= form.label :position, "Position this #{resource.namespace.singularize} on the index page" %>
-  <%= form.number_field :position, step: 1, class: 'form-control' %>
-</div><!-- #position -->

--- a/app/views/admin/logos/_form.html.erb
+++ b/app/views/admin/logos/_form.html.erb
@@ -13,6 +13,8 @@
     </div>
   </div>
 
+  <%= render "admin/shared/position", form: form, resource: resource %>
+
   <fieldset>
     <legend>Uploads</legend>
     <div class="row">

--- a/app/views/admin/posters/_form.html.erb
+++ b/app/views/admin/posters/_form.html.erb
@@ -18,6 +18,8 @@
     </div>
   </div>
 
+  <%= render "admin/shared/position", form: form, resource: resource %>
+
   <div class="row my-5">
     <div class="col-12 col-sm-6">
       <%= render "admin/label_and_field_form_group", form: form, attr: :slug %>

--- a/app/views/admin/shared/_position.html.erb
+++ b/app/views/admin/shared/_position.html.erb
@@ -1,0 +1,24 @@
+<%# journals are a special case we aren't ready for yet %>
+<% return if resource.namespace == "journals" %>
+
+<% resource_name = resource.namespace.singularize %>
+<% resource_link = link_to "crimethinc.com/#{resource_name.pluralize}", "/#{resource_name.pluralize}", target: "_blank" %>
+
+<div class="row">
+  <div class="col-6">
+    <div id="position" class="form-group">
+      <%= form.label :position, "Position this #{resource_name} on the index page" %>
+      <%= form.number_field :position, step: 1, class: 'form-control' %>
+    </div>
+    <p class="form-text text-muted">This will set the order that
+      this <%= resource_name %> shows up on <%= resource_link %>.</p>
+  </div>
+
+  <div class="col-6">
+    <%= form.check_box :hide_from_index %>
+    <%= form.label :has_index, "Hide this #{resource_name} from the index page?" %><br>
+
+    <p class="form-text text-muted">This will prevent the <%= resource_name %> from
+      showing up on <%= resource_link %>.</p>
+  </div>
+</div>


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/WpIjh42KPontoNSF0J/giphy.gif)

# What are the relevant GitHub issues?

resolves #1753 

# What does this pull request do?

This, combined with @just1602's PR (#1756) will set up admin to be able to set `position` on the various tools `#edit` pages

# How should this be manually tested?

??

