### PR TITLE
[i18n] Show available localizations on tool index pages

### DIFF
--- a/app/assets/stylesheets/2017/views/_tools.scss
+++ b/app/assets/stylesheets/2017/views/_tools.scss
@@ -26,6 +26,7 @@
           border-right: 1px solid #ccc;
           padding-right: .5em;
           margin-right: .25em;
+          display: inline-block;
         }
 
         li:last-child { border-right: none; }

--- a/app/views/2017/articles/_localizations.html.erb
+++ b/app/views/2017/articles/_localizations.html.erb
@@ -1,9 +1,10 @@
+<% show_icon ||= false %>
 <% if localizations_for(article).present? %>
   <div class="localizations">
     <b class="badge">Localizations:</b>
 
     <ul>
-      <% if action_name == 'show' %>
+      <% if (action_name == 'show' || show_icon) %>
         <li><%= image_tag 'library/localizations.png', class: 'icon-image' %></li>
       <% end %>
       <% localizations_for(article).each do |article| %>

--- a/app/views/2017/tools/_tool.html.erb
+++ b/app/views/2017/tools/_tool.html.erb
@@ -15,6 +15,7 @@
     <div class="tool-main column column-three-quarter">
       <header>
         <%= render_themed "articles/titles", header: tool, linked: true %>
+        <%= render_themed "articles/localizations", article: tool, show_icon: true %>
       </header>
 
       <div class="p-summary">


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/L1PqqvVFtQiEU/giphy.gif)

# What are the relevant GitHub issues?

n/a

# What does this pull request do?

??

# How should this be manually tested?

go to all the index pages, and see no errors:

| | image | preview app link |
|-|----------|----------------------|
| **books** | ![books](https://user-images.githubusercontent.com/13190980/103325691-b494b780-4a01-11eb-89b7-3950aa4e1802.png) | [books](https://pipeline-to-add-tool-lo-yrh92y.herokuapp.com/books) |
| **zines** | ![zines](https://user-images.githubusercontent.com/13190980/103325677-a777c880-4a01-11eb-9d56-946ca613d9f5.png) | [zines](https://pipeline-to-add-tool-lo-yrh92y.herokuapp.com/zines) |
| **stickers** | foo | [stickers](https://pipeline-to-add-tool-lo-yrh92y.herokuapp.com/stickers) |
| **logos** | foo | [logos](https://pipeline-to-add-tool-lo-yrh92y.herokuapp.com/logos) |
| **posters** | foo | [posters](https://pipeline-to-add-tool-lo-yrh92y.herokuapp.com/posters) |

