### PR TITLE
Use :rack_test as default capybara driver

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,4 +18,4 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 end
 
-Capybara.javascript_driver = :selenium_headless
+Capybara.javascript_driver = :selenium_chrome_headless

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ SimpleCov.start 'rails'
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless
+    driven_by :rack_test
   end
 
   config.expect_with :rspec do |expectations|

--- a/spec/system/article_datetime_settings_spec.rb
+++ b/spec/system/article_datetime_settings_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Setting and changing an articles published_at date' do
+describe 'Setting and changing an articles published_at date', js: true do
   include ActiveSupport::Testing::TimeHelpers
 
   before do


### PR DESCRIPTION
The capybara documentation was suggesting that if the app was working without JavaScript we could use the `:rack_test` driver which is smaller and faster, and simply configure a `Capybara.javascript_driver` and use the `js: true` annotation on specs that need to use the `javasdript_driver`.

It's not a lot faster, but on my computer it's 4-5 sec faster, which is not bad, tho.