### PR TITLE
Set the `actions/labeler@4.0.0` version

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/labeler
+      - name: Labeler
+        uses: actions/labeler@v4.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This pull request fixes the failing Labeler task that failed every time I merged a PR.

To not miss anything I also subscribe to the release of `actions/labeler` so I'll be able to bump the version when there will be a new release.