### PR TITLE
[REFACTOR] DRY up the `for_index` scope

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -7,7 +7,7 @@ class BooksController < ApplicationController
     @type    = 'books'
     @title   = PageTitle.new title_for(:books)
 
-    @books = Book.english.for_index
+    @books = Book.for_index
 
     render "#{Current.theme}/books/index"
   end

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -37,7 +37,7 @@ class ToolsController < ApplicationController
   end
 
   def set_tools
-    @tools = tool_class.english.reorder(position: :asc).order(published_at: :desc).live.published.page(params[:page]).per(10)
+    @tools = tool_class.for_index(published_at: :desc).page(params[:page]).per(10)
   end
 
   def tool_class

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,8 +2,6 @@ class Book < ApplicationRecord
   include MultiPageTool
   include Featureable
 
-  scope :for_index, -> { where.not(hide_from_index: true).reorder(position: :asc).order(title: :asc) }
-
   def ask_for_donation?
     downloads_available?
   end

--- a/app/models/concerns/featureable.rb
+++ b/app/models/concerns/featureable.rb
@@ -6,6 +6,12 @@ module Featureable
     before_save :update_featured_at
   end
 
+  module ClassMethods
+    def for_index fallback_sort = { title: :asc }
+      where.not(hide_from_index: true).reorder(position: :asc).order(fallback_sort).english.published.live
+    end
+  end
+
   def update_featured_at
     self.featured_at = featured_status? ? Time.current : nil
   end


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/kiGxsKmkY73ig/giphy.gif)

# What are the relevant GitHub issues?

n/a

# What does this pull request do?

DRY up the books and tools index logic

# How should this be manually tested?

go to all the index pages, and see no errors:

- [x] books: https://pipeline-to-add-langs-t-kd7hyf.herokuapp.com/books
- [x] zines: https://pipeline-to-add-langs-t-kd7hyf.herokuapp.com/zines
- [ ] stickers: https://pipeline-to-add-langs-t-kd7hyf.herokuapp.com/stickers
- [ ] logos: https://pipeline-to-add-langs-t-kd7hyf.herokuapp.com/logos
- [ ] posters: https://pipeline-to-add-langs-t-kd7hyf.herokuapp.com/posters
- [x] journals: https://pipeline-to-add-langs-t-kd7hyf.herokuapp.com/journals
- [x] videos: https://pipeline-to-add-langs-t-kd7hyf.herokuapp.com/videos

# Is there any background context you want to provide for reviewers?

prep work for a `/tools` change (display localization links on the index page)

