### PR TITLE
Make 2020 theme works again

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
     render "#{Current.theme}/#{path}", options
   end
 
-  def tt path, options = {}
-    t "#{Current.theme}.#{path}", options
+  def tt path
+    t "#{Current.theme}.#{path}"
   end
 end


### PR DESCRIPTION
Without this fixed, I got an error stating that `t` receive 2 arguments, but expect 1.

My Crimethinc. goal for 2023 would be to get some work done on the 2020 theme (damn time fly), so if you could tell me if this fix sounds fine to you, I'll try to get access back to the mockup and try to do some integration ! 😀🎉