### PR TITLE
Fix `issues#show`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     i18n-debug (1.2.0)
       i18n (< 2)
@@ -325,7 +325,7 @@ GEM
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
       rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
+    rspec-core (3.10.2)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -437,7 +437,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.5.3)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,12 +1,29 @@
-class IssuesController < ToolsController
-  # See tools_controller.rb for inherited behavior
+class IssuesController < ApplicationController
+  before_action :set_html_id
+  before_action :set_body_id
+
   def show
-    journal   = Journal.find_by(slug: params[:slug])
-    @issue    = Issue.find_by(issue: params[:issue_number], journal_id: journal.id)
+    @type = 'issues'
+    journal   = Journal.find_by(slug: show_params[:slug])
+    @issue    = Issue.find_by(issue: show_params[:issue_number], journal_id: journal.id)
     @tool     = @issue
     @editable = @issue
 
     @title = PageTitle.new title_for :journals, journal.name, @issue.issue
     render "#{Current.theme}/books/show"
+  end
+
+  private
+
+  def set_html_id
+    @html_id = 'page'
+  end
+
+  def set_body_id
+    @body_id = 'tools'
+  end
+
+  def show_params
+    params.permit(:slug, :issue_number)
   end
 end


### PR DESCRIPTION

# What are the relevant GitHub issues?

resolves 500 when trying to view journal issues

# What does this pull request do?

- runs `budle update` to get around an issue with i18n v1.9.0
- decouples the issues controller from the tools controller

# How should this be manually tested?

- try viewing the show page for an issue

# Is there any background context you want to provide for reviewers?

having these controllers coupled results in `nil` checking code in the tools controller that is specifically there to handle the `issues` model, but isn't used by any other `tool`. if the `issue` model requires unique controller logic, then we might as well put it in its own controller
