### PR TITLE
[Bootstrap 5] Add .visually-hidden, to replace .sr-only

### DIFF
--- a/app/assets/stylesheets/2017/views/support.scss
+++ b/app/assets/stylesheets/2017/views/support.scss
@@ -238,6 +238,7 @@ label[for=amount], label[for=amount_slider]  {
   color: #000;
 }
 
+.visually-hidden,
 .sr-only {
   position: absolute;
   width: 1px;

--- a/app/assets/stylesheets/views/support.scss
+++ b/app/assets/stylesheets/views/support.scss
@@ -238,6 +238,7 @@ label[for=amount], label[for=amount_slider]  {
   color: #000;
 }
 
+.visually-hidden,
 .sr-only {
   position: absolute;
   width: 1px;

--- a/app/views/2017/articles/_titles.html.erb
+++ b/app/views/2017/articles/_titles.html.erb
@@ -6,7 +6,7 @@
     </h1>
 
     <% if header.subtitle.present? %>
-      <span class="screen-reader-only sr-only"> : </span>
+      <span class="screen-reader-only visually-hidden sr-only"> : </span>
 
       <h2 class="p-x-subtitle">
         <%= RubyPants.new(header.subtitle).to_html.html_safe %>

--- a/app/views/2017/shared/head/_lite_mode_css.html.erb
+++ b/app/views/2017/shared/head/_lite_mode_css.html.erb
@@ -125,6 +125,7 @@
     padding-left: 15px;
   }
 
+  .visually-hidden,
   .sr-only {
     position: absolute;
     width: 1px;

--- a/app/views/2017/support/new.html.erb
+++ b/app/views/2017/support/new.html.erb
@@ -48,7 +48,7 @@
       <p><%= t('views.support.new.support_request.description') %></p>
 
       <%= form_tag [:support, :request] do %>
-        <%= label_tag :email, t('views.support.new.support_request.email_label'), class: "sr-only" %>
+        <%= label_tag :email, t('views.support.new.support_request.email_label'), class: "visually-hidden sr-only" %>
         <%= email_field_tag :email, nil, placeholder: t('views.support.new.support_request.email_placeholder') %>
         <%= submit_tag t('views.support.new.support_request.button_text') %>
       <% end %>

--- a/app/views/admin/_publication_status.html.erb
+++ b/app/views/admin/_publication_status.html.erb
@@ -20,7 +20,7 @@
 
     <div class="toggle">
       <% Publishable.publication_statuses_for(user: Current.user).each do |state| %>
-        <%= form.radio_button :publication_status, state, id: "publication_status_#{state}", class: "sr-only" %>
+        <%= form.radio_button :publication_status, state, id: "publication_status_#{state}", class: "visually-hidden sr-only" %>
 
         <%= form.label "publication_status_#{state}", state.capitalize, for: "publication_status_#{state}", class: "form-label" %>
       <% end %>

--- a/app/views/admin/articles/form/_featured_status.html.erb
+++ b/app/views/admin/articles/form/_featured_status.html.erb
@@ -1,6 +1,6 @@
 <% if FeatureFlag.enabled? :bootstrap5 %>
 
-  <div id="featured_status" class="form-group sr-only">
+  <div id="featured_status" class="form-group visually-hidden sr-only">
     <%= form.label :featured_status, "Feature this on homepage?", class: "form-label" %><br>
 
     <%= form.radio_button :featured_status, false, class: "btn-check" %>
@@ -12,13 +12,13 @@
 
 <% else %>
 
-  <div id="featured_status" class="form-group toggle sr-only">
+  <div id="featured_status" class="form-group toggle visually-hidden sr-only">
     <%= form.label :featured_status, "Feature this on homepage?", class: "form-label" %><br>
 
-    <%= form.radio_button :featured_status, false, class: "sr-only" %>
+    <%= form.radio_button :featured_status, false, class: "visually-hidden sr-only" %>
     <%= form.label :featured_status_false, 'Not featured', for: "#{klass}_featured_status_false", class: "form-label" %>
 
-    <%= form.radio_button :featured_status, true, class: "sr-only" %>
+    <%= form.radio_button :featured_status, true, class: "visually-hidden sr-only" %>
     <%= form.label :featured_status_true, 'Featured', for: "#{klass}_featured_status_true", class: "form-label" %>
   </div><!-- #featured_status -->
 

--- a/app/views/admin/kaminari/twitter-bootstrap-4/_next_page.html.erb
+++ b/app/views/admin/kaminari/twitter-bootstrap-4/_next_page.html.erb
@@ -10,7 +10,7 @@
 
     <%= link_to url, rel: "next", class: "page-link" do %>
       <span aria-hidden="true"><%= t("views.pagination.next").html_safe %></span>
-      <span class="sr-only"><%= t("views.pagination.next_screen_reader").html_safe %></span>
+      <span class="visually-hidden sr-only"><%= t("views.pagination.next_screen_reader").html_safe %></span>
     <% end %>
 
   <% end %>

--- a/app/views/admin/kaminari/twitter-bootstrap-4/_prev_page.html.erb
+++ b/app/views/admin/kaminari/twitter-bootstrap-4/_prev_page.html.erb
@@ -10,7 +10,7 @@
 
     <%= link_to url, rel: "prev", class: "page-link" do %>
       <span aria-hidden="true"><%= t("views.pagination.previous").html_safe %></span>
-      <span class="sr-only"><%= t("views.pagination.previous_screen_reader").html_safe %></span>
+      <span class="visually-hidden sr-only"><%= t("views.pagination.previous_screen_reader").html_safe %></span>
     <% end %>
 
   <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -3,7 +3,7 @@
 
   <%= form_with url: [:sessions], local: true do |form| %>
     <div class="form-group">
-      <%= form.label :username, t("auth.username_label"), class: "sr-only form-label" %>
+      <%= form.label :username, t("auth.username_label"), class: "visually-hidden sr-only form-label" %>
       <%= form.text_field :username, autofocus: true, class: "form-control form-control-lg", placeholder: t("auth.username_label") %>
 
       <div class="form-text text-muted">
@@ -12,7 +12,7 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :password, t("auth.password_label"), class: "sr-only form-label" %>
+      <%= form.label :password, t("auth.password_label"), class: "visually-hidden sr-only form-label" %>
       <%= form.password_field :password, class: "form-control form-control-lg", placeholder: t("auth.password_label") %>
 
       <div class="form-text text-muted">

--- a/app/views/shared/head/_lite_mode_css.html.erb
+++ b/app/views/shared/head/_lite_mode_css.html.erb
@@ -125,6 +125,7 @@
     padding-left: 15px;
   }
 
+  .visually-hidden,
   .sr-only {
     position: absolute;
     width: 1px;

--- a/app/views/steal_something_from_work_day/head/_lite_mode_css.html.erb
+++ b/app/views/steal_something_from_work_day/head/_lite_mode_css.html.erb
@@ -125,6 +125,7 @@
     padding-left: 15px;
   }
 
+  .visually-hidden,
   .sr-only {
     position: absolute;
     width: 1px;


### PR DESCRIPTION
https://v5.getbootstrap.com/docs/5.0/migration/#helpers

> - “Screen reader” classes are now [“visually hidden” classes](https://v5.getbootstrap.com/docs/5.0/helpers/visually-hidden/).
>   - Changed the Sass file from `scss/helpers/_screenreaders.scss` to `scss/helpers/_visually-hidden.scss`
>   - Renamed `.sr-only` and `.sr-only-focusable` to `.visually-hidden` and `.visually-hidden-focusable`
>   - Renamed `sr-only()` and `sr-only-focusable()` mixins to `visually-hidden()` and `visually-hidden-focusable()`.

