### PR TITLE
Make PicTwitterRedirect rack middleware's matcher less liberal 😉

### DIFF
--- a/app/middlewares/rack/pic_twitter_redirect.rb
+++ b/app/middlewares/rack/pic_twitter_redirect.rb
@@ -7,7 +7,7 @@ module Rack
     def call env
       request = Rack::Request.new(env)
 
-      if request.path.include?('twitter')
+      if request.path.include?('pic.twitter.com')
         location = request.path.split('pic.twitter.com').first
 
         encoding_options = {


### PR DESCRIPTION
This middleware was catching a bad link that causing 100s of 500s.

Instead, it should be caught at the end of routes by the Redirects lookup.

It was a bad link that had `twitter.com` in the path, but it wasn't `pic.twitter.com`.