### PR TITLE
Move archive page title to the locale yml file

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -95,10 +95,10 @@ class ApplicationController < ActionController::Base
     page_keys.each do |key|
       piece = I18n.t("page_titles.#{namespace}.#{key}")
 
-      piece = if piece.include?('translation missing')
-                word_spaced_pieces = Array(key).join(' ')
-                String(word_spaced_pieces).humanize.titleize
-              end
+      if piece.include?('translation missing')
+        word_spaced_pieces = Array(key).join(' ')
+        piece = String(word_spaced_pieces).humanize.titleize
+      end
 
       pieces << piece
     end

--- a/app/controllers/article_archives_controller.rb
+++ b/app/controllers/article_archives_controller.rb
@@ -2,7 +2,7 @@ class ArticleArchivesController < ApplicationController
   def index
     @html_id = 'page'
     @body_id = 'article-archives'
-    @title   = PageTitle.new 'Articles'
+    @title   = PageTitle.new title_for :archives
 
     @article_archive = ArticleArchive.new(year:  params[:year],
                                           month: params[:month],

--- a/app/views/2017/article_archives/index.html.erb
+++ b/app/views/2017/article_archives/index.html.erb
@@ -4,7 +4,7 @@
 
 <header>
   <h1>
-    <%= link_to "Archives", [:library] %>
+    <%= link_to @title.text, [:library] %>
   </h1>
 
   <h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,6 +194,8 @@ en:
       work: Work
     definitions:
       index: Definitions
+    archives:
+      index: Archives
 
   podcast:
     latest_episode: Latest Episode

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -192,6 +192,8 @@ fr:
       off_the_map: Off the Map
       recipes_for_disaster: Recipes for Disaster
       work: Work
+    archives:
+      index: Archives
 
   podcast:
     latest_episode: Dernier épisode


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![House cleaning gif](https://media.giphy.com/media/FAeLdbV2IwkBDOl9jM/giphy.gif)

# What are the relevant GitHub issues?

resolves `[#1445]`

# What does this pull request do?

This PR move archive page title to the locale yml file

There was a bug in `title_for` and if you were not entering in the if,
`piece` was set to nil. With the condition write this way, it fixes the
issue.

# How should this be manually tested?

When new locales are gonna be translated, the title will change on different lang subdomain.
