### PR TITLE
Move fallback redirection to its own controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,6 @@ class ApplicationController < ActionController::Base
   before_action :set_current_theme
 
   before_action :set_site_locale
-  before_action :check_for_redirection
   before_action :strip_file_extension
   before_action :authorize, if: :staging?
   before_action :set_page_share
@@ -64,13 +63,6 @@ class ApplicationController < ActionController::Base
 
   def set_current_theme
     Current.theme = ENV.fetch('THEME') { '2017' }
-  end
-
-  def check_for_redirection
-    redirect = Redirect.where(source_path: request.path.downcase).last
-    redirect = Redirect.where(source_path: "#{request.path.downcase}/").last if redirect.blank?
-
-    return redirect_to(redirect.target_path.downcase, status: redirect.temporary? ? 302 : 301) if redirect.present?
   end
 
   # TODO: move to rack middleware

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,4 @@
 class ArticlesController < ApplicationController
-  skip_before_action :check_for_redirection, only: :index
-
   def index
     @articles = Article.includes(:tags, :categories).live.published.root.page(params[:page]).per(10)
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,16 +1,7 @@
 class PagesController < ApplicationController
-  before_action :set_page,       only: %i[show about contact]
-  before_action :page_redirects, only: %i[show about contact]
+  before_action :set_page,       only: %i[about contact]
+  before_action :page_redirects, only: %i[about contact]
   before_action :set_html_id
-
-  # TODO: Delete? Is this used by anything anymore?
-  def show
-    @editable = @page
-    @title    = PageTitle.new I18n.t("page_titles.about.#{@page.slug}")
-
-    # no layout
-    render html: @page.content.html_safe, layout: false if @page.content_in_html?
-  end
 
   def about
     @editable = @page

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -1,12 +1,17 @@
 class RedirectsController < ApplicationController
   def show
-    redirect = Redirect.where(source_path: request.path.downcase).last
-    redirect = Redirect.where(source_path: "#{request.path.downcase}/").last if redirect.blank?
-
     if redirect.present?
-      redirect_to(redirect.target_path.downcase, status: redirect.temporary? ? :found : :moved_permanently)
+      redirect_to redirect.target_path.downcase, status: redirect.temporary? ? :found : :moved_permanently
     else
       render file: Rails.root.join('public/404.html'), status: :not_found
     end
+  end
+
+  private
+
+  def redirect
+    return @redirect if @redirect.present?
+
+    @redirect = Redirect.where(source_path: request.path.downcase).or(Redirect.where(source_path: "#{request.path.downcase}/")).last
   end
 end

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -1,0 +1,5 @@
+class RedirectsController < ApplicationController
+  def show
+    # TODO: this will do stuff? Maybe.
+  end
+end

--- a/app/controllers/redirects_controller.rb
+++ b/app/controllers/redirects_controller.rb
@@ -1,5 +1,12 @@
 class RedirectsController < ApplicationController
   def show
-    # TODO: this will do stuff? Maybe.
+    redirect = Redirect.where(source_path: request.path.downcase).last
+    redirect = Redirect.where(source_path: "#{request.path.downcase}/").last if redirect.blank?
+
+    if redirect.present?
+      redirect_to(redirect.target_path.downcase, status: redirect.temporary? ? :found : :moved_permanently)
+    else
+      render file: Rails.root.join('public/404.html'), status: :not_found
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,7 +201,7 @@ Rails.application.routes.draw do
   get 'languages/:locale', to: 'languages#show',  as: :language
 
   # For redirection, exempts Active Storage upload paths
-  get '*path', to: 'redirects#show', as: :page, via: :all, constraints: lambda { |req|
+  get '*path', to: 'redirects#show', via: :all, constraints: lambda { |req|
     req.path.exclude? 'rails/active_storage'
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,7 +201,7 @@ Rails.application.routes.draw do
   get 'languages/:locale', to: 'languages#show',  as: :language
 
   # For redirection, exempts Active Storage upload paths
-  get '*path', to: 'pages#show', as: :page, via: :all, constraints: lambda { |req|
+  get '*path', to: 'redirects#show', as: :page, via: :all, constraints: lambda { |req|
     req.path.exclude? 'rails/active_storage'
   }
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -72,24 +72,6 @@ RSpec.describe ApplicationController, type: :controller do
     end
   end
 
-  describe '#check_for_redirection' do
-    it 'redirects temporarily when present' do
-      Redirect.create(source_path: '/anonymous', target_path: 'http://example.com', temporary: true)
-
-      get :index
-
-      expect(response.status).to eq(302)
-    end
-
-    it 'redirects permanently when present' do
-      Redirect.create(source_path: '/anonymous', target_path: 'http://example.com', temporary: false)
-
-      get :index
-
-      expect(response.status).to eq(301)
-    end
-  end
-
   describe '#strip_file_extension' do
     it 'strips .html' do
       get :index, format: 'html'

--- a/spec/controllers/redirects_controller_spec.rb
+++ b/spec/controllers/redirects_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe RedirectsController, type: :controller do
+  describe 'GET show' do
+    it 'redirects temporarily when present' do
+      Redirect.create(source_path: '/anonymous', target_path: 'http://example.com', temporary: true)
+
+      get :show
+
+      expect(response.status).to have_http_status(:moved_permanently)
+    end
+
+    it 'redirects permanently when present' do
+      Redirect.create(source_path: '/anonymous', target_path: 'http://example.com', temporary: false)
+
+      get :show
+
+      expect(response.status).to have_http_status(:found)
+    end
+  end
+end


### PR DESCRIPTION
# What are the relevant GitHub issues?

n/a

# What does this pull request do?

- This PR moves the fallback route for redirects from the `pages#show` controller action to a new `redirects#show` controller and action.
- It deletes `pages#show` since it wasn't used anymore
- It moves `check_for_redirection` from a before action on **every** request to only getting called when no other route matches

I initially set out to move this for the organization of it. But in the end, I think it might could be a performance improvement because we're not doing 1-2 database reads for every request even ones that are a routes match. Instead, we're only making 1 database read when no other route matches.

# How should this be manually tested?

- Go to a 404 route, like `/asdf`, expect the 404 page.
- Go to a normal route, like `/books`, expect it to work normally.
- Got to a redirect route, like `/j20`, expect it to redirect.
