### PR TITLE
[I18N] fix bug for displaying unicode urls

### DIFF
--- a/app/views/2017/shared/_footer.html.erb
+++ b/app/views/2017/shared/_footer.html.erb
@@ -7,7 +7,13 @@
 
   <% if media_mode? && I18n.locale == :en %>
     <p class="site-mode-link-container">
-      <%= link_to(t("footer.site_mode"), url_for_current_path_with_subdomain(subdomain: :lite)) %>
+      <%=
+        # the encode/decode stuff is to get international, unicode URIs to be url-encoded
+        current_uri_with_subdomain = url_for_current_path_with_subdomain(subdomain: :lite)
+        uri = Addressable::URI.parse(current_uri_with_subdomain).display_uri.to_s
+
+        link_to(t("footer.site_mode"), uri)
+        %>
     </p>
   <% end %>
 


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/13SYTDifJqy2Ck/giphy.gif)

# What does this pull request do?

We were getting the following errors for some international URLs:

```
  incompatible character encodings: ASCII-8BIT and UTF-8
```

You can reproduce this error using cURL:

```sh
  curl http://localhost:3000/languages/português-brasileiro
```

You cannot really reproduce this error by just pasting the above URL
into a browser's address bar because most modern browsers will
transparently URL encode Unicode

I found a good explanation and the fix on the [SO question][0]

[0]:https://stackoverflow.com/a/67400648


# How should this be manually tested?

1. run ` curl https:/crimethinc.com/languages/português-brasileiro` and observe a `500`
2. run ` curl https://pipeline-to-fix-unicoe--bini3n.herokuapp.com/languages/português-brasileiro` and observe a `200`


