### PR TITLE
Add a workflow to automerge dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,0 +1,15 @@
+name: Automerge dependabot pull request
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2.3.1
+        with:
+          target: minor
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
If we want to do it all by ourselves, we should have an action that would run all the other tasks on the PR and when everything is passed, we could run the command to merge the PR automatically. Instead, I found an actions that do it for us, so we'll try it and if it doesn't work, then I'll write something to orchestrate and automerge dependabot stuff.

Fixes #2500 

**EDIT**

I add a if check to only run the action on PRs made by the dependabot bot, otherwise it emits a warning.