### PR TITLE
Make Dependabot more liberal 😉

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    allow:
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "all"


### PR DESCRIPTION
Catch both direct and indirect dependencies.