### PR TITLE
[REFACTOR] Extract unicode handling code to helper

### DIFF
--- a/app/helpers/localization_helper.rb
+++ b/app/helpers/localization_helper.rb
@@ -3,6 +3,9 @@ module LocalizationHelper
     subdomain = subdomain == I18n.default_locale ? nil : "#{subdomain}."
     port      = ":#{request.port}" if request.port.present?
 
-    [request.protocol, subdomain, request.domain, port, request.path].join
+    uri_with_subdomain = [request.protocol, subdomain, request.domain, port, request.path].join
+
+    # the encode/decode stuff is to get international, unicode URIs to be url-encoded
+    Addressable::URI.parse(uri_with_subdomain).display_uri.to_s
   end
 end

--- a/app/views/2017/shared/_footer.html.erb
+++ b/app/views/2017/shared/_footer.html.erb
@@ -7,13 +7,7 @@
 
   <% if media_mode? && I18n.locale == :en %>
     <p class="site-mode-link-container">
-      <%=
-        # the encode/decode stuff is to get international, unicode URIs to be url-encoded
-        current_uri_with_subdomain = url_for_current_path_with_subdomain(subdomain: :lite)
-        uri = Addressable::URI.parse(current_uri_with_subdomain).display_uri.to_s
-
-        link_to(t("footer.site_mode"), uri)
-        %>
+      <%= link_to(t("footer.site_mode"), url_for_current_path_with_subdomain(subdomain: :lite)) %>
     </p>
   <% end %>
 


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](giphy link)

# What are the relevant GitHub issues?

n/a

# What does this pull request do?

I added some unicode-specific code in [PR #2205][0]

This refactor pulls that code into the `localization_helper`

[0]:https://github.com/crimethinc/website/pull/2205

# How should this be manually tested?

run `curl https://pipeline-to-refactor-un-k6ocwm.herokuapp.com/languages/português-brasileiro` and observe a 200

