### PR TITLE
[I18n] Add page with RSS feeds of all of our languages 

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -8,6 +8,9 @@ class ArticlesController < ApplicationController
                        .page(params[:page])
                        .per(10)
 
+    locale = Locale.find_by(abbreviation: params[:lang])
+    @lang = locale.abbreviation if locale.present?
+
     render "#{Current.theme}/articles/index"
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -26,6 +26,14 @@ class PagesController < ApplicationController
     render "#{Current.theme}/pages/contact"
   end
 
+  def feeds
+    @title = PageTitle.new I18n.t('page_titles.about.rss_feeds')
+
+    @locales = Locale.unscoped.order(name_in_english: :asc)
+
+    render "#{Current.theme}/pages/feeds"
+  end
+
   def library
     @title = PageTitle.new I18n.t('page_titles.about.library')
 

--- a/app/views/2017/articles/index.atom.erb
+++ b/app/views/2017/articles/index.atom.erb
@@ -6,7 +6,7 @@
   <link rel="alternate" type="text/html" href="<%= strip_subdomain request.original_url.sub('/feed', '') %>" />
   <link rel="self" type="application/atom+xml" href="<%= strip_subdomain request.original_url %>" />
 
-  <title><%= page_title %></title>
+  <title><%= page_title %> <%= " : #{@lang.upcase} " if @lang.present? %></title>
   <subtitle><%= meta_title(nil) %></subtitle>
 
   <link href="./" />

--- a/app/views/2017/articles/index.atom.erb
+++ b/app/views/2017/articles/index.atom.erb
@@ -6,7 +6,7 @@
   <link rel="alternate" type="text/html" href="<%= strip_subdomain request.original_url.sub('/feed', '') %>" />
   <link rel="self" type="application/atom+xml" href="<%= strip_subdomain request.original_url %>" />
 
-  <title><%= page_title %> <%= " : #{@lang.upcase} " if @lang.present? %></title>
+  <title><%= page_title %><%= " : #{@lang.upcase} " if @lang.present? %></title>
   <subtitle><%= meta_title(nil) %></subtitle>
 
   <link href="./" />

--- a/app/views/2017/languages/show.html.erb
+++ b/app/views/2017/languages/show.html.erb
@@ -20,6 +20,12 @@
 
     <%= render_markdown t("views.languages.view_tools_in_locale", locale: @locale.abbreviation) %>
     <%= render_markdown t("views.languages.view_books_in_locale", locale: @locale.abbreviation) %>
+
+    <p>
+      <%= link_to [:feed, lang: @locale.abbreviation] do %>
+        <%= @locale.name %> RSS
+      <% end %>
+    </p>
   </div>
 </header>
 

--- a/app/views/2017/pages/feeds.html.erb
+++ b/app/views/2017/pages/feeds.html.erb
@@ -1,0 +1,30 @@
+<article id="page-feeds" class="h-entry">
+  <header>
+    <h1><%= t "feeds.title" %></h1>
+  </header>
+
+  <div class="intro">
+    <%= render_markdown t("feeds.intro") %>
+  </div>
+
+  <div class="e-content">
+
+    <% @locales.each do |locale| %>
+      <%
+        unicode_link = link_to locale.name,            [:feed, lang: locale.abbreviation.to_sym]
+        slug_link    = link_to locale.slug,            [:feed, lang: locale.abbreviation.to_sym]
+        english_link = link_to locale.name_in_english, [:feed, lang: locale.abbreviation.to_sym]
+      %>
+
+      <ul>
+        <li>
+          <%= english_link %>
+          <b><%= unicode_link %></b>
+          (<%= slug_link %>)
+          <small><%= number_with_delimiter locale.articles_count %></small>
+        </li>
+      </ul>
+    <% end %>
+
+  </div>
+</article>

--- a/app/views/2017/pages/feeds.html.erb
+++ b/app/views/2017/pages/feeds.html.erb
@@ -3,9 +3,12 @@
     <h1><%= t "feeds.title" %></h1>
   </header>
 
+  <%# TODO %>
+  <% if false %>
   <div class="intro">
     <%= render_markdown t("feeds.intro") %>
   </div>
+  <% end %>
 
   <div class="e-content">
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,7 @@ en:
       library: Online Reading Library
       store: Store
       post_order_success: Post-Order Glow
+      rss_feeds: RSS Feeds
       submission_guidelines: Submission Guidelines
       steal_something_from_work_day: Steal Something from Work Day
     search:

--- a/config/locales/en/feeds.yml
+++ b/config/locales/en/feeds.yml
@@ -1,0 +1,11 @@
+en:
+  feeds:
+    title: RSS Feeds
+
+    intro: |
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
   get 'drafts/articles/:draft_code/edit', controller: 'admin/articles', action: 'edit'
 
   # Articles Atom Feed
+  get 'feeds',             to: 'pages#feeds',                                  as: :feeds
   get 'feed(/:lang).json', to: 'articles#index', defaults: { format: 'json' }, as: :json_feed
   get 'feed(/:lang)',      to: 'articles#index', defaults: { format: 'atom' }, as: :feed
 


### PR DESCRIPTION
The actual language specific feeds were already built (by @astronaut-wannabe) in [October 2021](https://github.com/crimethinc/website/pull/2167). This PR just adds a page making them more visible and discoverable.

- If there are any published articles in a language then that language will show up in this list.
- The list is ordered by each language's name in English
- There's also now a link to a language's RSS feed in the banner on the `languages#show` page for each language

# Feeds page

<img width="1392" alt="Screen Shot 2022-03-06 at 9 33 56 PM" src="https://user-images.githubusercontent.com/4361/156974226-09bba658-f1ae-467e-b40a-40f5791d1490.png">

# RSS link in banner

<img width="1392" alt="Screen Shot 2022-03-06 at 9 34 41 PM" src="https://user-images.githubusercontent.com/4361/156974236-2265d123-0750-4985-b568-fb6b921ce8e7.png">
