### PR TITLE
Convert .badge-* to .bg-* classes

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -110,6 +110,6 @@ module AdminHelper
   end
 
   def badge_color_class role:
-    { publisher: 'success', editor: 'warning', author: 'danger' }[role.to_sym]
+    { publisher: 'success text-white', editor: 'warning', author: 'danger text-white' }[role.to_sym]
   end
 end

--- a/app/helpers/redirects_helper.rb
+++ b/app/helpers/redirects_helper.rb
@@ -1,9 +1,9 @@
 module RedirectsHelper
   def redirect_http_status_code redirect
     if redirect.temporary?
-      tag.span 'TEMPORARY 302', class: 'badge badge-warning'
+      tag.span 'TEMPORARY 302', class: 'badge bg-warning'
     else
-      tag.span 'PERMANENT 301', class: 'badge badge-success'
+      tag.span 'PERMANENT 301', class: 'badge bg-success text-white'
     end
   end
 end

--- a/app/views/admin/articles/_children_articles_badge.html.erb
+++ b/app/views/admin/articles/_children_articles_badge.html.erb
@@ -1,5 +1,5 @@
 <% if article.collection_root? %>
-  <b class="badge badge-danger">
+  <b class="badge bg-danger text-white">
     <%= article.collection_posts.count %>
     NESTED
   </b>

--- a/app/views/admin/articles/_content_format_badge.html.erb
+++ b/app/views/admin/articles/_content_format_badge.html.erb
@@ -1,3 +1,3 @@
 <% if article.content_in_html? %>
-  <b class="badge badge-warning">HTML</b>
+  <b class="badge bg-warning">HTML</b>
 <% end %>

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -4,7 +4,7 @@
   <%= link_to_article_form_sections %>
 
   <%= link_to [:admin, :markdown], class: "btn btn-outline-primary mb-2 mr-2", target: "_blank", rel: "noopener" do %>
-    <span class="badge badge-secondary">MD</span>
+    <span class="badge bg-secondary text-white">MD</span>
     Markdown Cheatsheet ↗
   <% end %>
 </nav>

--- a/app/views/admin/articles/_publication_status_badge.html.erb
+++ b/app/views/admin/articles/_publication_status_badge.html.erb
@@ -1,3 +1,3 @@
-<b class="badge badge-<%= publication_status_badge_class resource %>">
+<b class="badge bg-<%= publication_status_badge_class resource %> text-white">
   <%= resource.publication_status.upcase %>
 </b>

--- a/app/views/admin/articles/draft.html.erb
+++ b/app/views/admin/articles/draft.html.erb
@@ -43,7 +43,7 @@
         <%= render "/admin/articles/publication_status_badge", resource: article %>
 
         <% if article.locale.present? %>
-          <%= link_to article.locale.upcase, [:admin, :locales], class: "badge badge-dark" %>
+          <%= link_to article.locale.upcase, [:admin, :locales], class: "badge bg-dark text-white" %>
         <% end %>
       </div>
 
@@ -54,7 +54,7 @@
         <% else %>
           <% if article.canonical_id.present? %>
             <% if article.canonical_record.locale.present? %>
-              <%= link_to article.canonical_record.locale.upcase, [:admin, :locales], class: "badge badge-secondary" %>
+              <%= link_to article.canonical_record.locale.upcase, [:admin, :locales], class: "badge bg-secondary text-white" %>
             <% end %>
             <span class="text-muted">English Article</span>
             <br>

--- a/app/views/admin/articles/form/_publication_status.html.erb
+++ b/app/views/admin/articles/form/_publication_status.html.erb
@@ -2,5 +2,5 @@
   <%= render 'admin/publication_status', form: form %>
 <% elsif @article.published? %>
   <b>Publication Status</b><br>
-  <span class='badge badge-success'>PUBLISHED</span>
+  <span class='badge bg-success text-white'>PUBLISHED</span>
 <% end %>

--- a/app/views/admin/articles/index.html.erb
+++ b/app/views/admin/articles/index.html.erb
@@ -74,7 +74,7 @@
         </div>
 
         <div class="col-10 mb-4">
