### PR TITLE
[article] Add space around share btn and tags

### DIFF
--- a/app/assets/stylesheets/2017/views/_article.scss
+++ b/app/assets/stylesheets/2017/views/_article.scss
@@ -164,10 +164,15 @@
       }
 
       .social {
-        h1 {
+        margin-bottom: 5rem;
+        h2 {
           font-weight: 700;
           font-size: 3rem;
         }
+      }
+
+      .tags {
+        margin-top: 1.25rem;
       }
     } /* footer */
   } /* .h-entry */


### PR DESCRIPTION
# What are the relevant GitHub issues?

resolves #2498 

# What does this pull request do?

* It adds some space between tags and categories in the article footer
* The style of the social sharing section header was for a `<h1>`, but the tag in the HTML is an `<h2>`, so I switch the CSS, so it is applied correctly

# How should this be manually tested?

What it actually looks like
![Actual article footer](https://user-images.githubusercontent.com/427123/204699940-1e1231d5-ad7f-440e-a120-1da654c64ba0.png)

What it'd looks like with those modifications
![What the footer would look like](https://user-images.githubusercontent.com/427123/204700024-7d778942-070b-45c4-8e44-a18f55876482.png)


