### PR TITLE
Add #notes to Article, re-organized article admin form

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -141,7 +141,7 @@ module Admin
 
     def article_params
       permitted_params = params.require(:article).permit(
-        :title, :subtitle, :content, :year, :month, :day, :tweet, :slug,
+        :title, :subtitle, :content, :notes, :year, :month, :day, :tweet, :slug,
         :draft_code, :summary, :published_at, :tags, :collection_id,
         :short_path, :image, :css, :image_description, :image_mobile,
         :published_at_tz, :locale, :canonical_id, :publication_status,

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -51,9 +51,13 @@ class Article < ApplicationRecord
 
   delegate :blank?, to: :short_path, prefix: true
 
+  def content_and_notes
+    [content, notes].join "\n\n"
+  end
+
   def content_rendered include_media: true
     Kramdown::Document.new(
-      MarkdownMedia.parse(content, include_media: include_media),
+      MarkdownMedia.parse(content_and_notes, include_media: include_media),
       input:                     content_format.to_sym,
       remove_block_html_tags:    false,
       transliterated_header_ids: true,

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -42,7 +42,7 @@
     </div>
   </div>
 
-  <hr class="mb-5">
+  <%= render "admin/form_actions", cancel_url: [:admin, :articles] %>
 
   <div class="row mb-5">
     <div class="col-12 col-md-7">
@@ -56,8 +56,6 @@
     </div>
   </div>
 
-  <hr class="mb-5">
-
   <div class="row mb-5">
     <div class="col-12 col-md-7">
       <%= render "admin/articles/form/tags", form: form %>
@@ -69,8 +67,17 @@
     </div>
   </div>
 
-  <hr class="mb-5">
+  <%= render "admin/form_actions", cancel_url: [:admin, :articles] %>
 
+  <div class="row mb-5">
+    <div class="col-12 col-md-7">
+      <%= render "admin/articles/form/appearance", form: form %>
+    </div>
 
+    <div class="col-12 col-md-5">
+      <%= render "admin/articles/form/syndication", form: form %>
+    </div>
+  </div>
 
+  <%= render "admin/form_actions", cancel_url: [:admin, :articles] %>
 <% end %>

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <div class="row">
+  <div class="row mb-5">
     <div class="col-12 col-md-7">
       <%= tag.div dir: html_dir do %>
         <%= render "admin/label_and_area_form_group", form: form, attr: :content, rows: 10 %>
@@ -39,6 +39,20 @@
         <%= render "admin/label_and_area_form_group", form: form, attr: :notes, rows: 10 %>
         <%= render "admin/articles/notes_note" %>
       <% end %>
+    </div>
+  </div>
+
+  <hr class="mb-5">
+
+  <div class="row mb-5">
+    <div class="col-12 col-md-7">
+      <%= render "admin/articles/form/published_at", form: form %>
+    </div>
+
+    <div class="col-12 col-md-5">
+      <%= render "admin/articles/form/short_url", form: form %>
+      <%#= render "admin/articles/form/featured_status", form: form, klass: :article %>
+      <%#= render "admin/articles/form/publication_status", form: form %>
     </div>
   </div>
 <% end %>

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -51,8 +51,26 @@
 
     <div class="col-12 col-md-5">
       <%= render "admin/articles/form/short_url", form: form %>
-      <%#= render "admin/articles/form/featured_status", form: form, klass: :article %>
-      <%#= render "admin/articles/form/publication_status", form: form %>
+      <%= render "admin/articles/form/featured_status", form: form, klass: :article %>
+      <%= render "admin/articles/form/publication_status", form: form %>
     </div>
   </div>
+
+  <hr class="mb-5">
+
+  <div class="row mb-5">
+    <div class="col-12 col-md-7">
+      <%= render "admin/articles/form/tags", form: form %>
+      <%= render "admin/articles/form/localization", form: form %>
+    </div>
+
+    <div class="col-12 col-md-5">
+      <%= render "admin/articles/form/categories", form: form %>
+    </div>
+  </div>
+
+  <hr class="mb-5">
+
+
+
 <% end %>

--- a/app/views/admin/articles/_form.html.erb
+++ b/app/views/admin/articles/_form.html.erb
@@ -9,54 +9,36 @@
   <% end %>
 </nav>
 
-<%= form_with model: [:admin, @article], id: "article-form", class: "row" do |form| %>
+<%= form_with model: [:admin, @article], id: "article-form" do |form| %>
   <%# For nested Articles, a la live blogs %>
   <%= form.hidden_field :collection_id, value: @collection&.id %>
 
-  <div class="col-12">
-    <%= render "admin/form_errors", thing: @article %>
+  <%= render "admin/form_errors", thing: @article %>
+
+  <div class="row">
+    <div class="col-12 col-md-7">
+      <%= render "admin/label_and_field_form_group", form: form, attr: :title %>
+      <%= render "admin/label_and_field_form_group", form: form, attr: :subtitle %>
+    </div>
+
+    <div class="col-12 col-md-5">
+      <%= render "admin/articles/upload_word_doc", form: form %>
+    </div>
   </div>
 
-  <section class="col-12 col-md-9">
-    <%= render "admin/label_and_field_form_group", form: form, attr: :title %>
-    <%= render "admin/label_and_field_form_group", form: form, attr: :subtitle %>
+  <div class="row">
+    <div class="col-12 col-md-7">
+      <%= tag.div dir: html_dir do %>
+        <%= render "admin/label_and_area_form_group", form: form, attr: :content, rows: 10 %>
+        <%= render "admin/articles/content_note" %>
+      <% end %>
+    </div>
 
-    <fieldset class="card mb-3">
-      <div class="card-body">
-        <%= form.label :word_doc, "Upload a Word Doc file", class: "card-title m-0 form-label" %>
-
-        <p class="card-text form-text text-muted">
-          An uploaded <code>.docx</code> file will get converted to Markdown and used in the <code>content</code> textarea, over-writing any content that is already there.
-          <b>ONLY .docx files will work!</b>
-        </p>
-
-        <%= form.file_field :word_doc, class: "form-control" %>
-      </div>
-    </fieldset>
-
-    <%= tag.div dir: html_dir do %>
-      <%= render "admin/label_and_area_form_group", form: form, attr: :content, rows: 10 %>
-      <%= render "admin/articles/content_note", form: form %>
-    <% end %>
-
-    <%= render "admin/form_actions", cancel_url: [:admin, :articles] %>
-
-    <%= render "admin/articles/form/syndication", form: form %>
-    <%= render "admin/articles/form/appearance", form: form %>
-
-    <%= render "admin/form_actions", cancel_url: [:admin, :articles] %>
-  </section>
-
-  <aside class="col-12 col-md-3">
-    <%= render "admin/articles/form/featured_status", form: form, klass: :article %>
-    <%= render "admin/articles/form/publication_status", form: form %>
-    <%= render "admin/articles/form/published_at", form: form %>
-
-    <%= render "admin/articles/form/categories", form: form %>
-    <%= render "admin/articles/form/tags", form: form %>
-    <%= render "admin/articles/form/short_url", form: form %>
-    <%= render "admin/articles/form/localization", form: form %>
-
-    <%= render "admin/form_actions", cancel_url: [:admin, :articles] %>
-  </aside>
+    <div class="col-12 col-md-5">
+      <%= tag.div dir: html_dir do %>
+        <%= render "admin/label_and_area_form_group", form: form, attr: :notes, rows: 10 %>
+        <%= render "admin/articles/notes_note" %>
+      <% end %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/admin/articles/_notes_note.html.erb
+++ b/app/views/admin/articles/_notes_note.html.erb
@@ -1,0 +1,5 @@
+<p class="form-text text-muted">
+  Include all footnotes/sidenotes here.
+  The references to them still need to go in the <code>content</code> as <code>[^1]</code> etc.
+  But the notes themselves go here with <code>[^1:]</code> etc.
+</p>

--- a/app/views/admin/articles/_notes_note.html.erb
+++ b/app/views/admin/articles/_notes_note.html.erb
@@ -1,5 +1,5 @@
 <p class="form-text text-muted">
   Include all footnotes/sidenotes here.
   The references to them still need to go in the <code>content</code> as <code>[^1]</code> etc.
-  But the notes themselves go here with <code>[^1:]</code> etc.
+  But the notes themselves go here with <code>[^1]:</code> etc.
 </p>

--- a/app/views/admin/articles/_upload_word_doc.html.erb
+++ b/app/views/admin/articles/_upload_word_doc.html.erb
@@ -1,0 +1,13 @@
+<%= form.label :word_doc, "Upload a Word Doc file", class: "form-label" %>
+
+<fieldset class="card mb-3">
+  <div class="card-body">
+
+    <p class="card-text form-text text-muted">
+      An uploaded <code>.docx</code> file will get converted to Markdown and used in the <code>content</code> textarea, over-writing any content that is already there.
+      <b>ONLY .docx files will work!</b>
+    </p>
+
+    <%= form.file_field :word_doc, class: "form-control" %>
+  </div>
+</fieldset>

--- a/app/views/admin/articles/form/_appearance.html.erb
+++ b/app/views/admin/articles/form/_appearance.html.erb
@@ -6,12 +6,13 @@
     <p class="form-text text-muted">
       This is the large image that will be front and center on the <i>Article</i> page,
       on the homepage and when syndicated to other sites. Preferred size:
-      <code>2000px wide</code> by about <code>1000px tall or more</code>.
+      <code>2000px wide</code> by about <code>1000px tall</code> (or taller).
     </p>
 
     <%= render "admin/label_and_area_form_group", form: form, attr: :image_description %>
     <p class="form-text text-muted">
       This is used for the <code>&lt;img&gt;</code>’s <code>alt</code> text.
+      And will be displayed underneath the header image in the redesign of the site.
     </p>
 
     <% unless @collection.present? %>

--- a/app/views/admin/articles/form/_featured_status.html.erb
+++ b/app/views/admin/articles/form/_featured_status.html.erb
@@ -1,9 +1,14 @@
-<div id="featured_status" class="mb-3 visually-hidden sr-only">
-  <%= form.label :featured_status, "Feature this on homepage?", class: "form-label" %><br>
+<div class="card mb-3 bg-light visually-hiddenXsr-only">
+  <div class="card-body">
+    <div id="featured_status">
+      <%= form.label :featured_status, "Feature this #{klass} on the homepage?", class: "form-label mb-0" %><br>
+      <p class="form-text text-muted">In the <i>Ex-Workers’ Collection</i></p>
 
-  <%= form.radio_button :featured_status, false, class: "btn-check" %>
-  <%= form.label :featured_status_false, 'Not featured', for: "#{klass}_featured_status_false", class: "btn btn-outline-secondary" %>
+      <%= form.radio_button :featured_status, false, class: "btn-check" %>
+      <%= form.label :featured_status_false, 'Not featured', for: "#{klass}_featured_status_false", class: "btn btn-outline-secondary" %>
 
-  <%= form.radio_button :featured_status, true, class: "btn-check" %>
-  <%= form.label :featured_status_true, 'Featured', for: "#{klass}_featured_status_true", class: "btn btn-outline-primary" %>
-</div><!-- #featured_status -->
+      <%= form.radio_button :featured_status, true, class: "btn-check" %>
+      <%= form.label :featured_status_true, 'Featured', for: "#{klass}_featured_status_true", class: "btn btn-outline-primary" %>
+    </div><!-- #featured_status -->
+  </div>
+</div>

--- a/app/views/admin/articles/form/_published_at.html.erb
+++ b/app/views/admin/articles/form/_published_at.html.erb
@@ -1,16 +1,18 @@
 <div id="datetime">
-  <% if @article.draft? %>
-    <%= render "admin/datetime_group", form: form, post: @article, type: :article %>
+  <%= render "admin/datetime_group", form: form, post: @article, type: :article %>
 
+  <% if @article.draft? %>
     <p class="m-0 fw-bold">To Future Publish…</p>
     <p>
       Set a date and time above, then save this form.
-      But don’t click the <b><code>Publish NOW!</code></b> button.
+      <% if Current.user.can_publish? && true %>
+        But don’t click the <b><code>Publish NOW!</code></b> button.
+
+        <hr>
+      <% end %>
     </p>
 
-    <hr>
-
-    <% if Current.user.can_publish? %>
+    <% if Current.user.can_publish? && true %>
       <p class="m-0 fw-bold">To Publish Now…</p>
 
       <p>
@@ -19,12 +21,9 @@
         show up in the homepage feed.
       </p>
 
-      <%= form.submit "Publish NOW!", name: 'publish_now', id: "publish-now", class: "btn btn-warning btn-sm" %>
+      <div class="text-end">
+        <%= form.submit "Publish NOW!", name: 'publish_now', id: "publish-now", class: "btn btn-warning btn-sm" %>
+      </div>
     <% end %>
-
-    <hr>
-
-  <% else %>
-    <%= render "admin/datetime_group", form: form, post: @article, type: :article %>
   <% end %>
 </div><!-- #datetime -->

--- a/app/views/admin/articles/form/_published_at.html.erb
+++ b/app/views/admin/articles/form/_published_at.html.erb
@@ -5,14 +5,14 @@
     <p class="m-0 fw-bold">To Future Publish…</p>
     <p>
       Set a date and time above, then save this form.
-      <% if Current.user.can_publish? && true %>
+      <% if Current.user.can_publish? %>
         But don’t click the <b><code>Publish NOW!</code></b> button.
 
         <hr>
       <% end %>
     </p>
 
-    <% if Current.user.can_publish? && true %>
+    <% if Current.user.can_publish? %>
       <p class="m-0 fw-bold">To Publish Now…</p>
 
       <p>

--- a/app/views/admin/articles/form/_syndication.html.erb
+++ b/app/views/admin/articles/form/_syndication.html.erb
@@ -2,6 +2,7 @@
   <fieldset>
     <legend>Syndication</legend>
 
+    <% if false %>
     <div class="mb-3">
       <%= form.label :tweet, class: "form-label" %>
       <%= form.text_area :tweet, class: "form-control form-control-lg", data: { 'max-length': '250', 'feedback-box': 'tweet-length' }, rows: 3 %>
@@ -11,10 +12,11 @@
         Used for syndicated tweet for this Article.
       </p>
     </div>
+    <% end %>
 
     <div class="mb-3">
       <%= form.label :summary, class: "form-label" %>
-      <%= form.text_area :summary, class: "form-control form-control-lg", data: { 'max-length': '150', 'feedback-box': 'summary-length' }, rows: 3 %>
+      <%= form.text_area :summary, class: "form-control form-control-lg", data: { 'max-length': '150', 'feedback-box': 'summary-length' }, rows: 5 %>
       <div id="summary-length">0</div>
       <p class="form-text text-muted">
         Maximum 150 characters.

--- a/app/views/admin/articles/form/_tags.html.erb
+++ b/app/views/admin/articles/form/_tags.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-3 mt-3">
+<div class="mb-3">
   <%= form.label :tags, "Tags", class: "form-label" %>
   <%= text_field_tag :tags, @article.tags.map(&:name).join(", "), class: "form-control form-control-lg" %>
   <p class="form-text text-muted">Comma separated. For example, <em>dogs, cats, etc</em>.</p>

--- a/db/migrate/20220216024113_add_notes_to_articles.rb
+++ b/db/migrate/20220216024113_add_notes_to_articles.rb
@@ -1,0 +1,5 @@
+class AddNotesToArticles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :articles, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,6 @@
 
 ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -20,7 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -32,7 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum"
-    t.datetime "created_at", precision: nil, null: false
+    t.datetime "created_at", null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -55,12 +54,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "draft_code"
-    t.datetime "published_at", precision: nil
+    t.datetime "published_at"
     t.string "year"
     t.string "month"
     t.string "day"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "collection_id"
     t.string "short_path"
     t.text "image_mobile"
@@ -71,7 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.integer "canonical_id"
     t.text "word_doc"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at", precision: nil
+    t.datetime "featured_at"
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.text "notes"
@@ -91,7 +90,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "series"
-    t.datetime "published_at", precision: nil
+    t.datetime "published_at"
     t.integer "price_in_cents"
     t.string "height"
     t.string "width"
@@ -109,8 +108,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.text "cover_style"
     t.text "binding_style"
     t.text "table_of_contents"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "back_image_present", default: false
     t.boolean "front_image_present", default: false
     t.boolean "lite_download_present", default: false
@@ -127,7 +126,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at", precision: nil
+    t.datetime "featured_at"
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_books_on_canonical_id"
@@ -136,22 +135,22 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
   create_table "categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "slug"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "categorizations", id: :serial, force: :cascade do |t|
     t.integer "category_id"
     t.integer "article_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "definitions", force: :cascade do |t|
     t.string "title"
     t.text "content"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.string "subtitle"
@@ -159,8 +158,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "draft_code"
     t.string "slug"
     t.integer "publication_status"
-    t.datetime "published_at", precision: nil
-    t.datetime "featured_at", precision: nil
+    t.datetime "published_at"
+    t.datetime "featured_at"
     t.boolean "featured_status", default: false
     t.index ["canonical_id"], name: "index_definitions_on_canonical_id"
   end
@@ -181,9 +180,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "duration"
     t.string "audio_type", default: "audio/mpeg"
     t.string "tags"
-    t.datetime "published_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "slug"
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.string "episode_number"
@@ -205,7 +204,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "series"
-    t.datetime "published_at", precision: nil
+    t.datetime "published_at"
     t.integer "price_in_cents"
     t.string "height"
     t.string "width"
@@ -241,7 +240,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at", precision: nil
+    t.datetime "featured_at"
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_issues_on_canonical_id"
@@ -251,10 +250,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "title"
     t.string "subtitle"
     t.text "description"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "slug"
-    t.datetime "published_at", precision: nil
+    t.datetime "published_at"
     t.integer "publication_status", default: 0, null: false
     t.text "buy_url"
     t.text "content"
@@ -272,8 +271,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "abbreviation"
     t.string "name_in_english"
     t.string "name"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "language_direction", default: 0
     t.string "slug"
     t.integer "articles_count", default: 0
@@ -285,10 +284,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "subtitle"
     t.text "description"
     t.string "content_format"
-    t.datetime "published_at", precision: nil
+    t.datetime "published_at"
     t.text "summary"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
@@ -311,9 +310,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "draft_code"
-    t.datetime "published_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.integer "publication_status", default: 0, null: false
     t.string "locale", default: "en"
@@ -339,8 +338,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.text "itunes_url"
     t.text "overcast_url"
     t.text "pocketcasts_url"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "episode_prefix"
     t.string "locale", default: "en"
     t.integer "canonical_id"
@@ -360,12 +359,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.text "slug"
     t.string "height"
     t.string "width"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "depth"
     t.string "front_image_format", default: "jpg"
     t.string "back_image_format", default: "jpg"
-    t.datetime "published_at", precision: nil
+    t.datetime "published_at"
     t.boolean "front_color_image_present"
     t.boolean "front_black_and_white_image_present"
     t.boolean "back_color_image_present"
@@ -378,7 +377,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at", precision: nil
+    t.datetime "featured_at"
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_posters_on_canonical_id"
@@ -388,8 +387,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "source_path"
     t.string "target_path"
     t.boolean "temporary"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "article_id"
   end
 
@@ -409,7 +408,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "depth"
     t.string "front_image_format", default: "jpg"
     t.string "back_image_format", default: "jpg"
-    t.datetime "published_at", precision: nil
+    t.datetime "published_at"
     t.boolean "front_color_image_present"
     t.boolean "front_black_and_white_image_present"
     t.boolean "back_color_image_present"
@@ -419,12 +418,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.boolean "back_color_download_present"
     t.boolean "back_black_and_white_download_present"
     t.integer "publication_status", default: 0, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at", precision: nil
+    t.datetime "featured_at"
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_stickers_on_canonical_id"
@@ -433,22 +432,22 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
   create_table "support_sessions", force: :cascade do |t|
     t.string "stripe_customer_id"
     t.string "token"
-    t.datetime "expires_at", precision: nil
+    t.datetime "expires_at"
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|
     t.integer "tag_id"
     t.integer "taggable_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "taggable_type"
   end
 
   create_table "tags", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "slug"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.index ["canonical_id"], name: "index_tags_on_canonical_id"
@@ -458,8 +457,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "username"
     t.string "password_digest"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "role", default: 0, null: false
   end
 
@@ -476,12 +475,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "quality"
     t.string "duration"
     t.string "vimeo_id"
-    t.datetime "published_at", precision: nil
+    t.datetime "published_at"
     t.string "year"
     t.string "month"
     t.string "day"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.integer "publication_status", default: 0, null: false
     t.string "locale", default: "en"
@@ -501,7 +500,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "series"
-    t.datetime "published_at", precision: nil
+    t.datetime "published_at"
     t.integer "price_in_cents"
     t.string "height"
     t.string "width"
@@ -532,12 +531,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
     t.boolean "screen_single_page_view_download_present"
     t.boolean "screen_two_page_view_download_present"
     t.integer "publication_status", default: 0, null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at", precision: nil
+    t.datetime "featured_at"
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_zines_on_canonical_id"
@@ -546,11 +545,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 
-  create_view "pg_stat_statements_info", sql_definition: <<-SQL
-      SELECT pg_stat_statements_info.dealloc,
-      pg_stat_statements_info.stats_reset
-     FROM pg_stat_statements_info() pg_stat_statements_info(dealloc, stats_reset);
-  SQL
   create_view "search_results", materialized: true, sql_definition: <<-SQL
       SELECT a.searchable_id,
       a.searchable_type,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_20_010100) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_02_16_024113) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -20,7 +20,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "record_type", null: false
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.text "metadata"
     t.bigint "byte_size", null: false
     t.string "checksum"
