### PR TITLE
[article][UI] Move `published_on` to top of article

### DIFF
--- a/app/assets/stylesheets/2017/views/_article.scss
+++ b/app/assets/stylesheets/2017/views/_article.scss
@@ -62,6 +62,12 @@
         text-decoration: none;
       }
 
+      time {
+        margin: 0;
+        padding: 1em 0 0;
+        text-rendering: optimizeLegibility;
+      }
+
       .categories {
         padding: 4rem 0 1.5rem 0;
       }

--- a/app/views/2017/articles/_published_on.html.erb
+++ b/app/views/2017/articles/_published_on.html.erb
@@ -1,5 +1,5 @@
 <% linked ||= false %>
 
-<p class="screen-reader-only">
-  <%= render_themed "articles/published_on_time_tag", article: article, linked: linked %>
-</p>
+<%= render_themed "articles/published_on_time_tag",
+    article: article,
+    linked: linked %>

--- a/app/views/2017/articles/show.html.erb
+++ b/app/views/2017/articles/show.html.erb
@@ -14,10 +14,9 @@
       <%= render_themed "articles/image_media", article: @article, linked: false %>
 
       <div class="meta">
-        <%= render_themed "articles/titles", header: @article, linked: false %>
-
-        <%= render_themed "articles/categories", article: @article %>
-
+        <%= render_themed "articles/titles",        header:  @article, linked: false %>
+        <%= render_themed "articles/published_on",  article: @article, linked: true %>
+        <%= render_themed "articles/categories",    article: @article %>
         <%= render_themed "articles/localizations", article: @article %>
       </div>
 
@@ -32,7 +31,6 @@
 
     <footer>
       <%= render_themed "articles/share_on_social_networks", article: @article %>
-      <%= render_themed "articles/published_on",             article: @article, linked: true %>
       <%= render_themed "articles/categories",               article: @article %>
       <%= render_themed "articles/tags",                     article: @article %>
 


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![alt text](https://media.giphy.com/media/ffd0F6WNcRJMQ/giphy.gif)

# What are the relevant GitHub issues?

related to https://github.com/crimethinc/website/issues/2345

# What does this pull request do?

This commit modifies the articles layout/css to move the `published_on` element from the bottom of the page to the top

# How should this be manually tested?

- look at an article in staging

# Is there any background context you want to provide for reviewers?

We added some basic `@media print` for articles in [d369182a][0]. We
did this to make nicer PDFs when someone "prints to PDF"

While doing this, we considered moving the `published_on` date to the
top of the page in the print version, and settled on moving it up for
all media types

[0]:https://github.com/crimethinc/website/commit/d369182a82f61b9c07bfae8d3dc757ca2c11bbd1