### PR TITLE
Version bump Bootstrap to 5.0.0.alpha2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma'
 
 # assets
 gem 'autoprefixer-rails'
-gem 'bootstrap'
+gem 'bootstrap', '5.0.0.alpha2'
 gem 'jquery-rails'      # for bootstrap pages (admin, steal-something-from-work-day)
 gem 'sassc-rails'
 gem 'sitemap_generator' # for generating a compliant xml sitemap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       nokogiri (~> 1.6, >= 1.6.8)
     bcrypt (3.1.16)
     bindex (0.8.1)
-    bootstrap (4.5.3)
+    bootstrap (5.0.0.alpha2)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
@@ -124,7 +124,7 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    erubi (1.9.0)
+    erubi (1.10.0)
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -483,7 +483,7 @@ DEPENDENCIES
   aws-sdk-s3
   azure-storage
   bcrypt
-  bootstrap
+  bootstrap (= 5.0.0.alpha2)
   bugsnag
   byebug
   capybara

--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -21,6 +21,6 @@ function updateCounter(e) {
 }
 
 ready(() => {
-  // Add the callback needed to update the text area character counters (e.g. for tweets)
+  // Add the callback needed to update the textarea character counters (e.g. for tweets)
   document.querySelectorAll("textarea[data-max-length]").forEach(textArea => { textArea.addEventListener("keyup", updateCounter) });
 });

--- a/app/assets/javascripts/steal-something-from-work-day.js
+++ b/app/assets/javascripts/steal-something-from-work-day.js
@@ -1,3 +1,2 @@
-//= require jquery3
 //= require popper
 //= require bootstrap


### PR DESCRIPTION
Currently, Bootstrap (4.5.x) is only used in `/admin` (and `/steal-something-from-work-day`). 
So this won't affect the public site (until the redesign theme is finished and rolled out).

- Remove remnants of jQuery in `/admin`
- Version bump Bootstrap to 5.0.0.alpha2
- ~Remove date/time pickers polyfill~ done