-    t.datetime "created_at", null: false
+    t.datetime "created_at", precision: nil, null: false
     t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
@@ -55,12 +55,12 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "draft_code"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.string "year"
     t.string "month"
     t.string "day"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "collection_id"
     t.string "short_path"
     t.text "image_mobile"
@@ -71,9 +71,10 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.integer "canonical_id"
     t.text "word_doc"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at"
+    t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
+    t.text "notes"
     t.index ["canonical_id"], name: "index_articles_on_canonical_id"
     t.index ["collection_id"], name: "index_articles_on_collection_id"
   end
@@ -90,7 +91,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "series"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.integer "price_in_cents"
     t.string "height"
     t.string "width"
@@ -108,8 +109,8 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.text "cover_style"
     t.text "binding_style"
     t.text "table_of_contents"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "back_image_present", default: false
     t.boolean "front_image_present", default: false
     t.boolean "lite_download_present", default: false
@@ -126,7 +127,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at"
+    t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_books_on_canonical_id"
@@ -135,22 +136,22 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
   create_table "categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "slug"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "categorizations", id: :serial, force: :cascade do |t|
     t.integer "category_id"
     t.integer "article_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
   end
 
   create_table "definitions", force: :cascade do |t|
     t.string "title"
     t.text "content"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.string "subtitle"
