### PR TITLE
Add missing timestamps to Issues table

### DIFF
--- a/db/migrate/20220305063227_add_timestamps_to_issues.rb
+++ b/db/migrate/20220305063227_add_timestamps_to_issues.rb
@@ -1,0 +1,8 @@
+class AddTimestampsToIssues < ActiveRecord::Migration[7.0]
+  def change
+    change_table :issues, bulk: true do |t|
+      t.datetime :created_at, precision: nil
+      t.datetime :updated_at, precision: nil
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_25_090158) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_05_063227) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -246,6 +246,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_25_090158) do
     t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["canonical_id"], name: "index_issues_on_canonical_id"
   end
 


### PR DESCRIPTION
Oops. Somehow we don't have the timestamp fields on the issues table. Which mostly doesn't matter. But `.updated_at` is called in the `sitemap:refresh` rake task in #2444.