### PR TITLE
Update the mastodon account URL

### DIFF
--- a/app/helpers/links_helper.rb
+++ b/app/helpers/links_helper.rb
@@ -5,7 +5,7 @@ module LinksHelper
     'Crimethinc. on Instagram'         => 'https://instagram.com/CrimethincAgain',
     'CrimethInc. on Github'            => 'https://github.com/crimethinc',
     'CrimethInc. on Tumblr'            => 'https://crimethinc.tumblr.com',
-    'CrimethInc. on Mastodon'          => 'https://mastodon.online/@crimethinc',
+    'CrimethInc. on Mastodon'          => 'https://todon.eu/@CrimethInc',
     'CrimethInc. on Telegram'          => 'https://t.me/ExWorkers',
     'CrimethInc.com Articles RSS feed' => 'https://crimethinc.com/feed'
   }.freeze


### PR DESCRIPTION
# What does this pull request do?

Crimethinc as migrate it's mastodon account from mastodon.online to todon.eu,

# How should this be manually tested?

Click on the mastodon logo in the footer and get redirect to the right mastodon instance.