@@ -158,8 +159,8 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "draft_code"
     t.string "slug"
     t.integer "publication_status"
-    t.datetime "published_at"
-    t.datetime "featured_at"
+    t.datetime "published_at", precision: nil
+    t.datetime "featured_at", precision: nil
     t.boolean "featured_status", default: false
     t.index ["canonical_id"], name: "index_definitions_on_canonical_id"
   end
@@ -180,9 +181,9 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "duration"
     t.string "audio_type", default: "audio/mpeg"
     t.string "tags"
-    t.datetime "published_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "published_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "slug"
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.string "episode_number"
@@ -204,7 +205,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "series"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.integer "price_in_cents"
     t.string "height"
     t.string "width"
@@ -240,7 +241,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at"
+    t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_issues_on_canonical_id"
@@ -250,10 +251,10 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "title"
     t.string "subtitle"
     t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "slug"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.integer "publication_status", default: 0, null: false
     t.text "buy_url"
     t.text "content"
@@ -271,8 +272,8 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "abbreviation"
     t.string "name_in_english"
     t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "language_direction", default: 0
     t.string "slug"
     t.integer "articles_count", default: 0
@@ -284,10 +285,10 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "subtitle"
     t.text "description"
     t.string "content_format"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.text "summary"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
@@ -310,9 +311,9 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "draft_code"
-    t.datetime "published_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "published_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.integer "publication_status", default: 0, null: false
     t.string "locale", default: "en"
