### PR TITLE
Replace jQuery with vanilla JS for 1912

### DIFF
--- a/app/views/layouts/to_change_everything.html.erb
+++ b/app/views/layouts/to_change_everything.html.erb
@@ -9,15 +9,26 @@
   <%= stylesheet_link_tag "to_change_everything", media: "screen" %>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-  <script>
-    $(window).resize(function() {
-      $("h1,h2,h4,blockquote").css("z-index", 1);
-    });
+  <script>    // For IE < 9
+    if(window.attachEvent) {
+        window.attachEvent('onresize', function() {
+      document.querySelectorAll("h1,h2,h4,blockquote").forEach( el => el.style.zIndex = '1')
+        });
+    }
+    // For IE9+
+    else if(window.addEventListener) {
+        window.addEventListener('resize', function() {
+      document.querySelectorAll("h1,h2,h4,blockquote").forEach( el => el.style.zIndex = '1')
+        }, true);
+    }
+    else {
+        //The browser does not support Javascript event binding
+    }
 
     function toggleDiv(div) {
-      $("#"+div).toggle();
+      document.querySelector("#"+div).style.display = document.querySelector("#"+div).style.display === "none" ? "flex" : "none"
     }
-  </script>
+</script>
 
   <link rel="stylesheet" href="https://cloudfront.crimethinc.com/assets/tce/css/jquery.fancybox.css" media="screen">
 


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![Happy Ghost](https://media.giphy.com/media/hQQx2V7aTzMix2tPra/giphy.gif)

# What are the relevant GitHub issues?

resolves https://github.com/crimethinc/website/issues/1912

# What does this pull request do?

Replaces jQuery `.resize()`, `.css()`, `.toggle()` and `$()` in a compatibility friendly way

# How should this be manually tested?

1. Navigate to 0.0.0.0:3000/tce
2. Check that headers have z-index of 1 after resizing browser window
3. Check that table of contents is toggleable in the same way as the live site

# Is there any background context you want to provide for reviewers?

This fix assumes that the intended display for visible elements is "flex"

# Questions for the pull request author (delete any that don't apply):

# Acceptance Criteria
## These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema
