### PR TITLE
Refresh sitemap on deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-release: bundle exec rake db:migrate
+release: bundle exec rake db:migrate sitemap:refresh
 web: bundle exec puma -C config/puma.rb
 worker: RAILS_MAX_THREADS=${SIDEKIQ_RAILS_MAX_THREADS} bundle exec sidekiq -q default -q mailers -q active_storage_analysis -q active_storage_purge


### PR DESCRIPTION
Fixes #2458 

This PR run `sitemap:refresh` when we deploy the application. Maybe it'd be better to run day using a scheduler, but if we deploy often enough this could be alright!