### PR TITLE
[Bootstrap 5] Delete deprecated .form-control-file class

### DIFF
--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -30,7 +30,7 @@
           <b>ONLY .docx files will work!</b>
         </p>
 
-        <%= form.file_field :word_doc, class: "form-control-file" %>
+        <%= form.file_field :word_doc %>
       </div>
     </fieldset>
 

--- a/app/views/admin/logos/_form.html.erb
+++ b/app/views/admin/logos/_form.html.erb
@@ -22,7 +22,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_jpg, "JPEG Image" %>
-            <%= form.file_field :image_jpg, class: "form-control-file", accept: "image/jpeg", required: !resource.image_jpg.attached? %>
+            <%= form.file_field :image_jpg, accept: "image/jpeg", required: !resource.image_jpg.attached? %>
 
             <% if resource.image_jpg.attached? %>
               <p><%= image_tag url_for(image_variant_by_width(resource.image_jpg, @preview_width)), class: "mt-3 rounded d-block" %></p>
@@ -37,7 +37,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_png, "PNG Image" %>
-            <%= form.file_field :image_png, class: "form-control-file", accept: "image/png" %>
+            <%= form.file_field :image_png, accept: "image/png" %>
 
             <% if resource.image_png.attached? %>
               <p><%= image_tag url_for(image_variant_by_width(resource.image_png, @preview_width)), class: "mt-3 rounded d-block" %></p>
@@ -50,7 +50,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_tif, "TIFF Image" %>
-            <%= form.file_field :image_tif, class: "form-control-file", accept: "image/tiff", class: "mt-3 rounded d-block" %>
+            <%= form.file_field :image_tif, accept: "image/tiff", class: "mt-3 rounded d-block" %>
 
             <% if resource.image_tif.attached? %>
               <p><%= image_tag url_for(image_variant_by_width(resource.image_tif, @preview_width)), class: "mt-3 rounded d-block" %></p>
@@ -63,7 +63,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_pdf, "PDF Image" %>
-            <%= form.file_field :image_pdf, class: "form-control-file", accept: "application/pdf" %>
+            <%= form.file_field :image_pdf, accept: "application/pdf" %>
 
             <% if resource.image_pdf.attached? %>
               <p><%= image_tag resource.image_pdf.preview(resize_to_limit: [@preview_width, @preview_width]), class: "mt-3 rounded d-block" %></p>
@@ -76,7 +76,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_svg, "SVG Image" %>
-            <%= form.file_field :image_svg, class: "form-control-file", accept: "image/svg+xml", class: "mt-3 rounded d-block" %>
+            <%= form.file_field :image_svg, accept: "image/svg+xml", class: "mt-3 rounded d-block" %>
 
             <% if resource.image_svg.attached? %>
               <p><%= image_tag url_for(resource.image_svg), class: "mt-3 rounded d-block" %></p>

--- a/app/views/admin/posters/_attachments.html.erb
+++ b/app/views/admin/posters/_attachments.html.erb
@@ -21,7 +21,7 @@
                 <div class="card">
                   <div class="card-body">
                     <%= form.label attachement_form_attr_for(side, kind, color), "#{color.titleize} #{attachment_display_name_for(kind)}" %>
-                    <%= form.file_field attachement_form_attr_for(side, kind, color), class: "form-control-file", accept: acceptable_mime_types_for(kind) %>
+                    <%= form.file_field attachement_form_attr_for(side, kind, color), accept: acceptable_mime_types_for(kind) %>
 
                     <% if resource.send(attachement_form_attr_for(side, kind, color)).attached? %>
                       <% if kind == 'download' %>


### PR DESCRIPTION
> Dropped native `.form-control-file` and `.form-control-range` components entirely.

https://v5.getbootstrap.com/docs/5.0/migration/#forms-1