### PR TITLE
Add json feed for zines

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -66,7 +66,7 @@ class ToolsController < ApplicationController
   end
 
   def request_namespace
-    request.path.split('/')[1]
+    controller_path
   end
 
   def set_type

--- a/app/views/2017/tools/index.json.jbuilder
+++ b/app/views/2017/tools/index.json.jbuilder
@@ -1,0 +1,45 @@
+json.prettify!
+
+json.version        'https://jsonfeed.org/version/1'
+json.user_comment   <<~USER_COMMENT.squish
+  I support your decision, I believe in change and hope you find just
+  what it is that you are looking for. If your heart is free, the
+  ground you stand on is liberated territory. Defend it. This feed
+  allows you to read the posts from this site in any feed reader that
+  supports the JSON Feed format. To add this feed to your reader, copy
+  the following URL — https://crimethinc.com/feed.json — and add it
+  your reader. For more info on this format: https://jsonfeed.org
+USER_COMMENT
+
+json.title          page_title
+json.description    meta_title
+json.home_page_url  root_url
+json.feed_url       "#{root_url}/#{controller_path}.json"
+
+next_path     = path_to_next_page @tools
+previous_path = path_to_previous_page @tools
+json.next_url       "#{root_url}#{next_path}" if next_path.present?
+json.previous_url   "#{root_url}#{previous_path}" if previous_path.present?
+
+json.icon           asset_url('icons/icon-600x600.png')
+json.favicon        asset_url('icons/icon-70x70.png')
+
+json.author do
+  json.name author
+  json.url  root_url
+  json.avatar asset_url('icons/icon-600x600.png')
+end
+
+json.items do
+  json.array! @tools.each do |tool|
+    json.id  root_url + tool.path
+    json.url root_url + tool.path
+    json.title tool.name
+    json.summary tool.summary
+    json.image tool.image
+    json.date_published tool.published_at.iso8601
+    json.date_modified tool.updated_at.iso8601
+    json.tags tool.tags.filter_map(&:name)
+    json.lang tool.locale
+  end
+end

--- a/app/views/2017/tools/index.json.jbuilder
+++ b/app/views/2017/tools/index.json.jbuilder
@@ -16,8 +16,10 @@ json.description    meta_title
 json.home_page_url  root_url
 json.feed_url       "#{root_url}/#{controller_path}.json"
 
-next_path     = path_to_next_page @tools
-previous_path = path_to_previous_page @tools
+json.feed_url       "#{root_url}/#{controller_path}.json"
+
+next_path           = path_to_next_page @tools
+previous_path       = path_to_previous_page @tools
 json.next_url       "#{root_url}#{next_path}" if next_path.present?
 json.previous_url   "#{root_url}#{previous_path}" if previous_path.present?
 


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/3o6MboxdySdgUuSfgQ/giphy.gif)

# What are the relevant GitHub issues?

n/a

# What does this pull request do?

We started getting `500`s for URLs that look like this:

```
https://crimethinc.com/zines.json
```

I went back through the git history to August of
2021 (ca65aed) to see if this was a
recent regression. It seems that we **never had JSON feed support for tools**
in the first place.

This PR adds support for Zines/stickers/posters. Journals and videos will need separate PRs

# How should this be manually tested?

- https://pipeline-to-add-json-fe-vwn0qd.herokuapp.com/zines.json
- https://pipeline-to-add-json-fe-vwn0qd.herokuapp.com/stickers.json
- https://pipeline-to-add-json-fe-vwn0qd.herokuapp.com/posters.json

# Is there any background context you want to provide for reviewers?

To add JSON support for tools, This PR does 3 things:

1. Add a json index template
2. modify the tool controller's namespace method to support json
3. swallows ActiveStorage issues on development and staging environments

details about 2 and 3 are below

<details>
<summary>  2. use controller_path for tool namespacing</summary>

When a request for an HTML page comes in, `request.path` looks like
this:

```ruby
[2] pry(#<StickersController>)> request.path
=> "/stickers"
```

The existing code then strips off the leading `/` and just returns
the tool name (`stickers` in this example)

An issues occurs when we get a JSON request. That is because
`request.path` will look like this:

```ruby
[1] pry(#<StickersController>)> request.path
=> "stickers.json"
```

The existing code will then incorrectly return `stickers.json` as the tool
namespace, which cause downstream issues

replacing the code with `controller_path` will return the controllers
name the same regardless of format, so this will hopefully have fewer
issues.

Note: Because we have this `tools` abstraction, I am not 100% sure
that the `controller_path` will always be the same as the expected
tool. I couldn't find an instance of this currently, but it doesn't
seem impossible
</details>

<details>
<summary>3. swallows ActiveStorage issues on development and staging environments</summary>

in development/staging we often download production data and load
it into our local database to facilitate development and
debugging. This causes an error with image and resources that are
uploaded via ActiveStorage. We get the below error whenever trying
to generate an image url:

```
 ActionView::Template::Error (undefined method `signed_id' for nil:NilClass):
```

This is because the development/staging ActiveStorage tables don't
(and cannot) match up with the actual ActiveStorage storage used
in these environments (e.g. the staging env points to aa different
AWS instance than the production env)

This is a bit of a stop-gap until we figure out a better way of
handling this issue.

I re-throw the error in production to prevent us from swallowing legit
errors

</details>