@@ -338,8 +339,8 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.text "itunes_url"
     t.text "overcast_url"
     t.text "pocketcasts_url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "episode_prefix"
     t.string "locale", default: "en"
     t.integer "canonical_id"
@@ -359,12 +360,12 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.text "slug"
     t.string "height"
     t.string "width"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "depth"
     t.string "front_image_format", default: "jpg"
     t.string "back_image_format", default: "jpg"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.boolean "front_color_image_present"
     t.boolean "front_black_and_white_image_present"
     t.boolean "back_color_image_present"
@@ -377,7 +378,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at"
+    t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_posters_on_canonical_id"
@@ -387,8 +388,8 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "source_path"
     t.string "target_path"
     t.boolean "temporary"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "article_id"
   end
 
@@ -408,7 +409,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "depth"
     t.string "front_image_format", default: "jpg"
     t.string "back_image_format", default: "jpg"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.boolean "front_color_image_present"
     t.boolean "front_black_and_white_image_present"
     t.boolean "back_color_image_present"
@@ -418,12 +419,12 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.boolean "back_color_download_present"
     t.boolean "back_black_and_white_download_present"
     t.integer "publication_status", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at"
+    t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_stickers_on_canonical_id"
@@ -432,22 +433,22 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
   create_table "support_sessions", force: :cascade do |t|
     t.string "stripe_customer_id"
     t.string "token"
