### PR TITLE
Add CDN data migration script

### DIFF
--- a/lib/tasks/data/cdn.rake
+++ b/lib/tasks/data/cdn.rake
@@ -1,0 +1,50 @@
+namespace :cdn do
+  namespace :migrate do
+    desc 'Migrate articles to new CDN'
+    task articles: :environment do
+    end
+
+    desc 'Migrate books to new CDN'
+    task books: :environment do
+    end
+
+    desc 'Migrate zines to new CDN'
+    task zines: :environment do
+    end
+
+    desc 'Migrate journals to new CDN'
+    task journals: :environment do
+    end
+
+    desc 'Migrate issues to new CDN'
+    task issues: :environment do
+    end
+
+    desc 'Migrate podcasts to new CDN'
+    task podcasts: :environment do
+    end
+
+    desc 'Migrate episodes to new CDN'
+    task episodes: :environment do
+    end
+
+    desc 'Migrate posters to new CDN'
+    task posters: :environment do
+    end
+
+    desc 'Migrate stickers to new CDN'
+    task stickers: :environment do
+    end
+
+    desc 'Migrate redirects to new CDN'
+    task redirects: :environment do
+      Redirect.find_each do |redirect|
+        puts "==> Migrating CDN: Redirect: #{redirect.id}"
+        if redirect.source_path =~ /cloudfront/i || redirect.target_path =~ /cloudfront/i
+          redirect.update source_path: redirect.source_path.gsub('cloudfront.', 'cdn.'), target_path: redirect.target_path.gsub('cloudfront.', 'cdn.')
+        end
+      end
+    end
+
+  end
+end

--- a/lib/tasks/data/cdn.rake
+++ b/lib/tasks/data/cdn.rake
@@ -39,8 +39,9 @@ namespace :cdn do
     desc 'Migrate redirects to new CDN'
     task redirects: :environment do
       Redirect.find_each do |redirect|
-        puts "==> Migrating CDN: Redirect: #{redirect.id}"
+        puts "==> Checking if CDN migration needed Redirect #{redirect.id}"
         if redirect.source_path =~ /cloudfront/i || redirect.target_path =~ /cloudfront/i
+          puts "==> Migrating CDN: Redirect: #{redirect.id}"
           redirect.update source_path: redirect.source_path.gsub('cloudfront.', 'cdn.'), target_path: redirect.target_path.gsub('cloudfront.', 'cdn.')
         end
       end

--- a/lib/tasks/data/cdn.rake
+++ b/lib/tasks/data/cdn.rake
@@ -1,51 +1,65 @@
-namespace :cdn do
-  namespace :migrate do
-    desc 'Migrate articles to new CDN'
-    task articles: :environment do
-    end
+namespace :data do
+  namespace :cdn do
+    desc 'Migrate everything to new CDN'
+    task migrate: %i[migrate:stickers migrate:redirects]
 
-    desc 'Migrate books to new CDN'
-    task books: :environment do
-    end
+    namespace :migrate do
+      desc 'Migrate articles to new CDN'
+      task articles: :environment do
+      end
 
-    desc 'Migrate zines to new CDN'
-    task zines: :environment do
-    end
+      desc 'Migrate books to new CDN'
+      task books: :environment do
+      end
 
-    desc 'Migrate journals to new CDN'
-    task journals: :environment do
-    end
+      desc 'Migrate zines to new CDN'
+      task zines: :environment do
+      end
 
-    desc 'Migrate issues to new CDN'
-    task issues: :environment do
-    end
+      desc 'Migrate journals to new CDN'
+      task journals: :environment do
+      end
 
-    desc 'Migrate podcasts to new CDN'
-    task podcasts: :environment do
-    end
+      desc 'Migrate issues to new CDN'
+      task issues: :environment do
+      end
 
-    desc 'Migrate episodes to new CDN'
-    task episodes: :environment do
-    end
+      desc 'Migrate podcasts to new CDN'
+      task podcasts: :environment do
+      end
 
-    desc 'Migrate posters to new CDN'
-    task posters: :environment do
-    end
+      desc 'Migrate episodes to new CDN'
+      task episodes: :environment do
+      end
 
-    desc 'Migrate stickers to new CDN'
-    task stickers: :environment do
-    end
+      desc 'Migrate posters to new CDN'
+      task posters: :environment do
+      end
 
