### PR TITLE
 #1878 Add languages item to nav bar

### DIFF
--- a/app/views/2017/shared/_header.html.erb
+++ b/app/views/2017/shared/_header.html.erb
@@ -13,6 +13,7 @@
       <li class="nav-link"><%= link_to t("header.audio"),   "/podcasts" %></li>
       <li class="nav-link"><%= link_to t("header.store"),   "/store" %></li>
       <li class="nav-link"><%= link_to t("header.search"),  "/search" %></li>
+      <li class="nav-link"><%= link_to t("header.languages"),  "/languages" %></li>
       <li class="nav-link"><%= link_to t("header.about"),   "/about" %></li>
     </ul>
 

--- a/app/views/2017/shared/_header.html.erb
+++ b/app/views/2017/shared/_header.html.erb
@@ -10,11 +10,11 @@
       <li class="nav-link"><%= link_to t("header.books"),   "/books" %></li>
       <li class="nav-link"><%= link_to t("header.library"), "/library" %></li>
       <li class="nav-link"><%= link_to t("header.tools"),   "/tools" %></li>
-      <li class="nav-link"><%= link_to t("header.audio"),   "/podcasts" %></li>
-      <li class="nav-link"><%= link_to t("header.store"),   "/store" %></li>
-      <li class="nav-link"><%= link_to t("header.search"),  "/search" %></li>
+      <li class="nav-link"><%= link_to t("header.audio"),      "/podcasts" %></li>
+      <li class="nav-link"><%= link_to t("header.store"),      "/store" %></li>
+      <li class="nav-link"><%= link_to t("header.search"),     "/search" %></li>
       <li class="nav-link"><%= link_to t("header.languages"),  "/languages" %></li>
-      <li class="nav-link"><%= link_to t("header.about"),   "/about" %></li>
+      <li class="nav-link"><%= link_to t("header.about"),      "/about" %></li>
     </ul>
 
     <% unless Locale.english? %>


### PR DESCRIPTION
# What are the relevant GitHub issues?

resolves [#1878](https://github.com/crimethinc/website/issues/1878)

# What does this pull request do?

Adds new item in the primary navbar linking to `/languages`.

# How should this be manually tested?

Open home page and find `Languages` between `Search` and `About` in the navbar. Resize the browser and check that the navbar is still usable