-    t.datetime "expires_at"
+    t.datetime "expires_at", precision: nil
   end
 
   create_table "taggings", id: :serial, force: :cascade do |t|
     t.integer "tag_id"
     t.integer "taggable_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "taggable_type"
   end
 
   create_table "tags", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "slug"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.index ["canonical_id"], name: "index_tags_on_canonical_id"
@@ -457,8 +458,8 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "username"
     t.string "password_digest"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "role", default: 0, null: false
   end
 
@@ -475,12 +476,12 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "quality"
     t.string "duration"
     t.string "vimeo_id"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.string "year"
     t.string "month"
     t.string "day"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.integer "publication_status", default: 0, null: false
     t.string "locale", default: "en"
@@ -500,7 +501,7 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.string "content_format", default: "kramdown"
     t.string "slug"
     t.string "series"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.integer "price_in_cents"
     t.string "height"
     t.string "width"
@@ -531,12 +532,12 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
     t.boolean "screen_single_page_view_download_present"
     t.boolean "screen_two_page_view_download_present"
     t.integer "publication_status", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
-    t.datetime "featured_at"
+    t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.index ["canonical_id"], name: "index_zines_on_canonical_id"
@@ -545,6 +546,11 @@ ActiveRecord::Schema.define(version: 2021_12_20_010100) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 
+  create_view "pg_stat_statements_info", sql_definition: <<-SQL
+      SELECT pg_stat_statements_info.dealloc,
+      pg_stat_statements_info.stats_reset
+     FROM pg_stat_statements_info() pg_stat_statements_info(dealloc, stats_reset);
+  SQL
   create_view "search_results", materialized: true, sql_definition: <<-SQL
       SELECT a.searchable_id,
       a.searchable_type,


### PR DESCRIPTION
This PR adds a `notes` field to the Article model and admin form.

It also re-arranges the admin/articles form to keep `notes` next to `content`.

The notes and content fields get combined by the `Article#content_and_notes` method which is what is used by `Article#content_rendered` method.

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/4361/154357365-c2def61f-0a7c-45a2-8b4b-0056fa423c2a.png">
