### PR TITLE
Add .form-label to all form labels (except labels on radios/checkboxes)

### DIFF
--- a/app/views/2017/search/advanced.html.erb
+++ b/app/views/2017/search/advanced.html.erb
@@ -2,27 +2,27 @@
 
 <%= form_with model: @advanced_search, local: true do |form| %>
   <fieldset>
-    <%= form.label :term, t("search.advanced.form.term_label") %>
+    <%= form.label :term, t("search.advanced.form.term_label"), class: "form-label" %>
     <%= form.text_field :term, class: "simple-field", autofocus: true %>
   </fieldset>
 
   <fieldset>
-    <%= form.label :title, t("search.advanced.form.title_label") %>
+    <%= form.label :title, t("search.advanced.form.title_label"), class: "form-label" %>
     <%= form.text_field :title, class: "simple-field" %>
   </fieldset>
 
   <fieldset>
-    <%= form.label :subtitle, t("search.advanced.form.subtitle_label") %>
+    <%= form.label :subtitle, t("search.advanced.form.subtitle_label"), class: "form-label" %>
     <%= form.text_field :subtitle, class: "simple-field" %>
   </fieldset>
 
   <fieldset>
-    <%= form.label :content, t("search.advanced.form.content_label") %>
+    <%= form.label :content, t("search.advanced.form.content_label"), class: "form-label" %>
     <%= form.text_field :content, class: "simple-field" %>
   </fieldset>
 
   <fieldset>
-    <%= form.label :tag, t("search.advanced.form.tag_label") %>
+    <%= form.label :tag, t("search.advanced.form.tag_label"), class: "form-label" %>
     <%= form.text_field :tag, class: "simple-field" %>
 
     <div class="form-text text-muted">
@@ -31,7 +31,7 @@
   </fieldset>
 
   <fieldset>
-    <%= form.label :category, t("search.advanced.form.category_label") %>
+    <%= form.label :category, t("search.advanced.form.category_label"), class: "form-label" %>
     <%= form.text_field :category, class: "simple-field" %>
 
     <div class="form-text text-muted">

--- a/app/views/2017/shared/footer/_newsletter.html.erb
+++ b/app/views/2017/shared/footer/_newsletter.html.erb
@@ -6,12 +6,12 @@
 
     <%= form_with url: "//crimethinc.us2.list-manage.com/subscribe/post?u=cb48383602b7373f496e9ba33&amp;id=344714b249", id: "mc-embedded-subscribe-form", class: "newsletter-signup-form validate", name: "mc-embedded-subscribe-form", target: "_blank", rel: "noopener", novalidate: true do |form| %>
         <div class="mc-field-group">
-          <%= form.label       "mce-EMAIL",                                         t("footer.contact.newsletter.signup_form_placeholder"), class: "screen-reader-only" %>
+          <%= form.label       "mce-EMAIL",                                         t("footer.contact.newsletter.signup_form_placeholder"), class: "screen-reader-only", class: "form-label" %>
           <%= form.email_field :email, name: "EMAIL", id: "mce-EMAIL", placeholder: t("footer.contact.newsletter.signup_form_placeholder"), class: "simple-field" %>
         </div>
 
         <div class="mc-field-group">
-          <%= form.label "mce-MMERGE3", t("footer.contact.newsletter.signup_form_select_placeholder"), class: "screen-reader-only" %>
+          <%= form.label "mce-MMERGE3", t("footer.contact.newsletter.signup_form_select_placeholder"), class: "screen-reader-only", class: "form-label" %>
 
           <select name="MMERGE3" class="required" id="mce-MMERGE3">
             <option value="<%= t("footer.contact.newsletter.signup_form_select_option_lot") %>"><%= t("footer.contact.newsletter.signup_form_select_option_lot") %></option>

