### PR TITLE
Add example form text to date/time form fields

### DIFF
--- a/app/assets/stylesheets/admin/_forms.scss
+++ b/app/assets/stylesheets/admin/_forms.scss
@@ -3,7 +3,11 @@ input[type=checkbox] {
 }
 
 .datetime-select {
-  margin-bottom: 1rem;
+  // TODO: Re-enable when Safari supports date/time pickers
+  //       and we drop the form text examples:
+  //       <p class="form-text text-muted">Example: 23:59</p>
+  //       <p class="form-text text-muted">Example: 1999-11-30</p>
+  // margin-bottom: 1rem;
 }
 
 .actions {

--- a/app/views/admin/_datetime_group.html.erb
+++ b/app/views/admin/_datetime_group.html.erb
@@ -4,21 +4,24 @@
   <div class="row">
     <div class="col-12">
       <input id="publication_date"
+             placeholder="YYYY-MM-DD"
              type="date"
              name="published_at_date"
              value="<%= admin_form_date(post) %>"
              class="form-control form-control-lg datetime-select">
+      <p class="form-text text-muted">Example: 1999-11-30</p>
     </div>
   </div>
 
   <div class="row">
     <div class="col-12">
       <input id="publication_time"
-             placeholder="hh:mm"
+             placeholder="HH:MM"
              type="time"
              name="published_at_time"
              value="<%= admin_form_time(post) %>"
              class="form-control form-control-lg datetime-select timepicker">
+      <p class="form-text text-muted">Example: 23:59</p>
     </div>
   </div>
 


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![I like turtles](https://media.giphy.com/media/3xz2BuuYbARSNcBBsI/giphy.gif)

# What are the relevant GitHub issues?

Related to #1864 

# What does this pull request do?

Adds a bit of example text to the date / time picker fields so that when a user's browser doesn't support them natively (current desktop Safari), they can still type in a date and time in the formats shown.

### In Chrome:

<img width="350" alt="Screen Shot 2020-11-12 at 10 57 43 PM" src="https://user-images.githubusercontent.com/4361/99038958-4c664100-253b-11eb-896d-2b099683ddd3.png">

### In Safari (or older versions of other browsers:

<img width="346" alt="Screen Shot 2020-11-12 at 10 57 31 PM" src="https://user-images.githubusercontent.com/4361/99038987-5be58a00-253b-11eb-9408-1dd07c0cce11.png">



# How should this be manually tested?

Look at an /admin form that has date / time fields, like `/admin/articles/new`.

# Is there any background context you want to provide for reviewers?

This will obviate the need for the date/time polypill and jQuery UI time picker.
That is our last usage of jQuery in admin land, so we can remove it and version bump Bootstrap to 5 alpha2 (in a separate PR).
