### PR TITLE
Replace jQuery with vanilla JS [#1912]

### DIFF
--- a/app/views/layouts/to_change_everything.html.erb
+++ b/app/views/layouts/to_change_everything.html.erb
@@ -9,20 +9,21 @@
   <%= stylesheet_link_tag "to_change_everything", media: "screen" %>
 
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-  <script>    // For IE < 9
+  <script>
+    var resizeCallback = function () {
+      var elements = document.querySelectorAll("h1,h2,h4,blockquote")
+      for (var i = 0; i < elements.length; i++) {
+        elements[i].style.zIndex = '1'
+      }
+    }
+
+    // For IE8
     if(window.attachEvent) {
-        window.attachEvent('onresize', function() {
-      document.querySelectorAll("h1,h2,h4,blockquote").forEach( el => el.style.zIndex = '1')
-        });
+        window.attachEvent('onresize', resizeCallback);
     }
     // For IE9+
     else if(window.addEventListener) {
-        window.addEventListener('resize', function() {
-      document.querySelectorAll("h1,h2,h4,blockquote").forEach( el => el.style.zIndex = '1')
-        }, true);
-    }
-    else {
-        //The browser does not support Javascript event binding
+        window.addEventListener('resize', resizeCallback, true);
     }
 
     function toggleDiv(div) {


### PR DESCRIPTION
# For #1912 

As discussed [here](https://github.com/crimethinc/website/commit/ce3cccda5e72e11473ddd83eca4d657a2240d7fd), I have adapted the resize callbacks to be run up to IE8.

**Suggestion:**
I would suggest to remove the resize events altogether, they shouldn't be of any use on the page. I investigated a bit and it feels like legacy code. The Z-Index applies to titles (there are no blockquotes on the page) that should already be positioned correctly (and it also applies to an element in the header which shouldn't be concerned by this script in my opinion. Removing the functions doesn't seem to affect the layout _as far as I've seen._