--- a/app/views/2020/shared/_footer.html.erb
+++ b/app/views/2020/shared/_footer.html.erb
@@ -76,12 +76,12 @@
 
         <%= form_with url: '//crimethinc.us2.list-manage.com/subscribe/post?u=cb48383602b7373f496e9ba33&amp;id=344714b249', id: 'mc-embedded-subscribe-form', class: 'newsletter-signup-form validate', name: 'mc-embedded-subscribe-form', target: '_blank', rel: 'noopener', novalidate: true do |form| %>
           <div class='mc-field-group'>
-            <%= form.label       'mce-EMAIL',                                         t('footer.contact.newsletter.signup_form_placeholder'), class: 'screen-reader-only' %>
+            <%= form.label       'mce-EMAIL',                                         t('footer.contact.newsletter.signup_form_placeholder'), class: 'screen-reader-only', class: "form-label" %>
             <%= form.email_field :email, name: 'EMAIL', id: 'mce-EMAIL', placeholder: t('footer.contact.newsletter.signup_form_placeholder'), class: 'simple-field' %>
           </div>
 
           <div class='mc-field-group'>
-            <%= form.label 'mce-MMERGE3', t('footer.contact.newsletter.signup_form_select_placeholder'), class: 'screen-reader-only' %>
+            <%= form.label 'mce-MMERGE3', t('footer.contact.newsletter.signup_form_select_placeholder'), class: 'screen-reader-only', class: "form-label" %>
 
             <select name='MMERGE3' class='required' id='mce-MMERGE3'>
               <option value='<%= t('footer.contact.newsletter.signup_form_select_option_lot') %>'><%= t('footer.contact.newsletter.signup_form_select_option_lot') %></option>

--- a/app/views/admin/_datetime_group.html.erb
+++ b/app/views/admin/_datetime_group.html.erb
@@ -1,5 +1,5 @@
 <div class="form-group" id="publication_datetime">
-  <%= form.label :published_at, "Publication Date &amp; Time".html_safe %>
+  <%= form.label :published_at, "Publication Date &amp; Time".html_safe, class: "form-label" %>
 
   <div class="row">
     <div class="col-12">

--- a/app/views/admin/_label_and_area_form_group.html.erb
+++ b/app/views/admin/_label_and_area_form_group.html.erb
@@ -2,6 +2,6 @@
 <% rows       ||= nil %>
 
 <div class="form-group">
-  <%= form.label     attr, label_text %>
+  <%= form.label     attr, label_text, class: "form-label" %>
   <%= form.text_area attr, class: "form-control form-control-lg", rows: rows %>
 </div>

--- a/app/views/admin/_label_and_field_form_group.html.erb
+++ b/app/views/admin/_label_and_field_form_group.html.erb
@@ -1,6 +1,6 @@
 <% label_text ||= nil %>
 
 <div class="form-group">
-  <%= form.label      attr, label_text %>
+  <%= form.label      attr, label_text, class: "form-label", class: "form-label" %>
   <%= form.text_field attr, class: "form-control form-control-lg" %>
 </div>

--- a/app/views/admin/_publication_status.html.erb
+++ b/app/views/admin/_publication_status.html.erb
@@ -1,11 +1,11 @@
 <div id="publication-status" class="form-group">
-  <%= form.label :publication_status, "Publication Status" %><br>
+  <%= form.label :publication_status, "Publication Status", class: "form-label" %><br>
 
   <div class="toggle">
     <% Publishable.publication_statuses_for(user: Current.user).each do |state| %>
       <%= form.radio_button :publication_status, state, id: "publication_status_#{state}", class: "sr-only" %>
 
-      <%= form.label "publication_status_#{state}", state.capitalize, for: "publication_status_#{state}" %>
+      <%= form.label "publication_status_#{state}", state.capitalize, for: "publication_status_#{state}", class: "form-label" %>
     <% end %>
   </div><!-- .toggle -->
 </div><!-- #publication-status -->

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -23,7 +23,7 @@
 
     <fieldset class="card mb-3">
       <div class="card-body">
-        <%= form.label :word_doc, "Upload a Word Doc file", class: "card-title m-0" %>
+        <%= form.label :word_doc, "Upload a Word Doc file", class: "card-title m-0", class: "form-label" %>
 
         <p class="card-text form-text text-muted">
           An uploaded <code>.docx</code> file will get converted to Markdown and used in the <code>content</code> textarea, over-writing any content that is already there.

--- a/app/views/admin/articles/form/_featured_status.html.erb
+++ b/app/views/admin/articles/form/_featured_status.html.erb
@@ -1,9 +1,9 @@
 <div id="featured_status" class="form-group toggle sr-only">
-  <%= form.label :featured_status, "Feature this on homepage?" %><br>
+  <%= form.label :featured_status, "Feature this on homepage?", class: "form-label" %><br>
 
   <%= form.radio_button :featured_status, false, class: "sr-only" %>
-  <%= form.label :featured_status_false, 'Not featured', for: "#{klass}_featured_status_false" %>
+  <%= form.label :featured_status_false, 'Not featured', for: "#{klass}_featured_status_false", class: "form-label" %>
 
   <%= form.radio_button :featured_status, true, class: "sr-only" %>
-  <%= form.label :featured_status_true, 'Featured', for: "#{klass}_featured_status_true" %>
+  <%= form.label :featured_status_true, 'Featured', for: "#{klass}_featured_status_true", class: "form-label" %>
 </div><!-- #featured_status -->

--- a/app/views/admin/articles/form/_localization.html.erb
+++ b/app/views/admin/articles/form/_localization.html.erb
@@ -1,6 +1,6 @@
 <div id="localization">
   <div class="form-group">
-    <%= form.label :locale %>
+    <%= form.label :locale, class: "form-label" %>
     <%= form.collection_select :locale,
                                Locale.all,
                                :abbreviation,
@@ -15,7 +15,7 @@
   </div>
 
   <div class="form-group">
-    <%= form.label "English #{current_item_class}" %>
+    <%= form.label "English #{current_item_class}", class: "form-label" %>
 
     <%= form.collection_select :canonical_id,
                                current_item_class.english,

--- a/app/views/admin/articles/form/_syndication.html.erb
+++ b/app/views/admin/articles/form/_syndication.html.erb
@@ -3,7 +3,7 @@
     <legend>Syndication</legend>
 
     <div class="form-group">
-      <%= form.label :tweet %>
+      <%= form.label :tweet, class: "form-label" %>
       <%= form.text_area :tweet, class: "form-control form-control-lg", data: { 'max-length': '250', 'feedback-box': 'tweet-length' }, rows: 3 %>
       <div id="tweet-length">0</div>
       <p class="form-text text-muted">
@@ -13,7 +13,7 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :summary %>
+      <%= form.label :summary, class: "form-label" %>
       <%= form.text_area :summary, class: "form-control form-control-lg", data: { 'max-length': '150', 'feedback-box': 'summary-length' }, rows: 3 %>
       <div id="summary-length">0</div>
       <p class="form-text text-muted">

--- a/app/views/admin/articles/form/_tags.html.erb
+++ b/app/views/admin/articles/form/_tags.html.erb
@@ -1,5 +1,5 @@
 <div class="form-group mt-3">
-  <%= form.label :tags, "Tags" %>
+  <%= form.label :tags, "Tags", class: "form-label" %>
   <%= text_field_tag :tags, @article.tags.map(&:name).join(", "), class: "form-control form-control-lg" %>
   <p class="form-text text-muted">Comma separated. For example, <em>dogs, cats, etc</em>.</p>
 </div>

--- a/app/views/admin/books/_form.html.erb
+++ b/app/views/admin/books/_form.html.erb
@@ -5,7 +5,7 @@
     <div class="row">
       <div class="col-12 col-lg-8">
         <div class="form-group">
-          <%= form.label :journal_id %>
+          <%= form.label :journal_id, class: "form-label" %>
           <%= form.collection_select :journal_id,
                                      Journal.all,
                                      :id,
