### PR TITLE
Remove dead code in rack_attack initializers

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,10 +1,4 @@
 if Rails.env.production?
-  # Only enable throttling if REDIS_URL is set
-  if ENV['REDIS_URL']
-    Redis.current = Redis.new(url: ENV['REDIS_URL'])
-    # Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(Redis.current)
-  end
-
   module Rack
     class Attack
       throttle('limit requests per IP', limit: 60, period: 1.minute) do |req|


### PR DESCRIPTION


# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/l2JefhuLRZWPnxF1m/giphy.gif)

# What are the relevant GitHub issues?

resolves #2460 

# What does this pull request do?

`Redis.current` has been deprecated ([src][0]). This resulted in us
getting a deprecation warning described in [issue #2460][1]

While looking into correcting that deprecation warning, we realized
that we actually stopped using redis as the cache backend in favor of
memcache ([commit][2])

Rack attack defaults to `Rails.cache` if present ([docs][3]), which we
set in the production config file [here][4].

So, this is the only place we call `Redis.current`, and we don't even
use it. Easy fix

[0]:https://github.com/redis/redis-rb/commit/9745e22db65ac294be51ed393b584c0f8b72ae98
[1]:https://github.com/crimethinc/website/issues/2460
[2]:https://github.com/crimethinc/website/commit/86df4c9f138226f452d3fe581d2cab4729d17135
[3]:https://github.com/rack/rack-attack/blob/b0be38334a3776c536bb5e54b2ce33fd38f8bf5c/README.md#cache-store-configuration
[4]:https://github.com/crimethinc/website/blob/61ef37baad2fe67385ba297b73a28bbda7bfe404/config/environments/production.rb#L23-L37

# How should this be manually tested?

Is rack attack still working in production?

