### PR TITLE
Fix capybara

### DIFF
--- a/.github/workflows/tests_system.yml
+++ b/.github/workflows/tests_system.yml
@@ -4,7 +4,7 @@ name: Tests, System
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       postgres:


### PR DESCRIPTION
We were using `ubuntu-latest` as value for the `runs-on` attribute of our GitHub actions. GitHub was in the process of rolling out their latest version of their Ubuntu image, which is 22.04. Since we start automatically using this image, our system tests are failing.

So far I'll pin the image to 20.04, and I'll try to investigate how to make it works on the latest image.