@@ -99,7 +99,7 @@
 
       <div class="col-12 col-sm-6">
         <div class="form-group">
-          <%= form.label :published_at %>
+          <%= form.label :published_at, class: "form-label" %>
           <%= form.date_select :published_at,
                                { start_year: Time.now.utc.year, end_year: 1995, include_blank: true },
                                class: "form-control form-control-lg" %>
@@ -137,7 +137,7 @@
 
         <div class="row">
           <div class="col-6">
-            <%= form.label :has_index, "Has Index?" %>
+            <%= form.label :has_index, "Has Index?", class: "form-label" %>
 
             <div class="form-check">
               <span class="d-inline-block mr-3">

--- a/app/views/admin/episodes/_form.html.erb
+++ b/app/views/admin/episodes/_form.html.erb
@@ -2,7 +2,7 @@
   <%= render "admin/form_errors", thing: @episode %>
 
   <div class="form-group">
-    <%= form.label :podcast_id %>
+    <%= form.label :podcast_id, class: "form-label" %>
 
     <% @podcasts.each do |podcast| %>
       <div class="form-check">

--- a/app/views/admin/locales/_form.html.erb
+++ b/app/views/admin/locales/_form.html.erb
@@ -8,7 +8,7 @@
 
     <div class="col-12 col-md-2">
       <div class="form-group">
-        <%= form.label :language_direction, "Direction" %>
+        <%= form.label :language_direction, "Direction", class: "form-label" %>
         <%= form.select :language_direction,
                         Locale.language_directions.keys,
                         {},

--- a/app/views/admin/logos/_form.html.erb
+++ b/app/views/admin/logos/_form.html.erb
@@ -21,7 +21,7 @@
       <div class="col-12 col-md-4 form-group">
         <div class="card">
           <div class="card-body">
-            <%= form.label :image_jpg, "JPEG Image" %>
+            <%= form.label :image_jpg, "JPEG Image", class: "form-label" %>
             <%= form.file_field :image_jpg, accept: "image/jpeg", required: !resource.image_jpg.attached? %>
 
             <% if resource.image_jpg.attached? %>
@@ -36,7 +36,7 @@
       <div class="col-12 col-md-4 form-group">
         <div class="card">
           <div class="card-body">
-            <%= form.label :image_png, "PNG Image" %>
+            <%= form.label :image_png, "PNG Image", class: "form-label" %>
             <%= form.file_field :image_png, accept: "image/png" %>
 
             <% if resource.image_png.attached? %>
@@ -49,7 +49,7 @@
       <div class="col-12 col-md-4 form-group">
         <div class="card">
           <div class="card-body">
-            <%= form.label :image_tif, "TIFF Image" %>
+            <%= form.label :image_tif, "TIFF Image", class: "form-label" %>
             <%= form.file_field :image_tif, accept: "image/tiff", class: "mt-3 rounded d-block" %>
 
             <% if resource.image_tif.attached? %>
@@ -62,7 +62,7 @@
       <div class="col-12 col-md-4 form-group">
         <div class="card">
           <div class="card-body">
-            <%= form.label :image_pdf, "PDF Image" %>
+            <%= form.label :image_pdf, "PDF Image", class: "form-label" %>
             <%= form.file_field :image_pdf, accept: "application/pdf" %>
 
             <% if resource.image_pdf.attached? %>
@@ -75,7 +75,7 @@
       <div class="col-12 col-md-4 form-group">
         <div class="card">
           <div class="card-body">
-            <%= form.label :image_svg, "SVG Image" %>
+            <%= form.label :image_svg, "SVG Image", class: "form-label" %>
             <%= form.file_field :image_svg, accept: "image/svg+xml", class: "mt-3 rounded d-block" %>
 
             <% if resource.image_svg.attached? %>
@@ -104,7 +104,7 @@
         <%= render "admin/books/categories_form", form: form %>
 
         <div class="form-group">
