### PR TITLE
Include Publishable in (Single|Multi)PageTool classes

### DIFF
--- a/app/models/concerns/multi_page_tool.rb
+++ b/app/models/concerns/multi_page_tool.rb
@@ -3,6 +3,7 @@ module MultiPageTool
   include Tool
   include Featureable
   include Translatable
+  include Publishable
 
   def gallery_images
     if gallery_images_count.present? && gallery_images_count.positive?

--- a/app/models/concerns/single_page_tool.rb
+++ b/app/models/concerns/single_page_tool.rb
@@ -3,6 +3,7 @@ module SinglePageTool
   include Tool
   include Featureable
   include Translatable
+  include Publishable
 
   def image_description
     I18n.t 'tools.poster.image_description', title: title


### PR DESCRIPTION
To add `.live` to the tools, so that the `.json` API requests to work again (for `rake seed:uploads:import` rake tasks).