### PR TITLE
Re-add rspec-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :development, :test do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
 end
 
 # testing / ci

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,6 +390,9 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.90.0, < 2.0)
+    rubocop-rspec (2.1.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.10.1)
     ruby-vips (2.0.17)
       ffi (~> 1.9)
@@ -530,6 +533,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
+  rubocop-rspec
   rubypants
   sassc-rails
   scenic


### PR DESCRIPTION
This PR re-enables `rubocop-rspec`.

Previously… 

```yaml
# TODO: Uncomment when rubocop-rspec is compatible with rubocop <= 1.0
```
