### PR TITLE
Fix image size of 'Dias de Guerra, Noites de Amor - Versão Reduzida' on /zines

### DIFF
--- a/app/assets/stylesheets/2017/views/_tools.scss
+++ b/app/assets/stylesheets/2017/views/_tools.scss
@@ -32,11 +32,11 @@
         display: block;
 
         a {
-            text-transform: capitalize;
-            text-decoration: underline;
-            font-style: italic;
-            font-weight: normal;
-            color: $color-gray;
+          text-transform: capitalize;
+          text-decoration: underline;
+          font-style: italic;
+          font-weight: normal;
+          color: $color-gray;
         }
 
         li {
@@ -87,26 +87,17 @@
       // books#show
       .tool-front.contradictionary-cover img { border-radius: 0 20px 20px 0; }
 
-      // Custom size
-      #recipes-for-disaster       .tool-front img { width: 100%; }
-      #expect-resistance          .tool-front img { width:  79%; }
-      #days-of-war-nights-of-love .tool-front img { width:  79%; }
-      #contradictionary           .tool-front img { width:  60%; }
+      // Cover image sizes on /books
+      .book {
+        // Custom size
+        &#recipes-for-disaster         .tool-front img { width: 100%; }
+        &#contradictionary             .tool-front img { width:  60%; }
 
-      // Default size
-      #da-democracia-a-liberdade,
-      #dias-de-guerra-noites-de-amor,
-      #espere-resistencia,
-      #from-democracy-to-freedom,
-      #from-democracy-to-freedom-der-unterschied-zwischen-regierung-und-selbstbestimmung,
-      #no-habra-muro-que-nos-pare,
-      #no-wall-they-can-build,
-      #off-the-map,
-      #receitas-para-o-desastre,
-      #trabalho-edicao-resumida-de-emergencia,
-      #work-kapitalismus-wirtschaft-widerstand,
-      #work {
-        .tool-front img { width:  68%; }
+        &#expect-resistance,
+        &#days-of-war-nights-of-love { .tool-front img { width:  79%; } }
+
+        // Default size
+        & .tool-front img { width:  68%; }
       }
 
       .tool-section {

--- a/app/views/2017/books/_book.html.erb
+++ b/app/views/2017/books/_book.html.erb
@@ -1,4 +1,4 @@
-<div class="tool" id="<%= book.slug %>">
+<div class="tool book" id="<%= book.slug %>">
   <header>
     <%= render_themed "articles/titles", header: book, linked: true %>
   </header>


### PR DESCRIPTION
There is CSS to re-size the **Book** images relative to each other, to reflect their physical size difference. It was also being applied to **Zines**, which was a no-op, except for a zine that happened to have the same slug as a PT translation of a book. And was thus being sized oddly too small.

This PR makes that CSS more targeted, not applying to any tools except books.

***

# Before
<img width="791" alt="before" src="https://user-images.githubusercontent.com/4361/149851978-4b6bcc5e-f422-485c-8272-a834dcd4bbf4.png">

# After
<img width="1009" alt="after" src="https://user-images.githubusercontent.com/4361/149851988-d49a237e-9c58-40de-905a-ed741b0b3cd3.png">

