### PR TITLE
Fix SSfWD page (card download button)

### DIFF
--- a/app/helpers/steal_something_from_work_day_helper.rb
+++ b/app/helpers/steal_something_from_work_day_helper.rb
@@ -7,8 +7,11 @@ module StealSomethingFromWorkDayHelper
   end
 
   def card_tag options
-    options[:download_button] = t('steal_something_from_work_day.outreach_materials.download_button')
-    card = OpenStruct.new options
+    card_options = {
+      download_button: t('steal_something_from_work_day.outreach_materials.download_button')
+    }.merge options
+
+    card = OpenStruct.new card_options
 
     tag.div class: 'card' do
       card_image(card: card) + card_body(card: card)


### PR DESCRIPTION
/ssfwd was 500ing.

Maybe a change in Ruby 3.0 made it so we couldn't edit the hash arg passed into this helper method? Not sure. 

Either way, this seems to fix it.