### PR TITLE
Add missing configuration for vi. subdomain

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ module Crimethinc
     config.i18n.default_locale = :en
 
     # Allowed list locales available for the application
-    subdomain_locales = %i[ar bn cs cz da de dv en es fa fi fr gr he id it ja ko nl no pl pt ru sh sv th tl tr uk zh]
+    subdomain_locales = %i[ar bn cs cz da de dv en es fa fi fr gr he id it ja ko nl no pl pt ru sh sv th tl tr uk vi zh]
     path_ltr_locales  = %i[
       english
       espanol

--- a/config/locales/vi/2020.yml
+++ b/config/locales/vi/2020.yml
@@ -11,7 +11,7 @@
 vi:
   '2020':
     theme: '2020'
-    name: English
+    name: Tiếng Việt
     language_direction: ltr
     site_name: CrimethInc.
     site_author: CrimethInc. Ex-Workers Collective

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -70,3 +70,17 @@ Duplicate this folder:
 Rename them to match the locale abbreviation:
 
 - `config/locales/pages/cs`
+
+### Add the abbreviation to array of allowed subdomains
+
+In the application config file:
+
+`config/application.rb`
+
+Add the locale abbreviation to the `subdomain_locales` array.
+
+Before:
+`subdomain_locales = subdomain_locales = %i[ar bn … zh]`
+
+After:
+`subdomain_locales = subdomain_locales = %i[ar bn cs … zh]`


### PR DESCRIPTION
Oops! I missed on important bit previous pr https://github.com/crimethinc/website/pull/2441.

We need to explicitly add the locale's abbreviation to the list of allowed subdomains.