### PR TITLE
[articles][UI][print] Add some basic CSS for print-media

### DIFF
--- a/app/assets/stylesheets/2017/views/_article.scss
+++ b/app/assets/stylesheets/2017/views/_article.scss
@@ -464,4 +464,32 @@
       }
     }
   }
+
+  @media print {
+      .related-articles { display: none; }
+      footer#site-footer { display: none; }
+      .social { display: none; }
+      .site-header { display: none; }
+      #development-mode-banner { display: none; }
+      .categories { display: none !important; }
+      .localizations { display: none !important; }
+
+      // only safari supports currently
+      div:has(> ul.pagination) { display: none; }
+      ul.pagination { display: none; }
+
+      // hide videos as they render as a large blank space in print
+      .video-container { display: none; }
+
+      // make title and subtitle a lil bit bigger in print
+      .p-name .p-x-title { font-size: 5rem; }
+      .p-name .p-x-subtitle { font-size: 3rem; }
+
+      // Prevent images and blockquotes from spanning a page break
+      blockquote, figure, img {
+          break-inside: avoid;
+          max-height: 90vh;
+      }
+  }
+
 } /* #article */


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/l0MYDzlBdiocY3UNq/giphy.gif)

# What are the relevant GitHub issues?

related to https://github.com/crimethinc/website/issues/2345

# What does this pull request do?

In github [issue 2345][0], it was suggested that we add some css
specifically for `@media print` so that you can save and article to
PDF and have a reasonably good looking document.

I did a very quick initial try at this.

[0]:https://github.com/crimethinc/website/issues/2345

# How should this be manually tested?

[CrimethInc. And After the War? The Prospects for Social Struggles in Ukraine, Belarus, and Russia.pdf](https://github.com/crimethinc/website/files/8801011/CrimethInc.And.After.the.War.The.Prospects.for.Social.Struggles.in.Ukraine.Belarus.and.Russia.pdf)

I think [this article][1] is a good demo as it has a lot of element types in it, but the PDF ends up being over the GH filesize limits

[1]:https://crimethinc.com/2022/04/14/more-world-less-bank-an-oral-history-of-the-a16-demonstrations-against-global-capitalism

# Is there any background context you want to provide for reviewers?

### What I did

1. hid a bunch of web-specific things
    - header
    - footer
    - category tags and localization links
    - related articles
    - social media links
    - pagination links
    - video embeds
2. bumped up the font size of the article title and subtitle
3. Added css to prevent images and block-quotes from spanning page breaks
4. made the max-height of images `100vh`
    - again, to prevent an image from spanning page breaks

### What I'd still like to do
1. make twitter embeds look nice
    - I left twitter embeds in place, as they still render as a link, but it would be nice to have them actually display. To do this would require us actually fetching twitter content and rendering it in our html. I think that would be neat, but it requires some significant dev work
2. Move The publication date to the top of the page
    - This could be done with pure css if articles had grid layouts
    - This could be done in erb by rendering a duplicate date element that is hidden in screen media, but visible on print media
3. For print maybe the title and subtitle should be above the header image?

# Acceptance Criteria
## These should be checked by the reviewers

- [X] This pull request does not cause the database export script to become out of sync with the db schema
