### PR TITLE
Add ruby-install and chruby to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,9 @@
+# Check for existing rbenv, otherwise install ruby-install and chruby
+brew 'ruby-install' unless system 'command -v rbenv > /dev/null 2>&1'
+brew 'chruby'       unless system 'command -v rbenv > /dev/null 2>&1'
+
 # Check for existing ruby-install, otherwise install rbenv
-brew 'rbenv' unless system 'command -v ruby-install >/dev/null 2>&1'
+brew 'rbenv' unless system 'command -v ruby-install > /dev/null 2>&1'
 
 # PaaS CLI
 tap 'heroku/brew'


### PR DESCRIPTION
When running `brew bundle`, install `ruby-install` and `chruby` unless `rbenv` is already installed.