### PR TITLE
Replace http image URL with https one

### DIFF
--- a/config/locales/steal_something_from_work_day/ar.yml
+++ b/config/locales/steal_something_from_work_day/ar.yml
@@ -115,8 +115,8 @@ ar:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/bn.yml
+++ b/config/locales/steal_something_from_work_day/bn.yml
@@ -115,8 +115,8 @@ bn:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/cs.yml
+++ b/config/locales/steal_something_from_work_day/cs.yml
@@ -115,8 +115,8 @@ cs:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/cz.yml
+++ b/config/locales/steal_something_from_work_day/cz.yml
@@ -115,8 +115,8 @@ cz:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/da.yml
+++ b/config/locales/steal_something_from_work_day/da.yml
@@ -115,8 +115,8 @@ da:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/de.yml
+++ b/config/locales/steal_something_from_work_day/de.yml
@@ -115,8 +115,8 @@ de:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/dv.yml
+++ b/config/locales/steal_something_from_work_day/dv.yml
@@ -115,8 +115,8 @@ dv:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/en.yml
+++ b/config/locales/steal_something_from_work_day/en.yml
@@ -115,8 +115,8 @@ en:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/es.yml
+++ b/config/locales/steal_something_from_work_day/es.yml
@@ -115,8 +115,8 @@ es:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/fa.yml
+++ b/config/locales/steal_something_from_work_day/fa.yml
@@ -115,8 +115,8 @@ fa:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/fi.yml
+++ b/config/locales/steal_something_from_work_day/fi.yml
@@ -115,8 +115,8 @@ fi:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/fr.yml
+++ b/config/locales/steal_something_from_work_day/fr.yml
@@ -115,8 +115,8 @@ fr:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/gr.yml
+++ b/config/locales/steal_something_from_work_day/gr.yml
@@ -115,8 +115,8 @@ gr:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/he.yml
+++ b/config/locales/steal_something_from_work_day/he.yml
@@ -115,8 +115,8 @@ he:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/id.yml
+++ b/config/locales/steal_something_from_work_day/id.yml
@@ -115,8 +115,8 @@ id:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/it.yml
+++ b/config/locales/steal_something_from_work_day/it.yml
@@ -115,8 +115,8 @@ it:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/ja.yml
+++ b/config/locales/steal_something_from_work_day/ja.yml
@@ -115,8 +115,8 @@ ja:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/ko.yml
+++ b/config/locales/steal_something_from_work_day/ko.yml
@@ -115,8 +115,8 @@ ko:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/nl.yml
+++ b/config/locales/steal_something_from_work_day/nl.yml
@@ -115,8 +115,8 @@ nl:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/pl.yml
+++ b/config/locales/steal_something_from_work_day/pl.yml
@@ -115,8 +115,8 @@ pl:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/pt.yml
+++ b/config/locales/steal_something_from_work_day/pt.yml
@@ -115,8 +115,8 @@ pt:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/ru.yml
+++ b/config/locales/steal_something_from_work_day/ru.yml
@@ -115,8 +115,8 @@ ru:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/sl.yml
+++ b/config/locales/steal_something_from_work_day/sl.yml
@@ -115,8 +115,8 @@ sl:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/sv.yml
+++ b/config/locales/steal_something_from_work_day/sv.yml
@@ -115,8 +115,8 @@ sv:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/th.yml
+++ b/config/locales/steal_something_from_work_day/th.yml
@@ -115,8 +115,8 @@ th:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/tr.yml
+++ b/config/locales/steal_something_from_work_day/tr.yml
@@ -115,8 +115,8 @@ tr:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden

--- a/config/locales/steal_something_from_work_day/zh.yml
+++ b/config/locales/steal_something_from_work_day/zh.yml
@@ -115,8 +115,8 @@ zh:
         -
           name: Germany
           description: "[BEKLAU-DEINEN-ARBEITSPLATZ-TAG](http://crimethinc.blogsport.de/2013/11/01/beklau-deinen-arbeitsplatz-tag/)"
-          preview_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
-          download_url: http://minijob.cc/wp-content/uploads/2013/04/steal-from-work-day.jpg
+          preview_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
+          download_url: https://cloudfront.crimethinc.com/assets/steal-something-from-work-day/images/de/steal-from-work-day-minijob-cc.jpg
 
         -
           name: Sweden


### PR DESCRIPTION
Fixes **"SSfWD is “not secure” (in Chrome), but only that page."**

![image](https://user-images.githubusercontent.com/4361/96565070-bd864180-1278-11eb-845f-f5709339d741.png)

By uploading the image from http only site to https S3.

![image](https://user-images.githubusercontent.com/4361/96565040-b5c69d00-1278-11eb-8e1d-18a89b9643d9.png)
