### PR TITLE
Migrate Bootstrap to 5.0.0.alpha3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma'
 
 # assets
 gem 'autoprefixer-rails'
-gem 'bootstrap', '5.0.0.alpha2'
+gem 'bootstrap', '5.0.0.alpha3'
 gem 'jquery-rails'      # for bootstrap pages (admin, steal-something-from-work-day)
 gem 'sassc-rails'
 gem 'sitemap_generator' # for generating a compliant xml sitemap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       nokogiri (~> 1.6, >= 1.6.8)
     bcrypt (3.1.16)
     bindex (0.8.1)
-    bootstrap (5.0.0.alpha2)
+    bootstrap (5.0.0.alpha3)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
@@ -247,7 +247,7 @@ GEM
       railties (>= 4)
       request_store (~> 1.0)
     logstash-event (1.2.02)
-    loofah (2.7.0)
+    loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.2.4)
@@ -483,7 +483,7 @@ DEPENDENCIES
   aws-sdk-s3
   azure-storage
   bcrypt
-  bootstrap (= 5.0.0.alpha2)
+  bootstrap (= 5.0.0.alpha3)
   bugsnag
   byebug
   capybara

--- a/app/assets/stylesheets/admin/_articles.scss
+++ b/app/assets/stylesheets/admin/_articles.scss
@@ -21,18 +21,3 @@ label  {
 // Border on this article (2017-08-23) indicates when the view counter started.
 // Everything below it was published pre-counter.
 .article-counter-genesis { border-bottom: 10px solid #666; }
-
-// TODO: Delete after upgrade to Bootstrap 5
-.toggle {
-  // Treat radio buttons as toggle buttons
-  input + label {
-    @extend .btn;
-    @extend .btn-sm;
-    @extend .btn-outline-secondary;
-  }
-
-  input:checked + label {
-    @extend .btn;
-    @extend .btn-primary;
-  }
-}

--- a/app/assets/stylesheets/admin/_forms.scss
+++ b/app/assets/stylesheets/admin/_forms.scss
@@ -12,8 +12,3 @@ input[type=checkbox] {
 .table img {
   max-height: 100px;
 }
-
-// TODO: Transitional for Bootstrap 5
-.form-group {
-  @extend .mb-3;
-}

--- a/app/assets/stylesheets/admin/_forms.scss
+++ b/app/assets/stylesheets/admin/_forms.scss
@@ -13,12 +13,6 @@ input[type=checkbox] {
   border-bottom: $border-size-xsmall solid #eee;
 }
 
-// Upload button
-input[type="file"]::-webkit-file-upload-button {
-  @extend .btn;
-  @extend .btn-outline-primary;
-}
-
 .table img {
   max-height: 100px;
 }

--- a/app/assets/stylesheets/admin/_forms.scss
+++ b/app/assets/stylesheets/admin/_forms.scss
@@ -13,6 +13,7 @@ input[type=checkbox] {
   max-height: 100px;
 }
 
+// TODO: Transitional for Bootstrap 5
 .form-group {
   @extend .mb-3;
 }

--- a/app/assets/stylesheets/admin/_forms.scss
+++ b/app/assets/stylesheets/admin/_forms.scss
@@ -2,11 +2,6 @@ input[type=checkbox] {
   margin-right: .5rem;
 }
 
-// TODO: Transitional for Bootstrap 5
-.datetime-select {
-  margin-bottom: 1rem;
-}
-
 .actions {
   text-align: right;
   margin: 2em 0 3em 0;

--- a/app/assets/stylesheets/admin/_forms.scss
+++ b/app/assets/stylesheets/admin/_forms.scss
@@ -2,6 +2,7 @@ input[type=checkbox] {
   margin-right: .5rem;
 }
 
+// TODO: Transitional for Bootstrap 5
 .datetime-select {
   margin-bottom: 1rem;
 }
@@ -17,7 +18,6 @@ input[type=checkbox] {
   max-height: 100px;
 }
 
-// TODO: Transitional for Bootstrap 5
 .form-group {
   @extend .mb-3;
 }

--- a/app/views/admin/_datetime_group.html.erb
+++ b/app/views/admin/_datetime_group.html.erb
@@ -8,7 +8,7 @@
              type="date"
              name="published_at_date"
              value="<%= admin_form_date(post) %>"
-             class="form-control form-control-lg datetime-select">
+             class="form-select form-select-lg">
       <p class="form-text text-muted">Example: 1999-11-30</p>
     </div>
   </div>
@@ -20,7 +20,7 @@
              type="time"
              name="published_at_time"
              value="<%= admin_form_time(post) %>"
-             class="form-control form-control-lg datetime-select">
+             class="form-select form-select-lg">
       <p class="form-text text-muted">Example: 23:59</p>
     </div>
   </div>
@@ -31,7 +31,7 @@
                            :published_at_tz,
                            [ActiveSupport::TimeZone['Pacific Time (US & Canada)'], ActiveSupport::TimeZone['Eastern Time (US & Canada)']],
                            {},
-                           class: "datetime-select form-select form-select-lg todo-forward-delete-after-bootstrap-5-upgrade form-control form-control-lg" %>
+                           class: "datetime-select form-select form-select-lg" %>
     </div>
   </div>
 </div>

--- a/app/views/admin/_datetime_group.html.erb
+++ b/app/views/admin/_datetime_group.html.erb
@@ -31,7 +31,7 @@
                            :published_at_tz,
                            [ActiveSupport::TimeZone['Pacific Time (US & Canada)'], ActiveSupport::TimeZone['Eastern Time (US & Canada)']],
                            {},
-                           class: "datetime-select form-select form-select-lg" %>
+                           class: "form-select form-select-lg mb-2" %>
     </div>
   </div>
 </div>

--- a/app/views/admin/_datetime_group.html.erb
+++ b/app/views/admin/_datetime_group.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group" id="publication_datetime">
+<div class="mb-3" id="publication_datetime">
   <%= form.label :published_at, "Publication Date &amp; Time".html_safe, class: "form-label" %>
 
   <div class="row">

--- a/app/views/admin/_form_actions.html.erb
+++ b/app/views/admin/_form_actions.html.erb
@@ -3,5 +3,5 @@
 
 <div class="actions">
   <%= link_to "Cancel", cancel_url, class: "cancel action-cancel" %>
-  <%= button_tag button_text, class: "btn btn-primary btn-lg action-submit" %>
+  <%= button_tag button_text, class: "btn btn-primary btn-lg" %>
 </div>

--- a/app/views/admin/_label_and_area_form_group.html.erb
+++ b/app/views/admin/_label_and_area_form_group.html.erb
@@ -1,7 +1,7 @@
 <% label_text ||= nil %>
 <% rows       ||= nil %>
 
-<div class="form-group">
+<div class="mb-3">
   <%= form.label     attr, label_text, class: "form-label" %>
   <%= form.text_area attr, class: "form-control form-control-lg", rows: rows %>
 </div>

--- a/app/views/admin/_label_and_field_form_group.html.erb
+++ b/app/views/admin/_label_and_field_form_group.html.erb
@@ -1,6 +1,6 @@
 <% label_text ||= nil %>
 
-<div class="form-group">
+<div class="mb-3">
   <%= form.label      attr, label_text, class: "form-label", class: "form-label" %>
   <%= form.text_field attr, class: "form-control form-control-lg" %>
 </div>

--- a/app/views/admin/_publication_status.html.erb
+++ b/app/views/admin/_publication_status.html.erb
@@ -1,4 +1,4 @@
-<div id="publication-status" class="form-group">
+<div id="publication-status" class="mb-3">
   <%= form.label :publication_status, "Publication Status", class: "form-label" %><br>
 
   <% Publishable.publication_statuses_for(user: Current.user).each do |state| %>

--- a/app/views/admin/_publication_status.html.erb
+++ b/app/views/admin/_publication_status.html.erb
@@ -1,30 +1,12 @@
-<% if FeatureFlag.enabled? :bootstrap5 %>
+<div id="publication-status" class="form-group">
+  <%= form.label :publication_status, "Publication Status", class: "form-label" %><br>
 
-  <div id="publication-status" class="form-group">
-    <%= form.label :publication_status, "Publication Status", class: "form-label" %><br>
+  <% Publishable.publication_statuses_for(user: Current.user).each do |state| %>
+    <%= form.radio_button :publication_status, state, id: "publication_status_#{state}", class: "btn-check" %>
 
-    <% Publishable.publication_statuses_for(user: Current.user).each do |state| %>
-      <%= form.radio_button :publication_status, state, id: "publication_status_#{state}", class: "btn-check" %>
-
-      <%= form.label "publication_status_#{state}",
-                     state.capitalize,
-                     for: "publication_status_#{state}",
-                     class: "btn btn-outline-#{state == :draft ? :secondary : 'primary'}" %>
-    <% end %>
-  </div><!-- #publication-status -->
-
-<% else %>
-
-  <div id="publication-status" class="form-group">
-    <%= form.label :publication_status, "Publication Status", class: "form-label" %><br>
-
-    <div class="toggle">
-      <% Publishable.publication_statuses_for(user: Current.user).each do |state| %>
-        <%= form.radio_button :publication_status, state, id: "publication_status_#{state}", class: "visually-hidden sr-only" %>
-
-        <%= form.label "publication_status_#{state}", state.capitalize, for: "publication_status_#{state}", class: "form-label" %>
-      <% end %>
-    </div><!-- .toggle -->
-  </div><!-- #publication-status -->
-
-<% end %>
+    <%= form.label "publication_status_#{state}",
+                   state.capitalize,
+                   for: "publication_status_#{state}",
+                   class: "btn btn-outline-#{state == :draft ? :secondary : 'primary'}" %>
+  <% end %>
+</div><!-- #publication-status -->

--- a/app/views/admin/articles/_article.html.erb
+++ b/app/views/admin/articles/_article.html.erb
@@ -32,10 +32,10 @@
       <div class="row">
 
         <div class="col-12 col-md-10">
-          <h2 class="h5 mb-0 font-weight-bold"><%= link_to article.title, [:admin, article] %></h2>
+          <h2 class="h5 mb-0 fw-bold"><%= link_to article.title, [:admin, article] %></h2>
 
           <% if article.subtitle.present? %>
-            <h3 class="h6 mb-1 font-weight-light"><%= link_to article.subtitle, [:admin, article] %></h3>
+            <h3 class="h6 mb-1 fw-light"><%= link_to article.subtitle, [:admin, article] %></h3>
           <% end %>
 
           <%= time_tag article.published_at do %>

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -30,7 +30,7 @@
           <b>ONLY .docx files will work!</b>
         </p>
 
-        <%= form.file_field :word_doc %>
+        <%= form.file_field :word_doc, class: "form-control" %>
       </div>
     </fieldset>
 

--- a/app/views/admin/articles/draft.html.erb
+++ b/app/views/admin/articles/draft.html.erb
@@ -1,7 +1,7 @@
 <h2 class="mb-3">
   <%= link_to "NEW", [:new, :admin, :article], class: 'btn btn-outline-primary mb-2' %>
 
-  <span class='font-weight-light'><%= link_to_unless_current "Articles", [:admin, :articles] %></span>
+  <span class='fw-light'><%= link_to_unless_current "Articles", [:admin, :articles] %></span>
   <span class="text-muted">:</span>
   <b><%= link_to_unless_current "Draft", [:draft, :admin, :articles] %></b>
 

--- a/app/views/admin/articles/draft.html.erb
+++ b/app/views/admin/articles/draft.html.erb
@@ -20,12 +20,14 @@
   <% @articles.each do |article| %>
     <div class="articles-body row mb-3 py-0 <%= admin_articles_table_row_classes article %>">
       <div class="col-md-1 d-md-none my-3">
-        <%= link_to "Edit", [:edit, :admin, article], class: "btn btn-block btn-outline-primary" %>
+        <%= link_to "Edit", [:edit, :admin, article], class: "btn btn-outline-primary" %>
       </div>
 
       <div class="col-md-1 d-none d-md-block">
         <br>
+        <div class="d-grid gap-2">
         <%= link_to "Edit", [:edit, :admin, article], class: "btn btn-outline-primary" %>
+        </div>
       </div>
 
       <div class="col-md-6 pb-3">

--- a/app/views/admin/articles/form/_categories.html.erb
+++ b/app/views/admin/articles/form/_categories.html.erb
@@ -2,7 +2,7 @@
   <% unless @collection.present? %>
 
     <fieldset id="categories">
-      <p class="m-0 font-weight-bold">Categories</p>
+      <p class="m-0 fw-bold">Categories</p>
 
       <div class="form-check">
         <% @categories&.each do |category| %>

--- a/app/views/admin/articles/form/_featured_status.html.erb
+++ b/app/views/admin/articles/form/_featured_status.html.erb
@@ -1,4 +1,4 @@
-<div id="featured_status" class="form-group visually-hidden sr-only">
+<div id="featured_status" class="mb-3 visually-hidden sr-only">
   <%= form.label :featured_status, "Feature this on homepage?", class: "form-label" %><br>
 
   <%= form.radio_button :featured_status, false, class: "btn-check" %>

--- a/app/views/admin/articles/form/_featured_status.html.erb
+++ b/app/views/admin/articles/form/_featured_status.html.erb
@@ -1,25 +1,9 @@
-<% if FeatureFlag.enabled? :bootstrap5 %>
+<div id="featured_status" class="form-group visually-hidden sr-only">
+  <%= form.label :featured_status, "Feature this on homepage?", class: "form-label" %><br>
 
-  <div id="featured_status" class="form-group visually-hidden sr-only">
-    <%= form.label :featured_status, "Feature this on homepage?", class: "form-label" %><br>
+  <%= form.radio_button :featured_status, false, class: "btn-check" %>
+  <%= form.label :featured_status_false, 'Not featured', for: "#{klass}_featured_status_false", class: "btn btn-outline-secondary" %>
 
-    <%= form.radio_button :featured_status, false, class: "btn-check" %>
-    <%= form.label :featured_status_false, 'Not featured', for: "#{klass}_featured_status_false", class: "btn btn-outline-secondary" %>
-
-    <%= form.radio_button :featured_status, true, class: "btn-check" %>
-    <%= form.label :featured_status_true, 'Featured', for: "#{klass}_featured_status_true", class: "btn btn-outline-primary" %>
-  </div><!-- #featured_status -->
-
-<% else %>
-
-  <div id="featured_status" class="form-group toggle visually-hidden sr-only">
-    <%= form.label :featured_status, "Feature this on homepage?", class: "form-label" %><br>
-
-    <%= form.radio_button :featured_status, false, class: "visually-hidden sr-only" %>
-    <%= form.label :featured_status_false, 'Not featured', for: "#{klass}_featured_status_false", class: "form-label" %>
-
-    <%= form.radio_button :featured_status, true, class: "visually-hidden sr-only" %>
-    <%= form.label :featured_status_true, 'Featured', for: "#{klass}_featured_status_true", class: "form-label" %>
-  </div><!-- #featured_status -->
-
-<% end %>
+  <%= form.radio_button :featured_status, true, class: "btn-check" %>
+  <%= form.label :featured_status_true, 'Featured', for: "#{klass}_featured_status_true", class: "btn btn-outline-primary" %>
+</div><!-- #featured_status -->

--- a/app/views/admin/articles/form/_localization.html.erb
+++ b/app/views/admin/articles/form/_localization.html.erb
@@ -1,5 +1,5 @@
 <div id="localization">
-  <div class="form-group">
+  <div class="mb-3">
     <%= form.label :locale, class: "form-label" %>
     <%= form.collection_select :locale,
                                Locale.all,
@@ -14,7 +14,7 @@
     </p>
   </div>
 
-  <div class="form-group">
+  <div class="mb-3">
     <%= form.label "English #{current_item_class}", class: "form-label" %>
 
     <%= form.collection_select :canonical_id,

--- a/app/views/admin/articles/form/_localization.html.erb
+++ b/app/views/admin/articles/form/_localization.html.erb
@@ -6,7 +6,7 @@
                                :abbreviation,
                                :display_name,
                                {},
-                               class: "form-select todo-forward-delete-after-bootstrap-5-upgrade form-control form-control-lg" %>
+                               class: "form-select form-select-lg" %>
 
     <p class="form-text text-muted">
       If it’s not here, you can
@@ -22,6 +22,6 @@
                                :id,
                                :id_and_name,
                                { include_blank: true },
-                               class: "form-select todo-forward-delete-after-bootstrap-5-upgrade form-control form-control-lg" %>
+                               class: "form-select form-select-lg" %>
   </div>
 </div><!-- #localization -->

--- a/app/views/admin/articles/form/_published_at.html.erb
+++ b/app/views/admin/articles/form/_published_at.html.erb
@@ -2,7 +2,7 @@
   <% if @article.draft? %>
     <%= render "admin/datetime_group", form: form, post: @article, type: :article %>
 
-    <p class="m-0 font-weight-bold">To Future Publish…</p>
+    <p class="m-0 fw-bold">To Future Publish…</p>
     <p>
       Set a date and time above, then save this form.
       But don’t click the <b><code>Publish NOW!</code></b> button.
@@ -11,7 +11,7 @@
     <hr>
 
     <% if Current.user.can_publish? %>
-      <p class="m-0 font-weight-bold">To Publish Now…</p>
+      <p class="m-0 fw-bold">To Publish Now…</p>
 
       <p>
         If you want to publish this article <b>right now</b>, you can with one click.

--- a/app/views/admin/articles/form/_syndication.html.erb
+++ b/app/views/admin/articles/form/_syndication.html.erb
@@ -2,7 +2,7 @@
   <fieldset>
     <legend>Syndication</legend>
 
-    <div class="form-group">
+    <div class="mb-3">
       <%= form.label :tweet, class: "form-label" %>
       <%= form.text_area :tweet, class: "form-control form-control-lg", data: { 'max-length': '250', 'feedback-box': 'tweet-length' }, rows: 3 %>
       <div id="tweet-length">0</div>
@@ -12,7 +12,7 @@
       </p>
     </div>
 
-    <div class="form-group">
+    <div class="mb-3">
       <%= form.label :summary, class: "form-label" %>
       <%= form.text_area :summary, class: "form-control form-control-lg", data: { 'max-length': '150', 'feedback-box': 'summary-length' }, rows: 3 %>
       <div id="summary-length">0</div>

--- a/app/views/admin/articles/form/_tags.html.erb
+++ b/app/views/admin/articles/form/_tags.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group mt-3">
+<div class="mb-3 mt-3">
   <%= form.label :tags, "Tags", class: "form-label" %>
   <%= text_field_tag :tags, @article.tags.map(&:name).join(", "), class: "form-control form-control-lg" %>
   <p class="form-text text-muted">Comma separated. For example, <em>dogs, cats, etc</em>.</p>

--- a/app/views/admin/articles/index.html.erb
+++ b/app/views/admin/articles/index.html.erb
@@ -1,7 +1,7 @@
 <h2 class="mb-3">
   <%= link_to "NEW", [:new, :admin, :article], class: 'btn btn-outline-primary mb-2' %>
 
-  <span class='font-weight-light'><%= link_to_unless_current "Articles", [:admin, :articles] %></span>
+  <span class='fw-light'><%= link_to_unless_current "Articles", [:admin, :articles] %></span>
   <span class="text-muted">:</span>
   <b>Published</b>
 

--- a/app/views/admin/books/_downloads_form.html.erb
+++ b/app/views/admin/books/_downloads_form.html.erb
@@ -18,7 +18,7 @@
 
             <%= ebook_format.name %>
 
-            <span class="form-text text-muted font-weight-normal">
+            <span class="form-text text-muted fw-normal">
               <%= render_markdown ebook_format.description %>
 
               <code>

--- a/app/views/admin/books/_downloads_form.html.erb
+++ b/app/views/admin/books/_downloads_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-12">
-    <div class="form-group">
+    <div class="mb-3">
       <label for="downloads">Downloads</label>
 
       <p class="form-text text-muted">

--- a/app/views/admin/books/_form.html.erb
+++ b/app/views/admin/books/_form.html.erb
@@ -11,7 +11,7 @@
                                      :id,
                                      :name,
                                      { include_blank: true },
-                                     class: "form-control form-control-lg" %>
+                                     class: "form-select form-select-lg" %>
 
           <p class="form-text text-muted">
             If it’s not here, you can
@@ -102,7 +102,7 @@
           <%= form.label :published_at, class: "form-label" %>
           <%= form.date_select :published_at,
                                { start_year: Time.now.utc.year, end_year: 1995, include_blank: true },
-                               class: "form-control form-control-lg" %>
+                               class: "form-select form-select-lg mb-2" %>
         </div>
       </div>
 

--- a/app/views/admin/books/_form.html.erb
+++ b/app/views/admin/books/_form.html.erb
@@ -4,7 +4,7 @@
   <% if resource.is_a? Issue %>
     <div class="row">
       <div class="col-12 col-lg-8">
-        <div class="form-group">
+        <div class="mb-3">
           <%= form.label :journal_id, class: "form-label" %>
           <%= form.collection_select :journal_id,
                                      Journal.all,
@@ -98,7 +98,7 @@
       </div>
 
       <div class="col-12 col-sm-6">
-        <div class="form-group">
+        <div class="mb-3">
           <%= form.label :published_at, class: "form-label" %>
           <%= form.date_select :published_at,
                                { start_year: Time.now.utc.year, end_year: 1995, include_blank: true },

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="font-weight-light">Admin Dashboard</h1>
+<h1 class="fw-light">Admin Dashboard</h1>
 
 <nav class="mb-5">
   <p class="h6 text-muted">Jump to</p>

--- a/app/views/admin/dashboard/markdown.html.erb
+++ b/app/views/admin/dashboard/markdown.html.erb
@@ -25,8 +25,8 @@
             <%= render "markdown_#{card}" %>
           </div><!-- .card-body -->
 
-          <div class="card-footer">
-            <%= link_to "Back to Top ↑", "#top", class: "btn btn-outline-primary btn-block" %>
+          <div class="card-footer text-right">
+            <%= link_to "Back to Top ↑", "#top", class: "btn btn-outline-primary" %>
           </div><!-- .card-footer -->
         </div><!-- .card -->
       <% end %>

--- a/app/views/admin/episodes/_form.html.erb
+++ b/app/views/admin/episodes/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: [:admin, @episode]) do |form| %>
   <%= render "admin/form_errors", thing: @episode %>
 
-  <div class="form-group">
+  <div class="mb-3">
     <%= form.label :podcast_id, class: "form-label" %>
 
     <% @podcasts.each do |podcast| %>

--- a/app/views/admin/locales/_form.html.erb
+++ b/app/views/admin/locales/_form.html.erb
@@ -7,7 +7,7 @@
     </div>
 
     <div class="col-12 col-md-2">
-      <div class="form-group">
+      <div class="mb-3">
         <%= form.label :language_direction, "Direction", class: "form-label" %>
         <%= form.select :language_direction,
                         Locale.language_directions.keys,

--- a/app/views/admin/locales/_form.html.erb
+++ b/app/views/admin/locales/_form.html.erb
@@ -12,7 +12,7 @@
         <%= form.select :language_direction,
                         Locale.language_directions.keys,
                         {},
-                        class: "form-control form-control-lg text-uppercase" %>
+                        class: "form-select form-select-lg text-uppercase" %>
       </div>
     </div>
 

--- a/app/views/admin/logos/_form.html.erb
+++ b/app/views/admin/logos/_form.html.erb
@@ -22,7 +22,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_jpg, "JPEG Image", class: "form-label" %>
-            <%= form.file_field :image_jpg, accept: "image/jpeg", required: !resource.image_jpg.attached? %>
+            <%= form.file_field :image_jpg, accept: "image/jpeg", required: !resource.image_jpg.attached?, class: "form-control" %>
 
             <% if resource.image_jpg.attached? %>
               <p><%= image_tag url_for(image_variant_by_width(resource.image_jpg, @preview_width)), class: "mt-3 rounded d-block" %></p>
@@ -37,7 +37,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_png, "PNG Image", class: "form-label" %>
-            <%= form.file_field :image_png, accept: "image/png" %>
+            <%= form.file_field :image_png, accept: "image/png", class: "form-control" %>
 
             <% if resource.image_png.attached? %>
               <p><%= image_tag url_for(image_variant_by_width(resource.image_png, @preview_width)), class: "mt-3 rounded d-block" %></p>
@@ -50,7 +50,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_tif, "TIFF Image", class: "form-label" %>
-            <%= form.file_field :image_tif, accept: "image/tiff", class: "mt-3 rounded d-block" %>
+            <%= form.file_field :image_tif, accept: "image/tiff", class: "mt-3 rounded d-block", class: "form-control" %>
 
             <% if resource.image_tif.attached? %>
               <p><%= image_tag url_for(image_variant_by_width(resource.image_tif, @preview_width)), class: "mt-3 rounded d-block" %></p>
@@ -63,7 +63,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_pdf, "PDF Image", class: "form-label" %>
-            <%= form.file_field :image_pdf, accept: "application/pdf" %>
+            <%= form.file_field :image_pdf, accept: "application/pdf", class: "form-control" %>
 
             <% if resource.image_pdf.attached? %>
               <p><%= image_tag resource.image_pdf.preview(resize_to_limit: [@preview_width, @preview_width]), class: "mt-3 rounded d-block" %></p>
@@ -76,7 +76,7 @@
         <div class="card">
           <div class="card-body">
             <%= form.label :image_svg, "SVG Image", class: "form-label" %>
-            <%= form.file_field :image_svg, accept: "image/svg+xml", class: "mt-3 rounded d-block" %>
+            <%= form.file_field :image_svg, accept: "image/svg+xml", class: "mt-3 rounded d-block", class: "form-control" %>
 
             <% if resource.image_svg.attached? %>
               <p><%= image_tag url_for(resource.image_svg), class: "mt-3 rounded d-block" %></p>

--- a/app/views/admin/logos/_form.html.erb
+++ b/app/views/admin/logos/_form.html.erb
@@ -27,7 +27,7 @@
             <% if resource.image_jpg.attached? %>
               <p><%= image_tag url_for(image_variant_by_width(resource.image_jpg, @preview_width)), class: "mt-3 rounded d-block" %></p>
             <% else %>
-              <p class="form-text text-danger font-weight-bold">Required.</p>
+              <p class="form-text text-danger fw-bold">Required.</p>
             <% end %>
           </div>
         </div>

--- a/app/views/admin/logos/_form.html.erb
+++ b/app/views/admin/logos/_form.html.erb
@@ -18,7 +18,7 @@
   <fieldset>
     <legend>Uploads</legend>
     <div class="row">
-      <div class="col-12 col-md-4 form-group">
+      <div class="col-12 col-md-4 mb-3">
         <div class="card">
           <div class="card-body">
             <%= form.label :image_jpg, "JPEG Image", class: "form-label" %>
@@ -33,7 +33,7 @@
         </div>
       </div>
 
-      <div class="col-12 col-md-4 form-group">
+      <div class="col-12 col-md-4 mb-3">
         <div class="card">
           <div class="card-body">
             <%= form.label :image_png, "PNG Image", class: "form-label" %>
@@ -46,7 +46,7 @@
         </div>
       </div>
 
-      <div class="col-12 col-md-4 form-group">
+      <div class="col-12 col-md-4 mb-3">
         <div class="card">
           <div class="card-body">
             <%= form.label :image_tif, "TIFF Image", class: "form-label" %>
@@ -59,7 +59,7 @@
         </div>
       </div>
 
-      <div class="col-12 col-md-4 form-group">
+      <div class="col-12 col-md-4 mb-3">
         <div class="card">
           <div class="card-body">
             <%= form.label :image_pdf, "PDF Image", class: "form-label" %>
@@ -72,7 +72,7 @@
         </div>
       </div>
 
-      <div class="col-12 col-md-4 form-group">
+      <div class="col-12 col-md-4 mb-3">
         <div class="card">
           <div class="card-body">
             <%= form.label :image_svg, "SVG Image", class: "form-label" %>
@@ -103,7 +103,7 @@
       <div class="col-12 col-sm-6">
         <%= render "admin/books/categories_form", form: form %>
 
-        <div class="form-group">
+        <div class="mb-3">
           <%= form.label :published_at, class: "form-label" %>
           <%= form.date_select :published_at,
                                { start_year: Time.now.utc.year, end_year: 1995, include_blank: true },

--- a/app/views/admin/logos/_form.html.erb
+++ b/app/views/admin/logos/_form.html.erb
@@ -107,7 +107,7 @@
           <%= form.label :published_at, class: "form-label" %>
           <%= form.date_select :published_at,
                                { start_year: Time.now.utc.year, end_year: 1995, include_blank: true },
-                               class: "form-control form-control-lg" %>
+                               class: "form-select form-select-lg mb-2" %>
         </div>
       </div>
 

--- a/app/views/admin/pages/_form.html.erb
+++ b/app/views/admin/pages/_form.html.erb
@@ -21,7 +21,7 @@
     <div class="col-12 col-sm-6">
       <fieldset id="meta">
         <legend>Meta</legend>
-        <div class="form-group">
+        <div class="mb-3">
           <%= form.label :tags, class: "form-label", class: "form-label" %>
           <%= text_area_tag :tags, @page.tags.map{ |t| t.name }.join(", "), class: "form-control form-control-lg" %>
           <p class="form-text text-muted">Comma separated. For example, <em>dogs, cats, etc</em>.</p>

--- a/app/views/admin/podcasts/_form.html.erb
+++ b/app/views/admin/podcasts/_form.html.erb
@@ -30,7 +30,7 @@
 
   <%= render "admin/label_and_area_form_group", form: form, attr: :content, rows: 6 %>
 
-  <div class="form-group">
+  <div class="mb-3">
     <%= render "admin/label_and_field_form_group", form: form, attr: :tags %>
 
     <p class="form-text text-muted">

--- a/app/views/admin/posters/_attachments.html.erb
+++ b/app/views/admin/posters/_attachments.html.erb
@@ -21,7 +21,7 @@
                 <div class="card">
                   <div class="card-body">
                     <%= form.label attachement_form_attr_for(side, kind, color), "#{color.titleize} #{attachment_display_name_for(kind)}", class: "form-label" %>
-                    <%= form.file_field attachement_form_attr_for(side, kind, color), accept: acceptable_mime_types_for(kind) %>
+                    <%= form.file_field attachement_form_attr_for(side, kind, color), accept: acceptable_mime_types_for(kind), class: "form-control" %>
 
                     <% if resource.send(attachement_form_attr_for(side, kind, color)).attached? %>
                       <% if kind == 'download' %>

--- a/app/views/admin/posters/_attachments.html.erb
+++ b/app/views/admin/posters/_attachments.html.erb
@@ -17,7 +17,7 @@
           <% %w[color black_and_white].each do |color| %>
             <div class="col-12 col-sm-6 mb-3">
 
-              <div class="form-group">
+              <div class="mb-3">
                 <div class="card">
                   <div class="card-body">
                     <%= form.label attachement_form_attr_for(side, kind, color), "#{color.titleize} #{attachment_display_name_for(kind)}", class: "form-label" %>

--- a/app/views/admin/posters/_deprecated_download_checks.html.erb
+++ b/app/views/admin/posters/_deprecated_download_checks.html.erb
@@ -36,7 +36,7 @@
 
                   <%= form.label "#{side}_#{color}_#{type}_present", class: "form-check-label" do %>
                     <b><%= side.capitalize %> <%= color.titleize %></b>
-                    <span class="form-text text-muted font-weight-normal">
+                    <span class="form-text text-muted fw-normal">
                       Is there a <%= file %> of the <%= side %> in <%= color.titleize.downcase %> of the poster uploaded?
                     </span>
                   <% end %>
@@ -62,7 +62,7 @@
               <%= form.label "#{side}_image_format_#{filetype}", class: "form-check-label" do %>
                 <%= form.radio_button "#{side}_image_format", filetype, id: "poster_#{side}_image_format_#{filetype}", class: "form-check-input" %>
                 <b><%= filetype.upcase %></b>
-                <span class="text-muted font-weight-normal">Are the <%= side %> side images <%= filetype.upcase %>s?</span>
+                <span class="text-muted fw-normal">Are the <%= side %> side images <%= filetype.upcase %>s?</span>
               <% end %>
             </div>
           <% end %>

--- a/app/views/admin/posters/_deprecated_download_checks.html.erb
+++ b/app/views/admin/posters/_deprecated_download_checks.html.erb
@@ -6,7 +6,7 @@
       <% extension = type == "image" ? "[filetype]" : "pdf" %>
 
       <div class="col-12 col-sm-6">
-        <div class="form-group">
+        <div class="mb-3">
           <label for="downloads"><%= type.capitalize.pluralize %></label>
 
           <p class="form-text text-muted">
@@ -27,7 +27,7 @@
             <% end %>
           </p>
 
-          <div class="form-group">
+          <div class="mb-3">
             <% %w[front back].each do |side| %>
               <% %w[color black_and_white].each do |color| %>
 
@@ -54,7 +54,7 @@
   <div class="row">
     <% %w[front back].each do |side| %>
       <div class="col-12 col-sm-6">
-        <div class="form-group">
+        <div class="mb-3">
           <label for="downloads">Preview <%= side.capitalize %> Images Format</label>
 
           <% %w[jpg gif png].each do |filetype| %>

--- a/app/views/admin/posters/_form.html.erb
+++ b/app/views/admin/posters/_form.html.erb
@@ -82,7 +82,7 @@
       <div class="col-12 col-sm-6">
         <%= render "admin/posters/categories_form", form: form %>
 
-        <div class="form-group">
+        <div class="mb-3">
           <%= form.label :published_at, class: "form-label" %>
           <%= form.date_select :published_at,
                                { start_year: Time.now.utc.year, end_year: 1995, include_blank: true },

--- a/app/views/admin/posters/show.html.erb
+++ b/app/views/admin/posters/show.html.erb
@@ -17,7 +17,7 @@
         <% %w[color black_and_white].each do |color| %>
 
           <div class="col-12 col-md-6 col-lg-3 mb-5">
-            <p class="font-weight-bold">
+            <p class="fw-bold">
               <%= side.titleize %>
               <%= color.titleize %>
             </p>

--- a/app/views/admin/redirects/_form.html.erb
+++ b/app/views/admin/redirects/_form.html.erb
@@ -15,7 +15,7 @@
 
   <hr>
 
-  <div class="form-group">
+  <div class="mb-3">
     <%= form.check_box :temporary %>
     <%= form.label :temporary, class: "form-label" %>
 

--- a/app/views/admin/redirects/index.html.erb
+++ b/app/views/admin/redirects/index.html.erb
@@ -20,7 +20,7 @@
 <div class="row my-5">
   <div class="col">
     <%= form_with url: [:admin, :redirects], method: "get" do %>
-      <div class="form-group">
+      <div class="mb-3">
         <%= text_field_tag :source_path, params[:source_path], class: "form-control form-control-lg", placeholder: "FROM" %>
       </div>
 
@@ -32,7 +32,7 @@
 
   <div class="col">
     <%= form_tag [:admin, :redirects], method: "get" do %>
-      <div class="form-group">
+      <div class="mb-3">
         <%= text_field_tag :target_path, params[:target_path], class: "form-control form-control-lg", placeholder: "TO" %>
       </div>
 

--- a/app/views/admin/shared/_position.html.erb
+++ b/app/views/admin/shared/_position.html.erb
@@ -6,7 +6,7 @@
 
 <div class="row">
   <div class="col-6">
-    <div id="position" class="form-group">
+    <div id="position" class="mb-3">
       <%= form.label :position, "Position this #{resource_name} on the index page", class: "form-label" %>
       <%= form.number_field :position, step: 1, min: 0, class: 'form-control' %>
     </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -20,8 +20,8 @@
       </div>
     </div>
 
-    <div class="text-center my-5">
-      <%= button_tag t("auth.signin_button_text"), class: "btn btn-primary btn-lg btn-block action-submit" %>
+    <div class="text-right my-5">
+      <%= button_tag t("auth.signin_button_text"), class: "btn btn-primary btn-lg" %>
     </div>
   <% end %>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,7 +2,7 @@
   <h1 class="display-3">Sign In</h1>
 
   <%= form_with url: [:sessions], local: true do |form| %>
-    <div class="form-group">
+    <div class="mb-3">
       <%= form.label :username, t("auth.username_label"), class: "visually-hidden sr-only form-label" %>
       <%= form.text_field :username, autofocus: true, class: "form-control form-control-lg", placeholder: t("auth.username_label") %>
 
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    <div class="form-group">
+    <div class="mb-3">
       <%= form.label :password, t("auth.password_label"), class: "visually-hidden sr-only form-label" %>
       <%= form.password_field :password, class: "form-control form-control-lg", placeholder: t("auth.password_label") %>
 


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![Stay on target…](https://media.giphy.com/media/rcqtfj0RAhWLu/giphy.gif)

# What does this pull request do?

- Version bumps Bootstrap from `5.0.0.alpha2` to `5.0.0.alpha3`
- Migrates classes and such as laid out in the migration guide https://getbootstrap.com/docs/5.0/migration/#v500-alpha3
- Deleted a few of our custom CSSes in favor of using new Bootstrap provided defaults 

# How should this be manually tested?

Click around in `/admin`

# Is there any background context you want to provide for reviewers?

Toward Bootstrap 5

# Acceptance Criteria
## These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema
