### PR TITLE
Return `404` when archive path is incorrect

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
   get '(/:year)(/:month)(/:day)/page(/1)', to: redirect { |_, req|
     req.path.split('page').first
   }
-  get '/(:year)/(:month)/(:day)/(page/:page)',
+  get '/(:year(/:month(/:day(/page/:page))))',
       to:          'article_archives#index',
       constraints: { year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ },
       as:          :article_archives


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/ZuZWC5qDDhQvRrAOqw/giphy.gif)


# What does this pull request do?

Currently, we get a runtime error [here][0] if someone tries to
navigate to a path such as `http://crimethinc.com/20`

This is because, with the existing route, we end up passing the
following params into the archive paginator:

```ruby
{
  year: "",
  month: "20",
  day: ""
}
```

nesting the path params as I do in this change will make the
contraints apply as expected, resulting in a `404` rather than a `500`

[0]:https://github.com/crimethinc/website/blob/78e06588d0f8f4f70240f33d0d44230227070f9b/app/models/article_archive_paginator.rb#L70

# How should this be manually tested?

- go to [http://crimethinc.com/20 on production](http://crimethinc.com/20), see a `500`
- go to [http://review-app/20](https://pipeline-to-return-404--zswmre.herokuapp.com//20), see a 404

