### PR TITLE
Add /tools/random for a random tool

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -5,8 +5,8 @@ class ToolsController < ApplicationController
   before_action :set_body_id
   before_action :set_type
 
-  before_action :set_tool,  except: :about
-  before_action :set_tools, except: :about
+  before_action :set_tool,  except: %i[about random]
+  before_action :set_tools, except: %i[about random]
 
   before_action :set_title
   before_action :set_editable, only: :show
@@ -18,13 +18,19 @@ class ToolsController < ApplicationController
     render "#{Current.theme}/tools/about"
   end
 
+  # Inherited by each kind of tool
   def index
     render "#{Current.theme}/tools/index"
   end
 
+  # Inherited by each kind of tool
   def show
     @preview_width = 400
     render "#{Current.theme}/tools/show"
+  end
+
+  def random
+    redirect_to RandomTool.new.sample.path
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,8 @@ Rails.application.routes.draw do
   get 'journals',                     to: 'journals#index', as: :issues
 
   # Tools
-  get 'tools', to: 'tools#about', as: :tools
+  get 'tools',        to: 'tools#about',  as: :tools
+  get 'tools/random', to: 'tools#random', as: :random_tool
 
   # Site search
   get 'search',           to: 'search#index'


### PR DESCRIPTION
Using `RandomTool.new.sample` from https://github.com/crimethinc/website/pull/2357, this will redirect the user from `/tools/random` to a, wait for it, random tool. For now, this is HTML only. But my plan is to work for JSON too. So that a Twitter bot can use it to easily get the data about said random tool to make its post.