-          <%= form.label :published_at %>
+          <%= form.label :published_at, class: "form-label" %>
           <%= form.date_select :published_at,
                                { start_year: Time.now.utc.year, end_year: 1995, include_blank: true },
                                class: "form-control form-control-lg" %>

--- a/app/views/admin/pages/_form.html.erb
+++ b/app/views/admin/pages/_form.html.erb
@@ -22,7 +22,7 @@
       <fieldset id="meta">
         <legend>Meta</legend>
         <div class="form-group">
-          <%= form.label :tags %>
+          <%= form.label :tags, class: "form-label", class: "form-label" %>
           <%= text_area_tag :tags, @page.tags.map{ |t| t.name }.join(", "), class: "form-control form-control-lg" %>
           <p class="form-text text-muted">Comma separated. For example, <em>dogs, cats, etc</em>.</p>
         </div>

--- a/app/views/admin/posters/_attachments.html.erb
+++ b/app/views/admin/posters/_attachments.html.erb
@@ -20,7 +20,7 @@
               <div class="form-group">
                 <div class="card">
                   <div class="card-body">
-                    <%= form.label attachement_form_attr_for(side, kind, color), "#{color.titleize} #{attachment_display_name_for(kind)}" %>
+                    <%= form.label attachement_form_attr_for(side, kind, color), "#{color.titleize} #{attachment_display_name_for(kind)}", class: "form-label" %>
                     <%= form.file_field attachement_form_attr_for(side, kind, color), accept: acceptable_mime_types_for(kind) %>
 
                     <% if resource.send(attachement_form_attr_for(side, kind, color)).attached? %>

--- a/app/views/admin/posters/_form.html.erb
+++ b/app/views/admin/posters/_form.html.erb
@@ -83,7 +83,7 @@
         <%= render "admin/posters/categories_form", form: form %>
 
         <div class="form-group">
-          <%= form.label :published_at %>
+          <%= form.label :published_at, class: "form-label" %>
           <%= form.date_select :published_at,
                                { start_year: Time.now.utc.year, end_year: 1995, include_blank: true },
                                class: "form-control" %>

--- a/app/views/admin/redirects/_form.html.erb
+++ b/app/views/admin/redirects/_form.html.erb
@@ -17,7 +17,7 @@
 
   <div class="form-group">
     <%= form.check_box :temporary %>
-    <%= form.label :temporary %>
+    <%= form.label :temporary, class: "form-label" %>
 
     <p class="form-text text-muted">
       By default, all Redirects are saved as a permanent redirect,

--- a/app/views/admin/shared/_position.html.erb
+++ b/app/views/admin/shared/_position.html.erb
@@ -7,7 +7,7 @@
 <div class="row">
   <div class="col-6">
     <div id="position" class="form-group">
-      <%= form.label :position, "Position this #{resource_name} on the index page" %>
+      <%= form.label :position, "Position this #{resource_name} on the index page", class: "form-label" %>
       <%= form.number_field :position, step: 1, min: 0, class: 'form-control' %>
     </div>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,7 +3,7 @@
 
   <%= form_with url: [:sessions], local: true do |form| %>
     <div class="form-group">
-      <%= form.label :username, t("auth.username_label"), class: "sr-only" %>
+      <%= form.label :username, t("auth.username_label"), class: "sr-only form-label" %>
       <%= form.text_field :username, autofocus: true, class: "form-control form-control-lg", placeholder: t("auth.username_label") %>
 
       <div class="form-text text-muted">
@@ -12,7 +12,7 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :password, t("auth.password_label"), class: "sr-only" %>
+      <%= form.label :password, t("auth.password_label"), class: "sr-only form-label" %>
       <%= form.password_field :password, class: "form-control form-control-lg", placeholder: t("auth.password_label") %>
 
       <div class="form-text text-muted">


### PR DESCRIPTION
> Form labels now require the `.form-label` class. Sass variables are now available to style form labels to your needs. [See #30476](https://github.com/twbs/bootstrap/pull/30476)

https://v5.getbootstrap.com/docs/5.0/migration/#forms-1