-    desc 'Migrate redirects to new CDN'
-    task redirects: :environment do
-      Redirect.find_each do |redirect|
-        puts "==> Checking if CDN migration needed Redirect #{redirect.id}"
-        if redirect.source_path =~ /cloudfront/i || redirect.target_path =~ /cloudfront/i
-          puts "==> Migrating CDN: Redirect: #{redirect.id}"
-          redirect.update source_path: redirect.source_path.gsub('cloudfront.', 'cdn.'), target_path: redirect.target_path.gsub('cloudfront.', 'cdn.')
+      desc 'Migrate stickers to new CDN'
+      task stickers: :environment do
+        Sticker.find_each do |sticker|
+          puts "==> Checking if CDN migration needed Sticker: #{sticker.id}"
+          if sticker.summary =~ /cloudfront/i || sticker.description =~ /cloudfront/i
+            puts "==> Migrating CDN: Sticker: #{sticker.id}"
+            sticker.update summary:     sticker.summary.gsub('cloudfront.', 'cdn.'),
+                           description: sticker.description.gsub('cloudfront.', 'cdn.')
+          end
         end
       end
-    end
 
+      desc 'Migrate redirects to new CDN'
+      task redirects: :environment do
+        Redirect.find_each do |redirect|
+          puts "==> Checking if CDN migration needed Redirect: #{redirect.id}"
+          if redirect.source_path =~ /cloudfront/i || redirect.target_path =~ /cloudfront/i
+            puts "==> Migrating CDN: Redirect: #{redirect.id}"
+            redirect.update source_path: redirect.source_path.gsub('cloudfront.', 'cdn.'),
+                            target_path: redirect.target_path.gsub('cloudfront.', 'cdn.')
+          end
+        end
+      end
+
+    end
   end
 end

--- a/lib/tasks/data/cdn.rake
+++ b/lib/tasks/data/cdn.rake
@@ -9,7 +9,7 @@ namespace :data do
         attrs.each do |attr|
           update_obj = true if obj.send(attr) =~ /cloudfront/i # rubocop:disable Performance/RegexpMatch
 
-          if update_obj == true
+          if update_obj == true && obj.send(attr).present?
             puts "==> Migrating CDN: #{klass}: #{obj.id}"
             obj.update attr => obj.send(attr).gsub('cloudfront.', 'cdn.')
           end
@@ -34,7 +34,7 @@ namespace :data do
     namespace :migrate do
       desc 'Migrate articles to new CDN'
       task articles: :environment do
-        migrate_table klass: Article, attrs: %i[content description image image_description image_mobile summary summary]
+        migrate_table klass: Article, attrs: %i[content image image_description image_mobile summary summary]
       end
 
       desc 'Migrate books to new CDN'

--- a/lib/tasks/data/cdn.rake
+++ b/lib/tasks/data/cdn.rake
@@ -7,12 +7,8 @@ namespace :data do
         update_obj = false
 
         attrs.each do |attr|
-          if obj.send(attr) =~ /cloudfront/i
-            update_obj = true
-          end
-        end
+          update_obj = true if obj.send(attr) =~ /cloudfront/i # rubocop:disable Performance/RegexpMatch
 
-        attrs.each do |attr|
           if update_obj == true
             puts "==> Migrating CDN: #{klass}: #{obj.id}"
             obj.update attr => obj.send(attr).gsub('cloudfront.', 'cdn.')
@@ -22,31 +18,48 @@ namespace :data do
     end
 
     desc 'Migrate everything to new CDN'
-    task migrate: %i[migrate:posters migrate:stickers migrate:redirects]
+    task migrate: %i[
+      migrate:articles
+      migrate:books
+      migrate:zines
+      migrate:journals
+      migrate:issues
+      migrate:podcasts
+      migrate:episodes
+      migrate:posters
+      migrate:stickers
+      migrate:redirects
+    ]
 
     namespace :migrate do
       desc 'Migrate articles to new CDN'
       task articles: :environment do
+        migrate_table klass: Article, attrs: %i[content description image image_description image_mobile summary summary]
       end
 
       desc 'Migrate books to new CDN'
       task books: :environment do
+        migrate_table klass: Book, attrs: %i[content description summary]
       end
 
       desc 'Migrate zines to new CDN'
       task zines: :environment do
+        migrate_table klass: Zine, attrs: %i[content description summary]
       end
 
       desc 'Migrate journals to new CDN'
       task journals: :environment do
+        migrate_table klass: Journal, attrs: %i[content description summary]
       end
 
       desc 'Migrate issues to new CDN'
       task issues: :environment do
+        migrate_table klass: Issue, attrs: %i[content description summary]
       end
 
       desc 'Migrate podcasts to new CDN'
       task podcasts: :environment do
+        migrate_table klass: Podcast, attrs: %i[image content copyright]
       end
 
       desc 'Migrate episodes to new CDN'
@@ -68,7 +81,6 @@ namespace :data do
       task redirects: :environment do
         migrate_table klass: Redirect, attrs: %i[source_path target_path]
       end
-
     end
   end
 end


### PR DESCRIPTION
tl;dr find `cloudfront. crimethinc.com` and replace with `cdn. crimethinc.com` in database records.

***

This is a data migration as rake task/s.

It goes through all of the table and looks at the contents of only certain columns. Ones that could have URLs to our old CDN in it. And if found, replaces with the URL to our new CDN.

