### PR TITLE
Fix download format checkboxes/labels on books/zines form

### DIFF
--- a/app/controllers/admin/zines_controller.rb
+++ b/app/controllers/admin/zines_controller.rb
@@ -26,7 +26,7 @@ module Admin
     end
 
     def create
-      @book = Zine.new(book_params)
+      @book = Zine.new(zine_params)
 
       if @book.save
         redirect_to [:admin, @book], notice: 'Zine was successfully created.'
@@ -36,7 +36,7 @@ module Admin
     end
 
     def update
-      if @book.update(book_params)
+      if @book.update(zine_params)
         redirect_to [:admin, @book], notice: 'Zine was successfully updated.'
       else
         render :edit
@@ -54,7 +54,7 @@ module Admin
       @book = Zine.find(params[:id])
     end
 
-    def book_params
+    def zine_params
       params.require(:zine).permit(:title, :subtitle, :content, :tweet, :summary, :locale,
                                    :description, :buy_url, :buy_info, :slug, :series, :published_at, :gallery_images_count,
                                    :price_in_cents, :height, :width, :depth, :weight, :pages, :words, :illustrations,

--- a/app/views/admin/books/_downloads_form.html.erb
+++ b/app/views/admin/books/_downloads_form.html.erb
@@ -11,11 +11,11 @@
 
       <% EbookFormat.all.each do |ebook_format| %>
         <div class="form-check mb-3">
-          <%= form.label class: "form-check-label" do %>
-            <%= form.check_box "#{ebook_format.slug}_download_present",
-                               id: "book_#{ebook_format.slug}_download_present",
-                               class: "form-check-input" %>
+          <%= form.check_box "#{ebook_format.slug}_download_present",
+                             id: "#{resource.class.name.downcase}_#{ebook_format.slug}_download_present",
+                             class: "form-check-input" %>
 
+          <%= form.label "#{ebook_format.slug}_download_present", class: "form-check-label" do %>
             <%= ebook_format.name %>
 
             <span class="form-text text-muted fw-normal">
@@ -26,6 +26,7 @@
               </code>
             </span>
           <% end %>
+
         </div>
       <% end %>
 

--- a/config/locales/admin/cs.yml
+++ b/config/locales/admin/cs.yml
@@ -113,7 +113,7 @@ cs:
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
       name: Lo Res PDF
-      description: Is there a `.epub` file uploaded?
+      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?

--- a/config/locales/admin/cz.yml
+++ b/config/locales/admin/cz.yml
@@ -113,7 +113,7 @@ cz:
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
       name: Lo Res PDF
-      description: Is there a `.epub` file uploaded?
+      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?

--- a/config/locales/admin/de.yml
+++ b/config/locales/admin/de.yml
@@ -113,7 +113,7 @@ de:
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
       name: Lo Res PDF
-      description: Is there a `.epub` file uploaded?
+      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -113,7 +113,7 @@ en:
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
       name: Lo Res PDF
-      description: Is there a `.epub` file uploaded?
+      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?

--- a/config/locales/admin/es.yml
+++ b/config/locales/admin/es.yml
@@ -113,7 +113,7 @@ es:
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
       name: Lo Res PDF
-      description: Is there a `.epub` file uploaded?
+      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?

--- a/config/locales/admin/fr.yml
+++ b/config/locales/admin/fr.yml
@@ -113,7 +113,7 @@ fr:
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
       name: Lo Res PDF
-      description: Is there a `.epub` file uploaded?
+      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?


### PR DESCRIPTION
When on the books or zines form's download formats section (pdf, ePub, etc), 
if you clicked on the label, 
the checkbox wasn't being un/checked.

we had the checkbox's `id` and label's `for` not matching.

this PR fixes that.

---

this also fixes a typo in the description text of the "lo res pdf" format.