-          <%= link_to article.locale.upcase, [:admin, :locales], class: "badge badge-secondary" %>
+          <%= link_to article.locale.upcase, [:admin, :locales], class: "badge bg-secondary text-white" %>
           <%= render "/admin/articles/publication_status_badge", resource: article %>
           <br>
 

--- a/app/views/admin/articles/show.html.erb
+++ b/app/views/admin/articles/show.html.erb
@@ -19,7 +19,7 @@
           <div class="card mb-3">
             <div class="card-header">
               <% if @article.canonical_record.locale.present? %>
-                <%= link_to @article.canonical_record.locale.upcase, [:admin, :locales], class: "badge badge-secondary" %>
+                <%= link_to @article.canonical_record.locale.upcase, [:admin, :locales], class: "badge bg-secondary text-white" %>
               <% end %>
 
               English Article
@@ -103,11 +103,11 @@
       <%= render "/admin/articles/publication_status_badge", resource: @article %>
 
       <% if @article.content_in_html? %>
-        <b class="badge badge-warning">HTML</b>
+        <b class="badge bg-warning">HTML</b>
       <% end %>
 
       <% if @article.locale.present? %>
-        <%= link_to @article.locale.upcase, [:admin, :locales], class: "badge badge-dark" %>
+        <%= link_to @article.locale.upcase, [:admin, :locales], class: "badge bg-dark text-white" %>
       <% end %>
     </p>
 
@@ -120,7 +120,7 @@
       Categories:<br>
       <% if @article.categories.present? %>
         <% @article.categories.each do |category| %>
-          <%= link_to category.name, category_path(category.slug), class: "badge badge-primary" %>
+          <%= link_to category.name, category_path(category.slug), class: "badge bg-primary text-white" %>
         <% end %>
       <% end %>
     </p>
@@ -129,7 +129,7 @@
       Tags:<br>
       <% if @article.tags.present? %>
         <% @article.tags.each do |tag| %>
-          <%= link_to tag.name, tag_path(tag.slug), class: "badge badge-info" %>
+          <%= link_to tag.name, tag_path(tag.slug), class: "badge bg-info text-white" %>
         <% end %>
       <% end %>
     </p>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,7 +2,7 @@
 
 <% @users.each do |user| %>
   <%= link_to [:edit, :admin, user], class: "btn btn-lg btn-light border-secondary mr-3 mb-3" do %>
-    <span class="mr-2 badge badge-<%= badge_color_class role: user.role %>"><%= user.role.upcase %></span>
+    <span class="mr-2 badge bg-<%= badge_color_class role: user.role %>"><%= user.role.upcase %></span>
     <%= user.username.upcase %>
   <% end %>
 <% end %>

--- a/spec/helpers/redirects_helper_spec.rb
+++ b/spec/helpers/redirects_helper_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RedirectsHelper, type: :helper do
 
       it { is_expected.to match('TEMPORARY') }
       it { is_expected.to match('302') }
-      it { is_expected.to match('badge-warning') }
+      it { is_expected.to match('bg-warning') }
     end
 
     context 'with permanent redirect' do
@@ -17,7 +17,7 @@ RSpec.describe RedirectsHelper, type: :helper do
 
       it { is_expected.to match('PERMANENT') }
       it { is_expected.to match('301') }
-      it { is_expected.to match('badge-success') }
+      it { is_expected.to match('bg-success') }
     end
   end
 end


### PR DESCRIPTION
Bootstrap 5 drops the `.badge-*`  classes, instead using `.bg-*` and optionally `.text-white` classes.

This PR is a part of the transition to Bootstrap 5.

***

https://v5.getbootstrap.com/docs/5.0/migration/#badges-1

> Badges were overhauled to better differentiate themselves from buttons and to better utilize utility classes.
> 
> - Removed and replaced `.badge` modifier classes with background utility classes (e.g., use `.bg-primary` instead of `.badge-primary`)
> - Removed `.badge-pill` for the `.rounded-pill` utility class
> - Removed badge’s hover and focus styles for `a.badge` and `button.badge`.
