### PR TITLE
Remove macos-strap from README since the URL give a 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Ruby on Rails app that powers https://crimethinc.com
 
 ## Short Version
 
-**First things first**, [Strap](https://macos-strap.herokuapp.com) your computer’s development environment.
+**First things first**, [Strap](https://strap.mikemcquaid.com/) your computer’s development environment.
 
 ```sh
-open https://macos-strap.herokuapp.com/strap.sh
+open https://strap.mikemcquaid.com/strap.sh
 ```
 
 Then…


### PR DESCRIPTION
The actual URL of the `strap.sh` script return a `404`, so I'd remove it. When I checked on Google, I found [this site](https://daptiv-macos-strap.herokuapp.com/), I don't know if it's the right thing. If so, then I will just change the URL, if it's not I'll just remove ti.