### PR TITLE
Add route and admin button to download .docx of article

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,7 +28,7 @@ Layout/SpaceBeforeBrackets:
   Enabled: false
 
 Metrics/AbcSize:
-  Max: 72
+  Max: 74
 
 Metrics/BlockLength:
   Max: 99
@@ -42,7 +42,7 @@ Metrics/CyclomaticComplexity:
   Max: 13
 
 Metrics/MethodLength:
-  Max: 30
+  Max: 31
   Exclude:
     - 'db/migrate/*'
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -81,7 +81,30 @@ class ArticlesController < ApplicationController
       respond_to do |format|
         format.html     { render "#{Current.theme}/articles/show" }
         format.markdown { render "#{Current.theme}/articles/show" }
+        format.docx     { download_docx }
       end
     end
+  end
+
+  private
+
+  def download_docx
+    send_data generate_docx, filename: "#{@article.slug}.docx", type: docx_mimetype
+  end
+
+  def generate_docx
+    PandocRuby.new(content_without_embeds, from: :markdown, to: :docx).convert
+  end
+
+  def content_without_embeds
+    @article
+      .content
+      .gsub(/\[\[.+\]\]/, '')
+      .gsub("\r\n\r\n\r\n\r\n", "\r\n\r\n")
+      .gsub("\r\n\r\n\r\n", "\r\n\r\n")
+  end
+
+  def docx_mimetype
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
   end
 end

--- a/app/views/shared/_admin_header.html.erb
+++ b/app/views/shared/_admin_header.html.erb
@@ -10,10 +10,12 @@
     <%= link_to "Scroll to Site Top", "#header",  class: "button" %>
 
     <% if @editable.present? %>
-      <b><%= link_to "Edit #{@editable.class}", [:edit, :admin, @editable], class: "button button-buy" %></b>
+      <b><%= link_to "Edit #{@editable.class}", [:edit, :admin, @editable], class: "button" %></b>
     <% end %>
 
     <% if @article.present? %>
+      <%= link_to "Download .docx", "#{@article.path}.docx", class: "button" %>
+
       <%= render 'admin/translate_this', resource: @article %>
     <% end %>
   </nav>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -4,3 +4,4 @@
 # Mime::Type.register "text/richtext", :rtf
 
 Mime::Type.register 'text/markdown', :markdown
+Mime::Type.register 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', :docx

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
 
   # Article permalink
   # no (/:lang) since slug should encompass that
-  get ':year/:month/:day/:slug(/feed)',
+  get ':year/:month/:day/:slug(.:format)',
       to:          'articles#show',
       constraints: { year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ },
       as:          :article


### PR DESCRIPTION
# What does this pull request do?

Adds a route and a button (in admin/authed site header) to download a `.docx` version of an Article.
It has the `[[ … ]]` embeds stripped out of the content too.

# Is there any background context you want to provide for reviewers?

This was requested by zine makers because importing a `.docx` into InDesign is much easier that copy/pasting the Markdown or HTML.

<img width="807" alt="Screen Shot 2022-03-14 at 12 24 39 AM" src="https://user-images.githubusercontent.com/4361/158124351-4533c35c-93bf-4a83-9d3b-a0dba059851a.png">

