### PR TITLE
Fix rubocop 1.21.0 linting before the gem update

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -43,8 +43,8 @@ class Episode < ApplicationRecord
     duration_in_seconds = duration.to_i.minutes
 
     hours   =  (duration_in_seconds / 3600).to_i
-    minutes =  (duration_in_seconds / 60 - hours * 60).to_i
-    seconds =  (duration_in_seconds - (minutes * 60 + hours * 3600)).to_i
+    minutes =  ((duration_in_seconds / 60) - (hours * 60)).to_i
+    seconds =  (duration_in_seconds - ((minutes * 60) + (hours * 3600))).to_i
 
     [
       hours.to_s.rjust(2, '0'),


### PR DESCRIPTION
@astronaut-wannabe could you check this simple PR?

It simply fix the dependabot rubocop linting error before merging the gem update.