### PR TITLE
Update sitemap.rb

### DIFF
--- a/app/middlewares/rack/clean_path.rb
+++ b/app/middlewares/rack/clean_path.rb
@@ -46,11 +46,11 @@ module Rack
       # request
       @req = Rack::Request.new(env)
 
+      # no-op for root route, assets and sitemap.xml
+      return @app.call(env) if exit_early?
+
       # source path
       @path = @req.path
-
-      # no-op for root route and assets
-      return @app.call(env) if exit_early?
 
       unsmoosh_path_from_unicode_tweet_text!
       make_subsitutions!

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -70,7 +70,7 @@ SitemapGenerator::Sitemap.create(default_host: 'https://crimethinc.com', compres
     add "/#{year}/"
   end
 
-  [Book, Episode, Page, Podcast, Video, Tools].each do |model|
+  [Book, Episode, Page, Podcast, Video, Zine, Journal, Issue, Episode, Poster, Sticker, Logo].each do |model|
     model.find_each do |page|
       add page.path, lastmod: page.updated_at
     end

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -27,22 +27,28 @@ SitemapGenerator::Sitemap.create(default_host: 'https://crimethinc.com', compres
   static_paths = [
     '/about/',
     '/arts/submission-guidelines',
-    '/books/into-libraries/', '/books/lit-kit/',
+    '/books/into-libraries/',
+    '/books/lit-kit/',
     '/categories/',
     '/faq/',
+    'games/j20',
     '/get/',
     '/kickstarter/2017/',
     '/listen/',
     '/library/',
     '/read/',
-    '/rt/', '/rt/archives/',
+    '/rt/',
+    '/rt/archives/',
     '/start/',
-    '/store/', '/store/audio/', '/store/added/',
+    '/steal-something-from-work-day',
+    '/store/',
+    '/store/audio/',
+    '/store/added/',
     '/tce/',
     '/tools/',
     '/watch/'
   ]
-  tce_languages = %w[czech deutsch espanol polski portugues quebecois slovenscina slovensko]
+  tce_languages = %w[czech deutsch espanol espanol-america-latina polski portugues quebecois slovenscina slovensko فارسی 日本語 한국어 lietuvos portugues ภาษาไทย]
 
   tce_languages.each do |lang|
     static_paths.push("/tce/#{lang}/", "/tce/#{lang}/get/")
@@ -60,11 +66,11 @@ SitemapGenerator::Sitemap.create(default_host: 'https://crimethinc.com', compres
     add "/categories/#{category.slug}/"
   end
 
-  [2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009, 2008, 2007, 2006, 2005, 2004, 2003, 2002, 2001, 2000, 1997, 1996].each do |year|
+  [1996..Time.zone.today.year].to_a.each do |year|
     add "/#{year}/"
   end
 
-  [Book, Episode, Page, Podcast, Video].each do |model|
+  [Book, Episode, Page, Podcast, Video, Tools].each do |model|
     model.find_each do |page|
       add page.path, lastmod: page.updated_at
     end

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,1 +1,0 @@
-<sitemap>test</sitemap>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,1 @@
+<sitemap>test</sitemap>

--- a/spec/requests/clean_paths_spec.rb
+++ b/spec/requests/clean_paths_spec.rb
@@ -1,4 +1,6 @@
 require 'rails_helper'
+require 'rake'
+Rails.application.load_tasks
 
 RSpec.describe 'Rack::CleanPath', type: :request do
   it 'redirects according to path clean up rules' do
@@ -14,10 +16,14 @@ RSpec.describe 'Rack::CleanPath', type: :request do
   end
 
   it 'do not strip .xml extension for sitemap.xml' do
-    get 'http://example.com/sitemap.xml'
+    Rake::Task['sitemap:refresh:no_ping'].invoke
+
+    get 'http://example.com/sitemap.xml.gz'
 
     expect(response.status).to eq(200)
     expect(response.header['Location']).to be_nil
-    expect(response.body).to eq('<sitemap>test</sitemap>')
+    expect(response.body).not_to be_empty
+
+    Rake::Task['sitemap:clean'].invoke
   end
 end

--- a/spec/requests/clean_paths_spec.rb
+++ b/spec/requests/clean_paths_spec.rb
@@ -12,4 +12,12 @@ RSpec.describe 'Rack::CleanPath', type: :request do
 
     expect(response.header['Location']).to eq('/about/faq?test=true')
   end
+
+  it 'do not strip .xml extension for sitemap.xml' do
+    get 'http://example.com/sitemap.xml'
+
+    expect(response.status).to eq(200)
+    expect(response.header['Location']).to eq(nil)
+    expect(response.body).to eq('<sitemap>test</sitemap>')
+  end
 end

--- a/spec/requests/clean_paths_spec.rb
+++ b/spec/requests/clean_paths_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Rack::CleanPath', type: :request do
     expect(response.header['Location']).to eq('/about/faq?test=true')
   end
 
-  it 'do not strip .xml extension for sitemap.xml' do
+  it 'does not strip .xml extension from sitemap.xml' do
     Rake::Task['sitemap:refresh:no_ping'].invoke
 
     get 'http://example.com/sitemap.xml.gz'

--- a/spec/requests/clean_paths_spec.rb
+++ b/spec/requests/clean_paths_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Rack::CleanPath', type: :request do
     get 'http://example.com/sitemap.xml'
 
     expect(response.status).to eq(200)
-    expect(response.header['Location']).to eq(nil)
+    expect(response.header['Location']).to be_nil
     expect(response.body).to eq('<sitemap>test</sitemap>')
   end
 end


### PR DESCRIPTION
# What does this pull request do?

I don't know why, but sitemap.xml is not redirected by our middleware. I
thought I'd ahve to add `|| @req.path == '/sitemap.xml'` to the
`exit_early?` method, but it's not the case.

To validate I add the `public/sitemap.xml` file and I validate the I got
the right content when I query `/sitemap.xml` and it works. The only
things to keep in mind is since I create a dummy `public/sitemap.xml`
file, we need to regenerate one every time we deploy the application.

To ensure the sitemap is generate, can I run the sitemap:clean and 
sitemap:refresh rake task in the postdeploy section of the app.json file?

# How should this be manually tested?

pinging /sitemap.xml shouldn't give you a 404.
