### PR TITLE
Drop unused search_results view

### DIFF
--- a/db/migrate/20230628052836_drop_search_results_view.rb
+++ b/db/migrate/20230628052836_drop_search_results_view.rb
@@ -1,0 +1,5 @@
+class DropSearchResultsView < ActiveRecord::Migration[7.0]
+  def change
+    drop_view :search_results, revert_to_version: 5, materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_05_063227) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_28_052836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -159,8 +159,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_05_063227) do
     t.string "draft_code"
     t.string "slug"
     t.integer "publication_status"
-    t.datetime "published_at", precision: nil
-    t.datetime "featured_at", precision: nil
+    t.datetime "published_at"
+    t.datetime "featured_at"
     t.boolean "featured_status", default: false
     t.index ["canonical_id"], name: "index_definitions_on_canonical_id"
   end
@@ -548,69 +548,4 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_05_063227) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-
-  create_view "search_results", materialized: true, sql_definition: <<-SQL
-      SELECT a.searchable_id,
-      a.searchable_type,
-      a.title,
-      a.subtitle,
-      a.content,
-      a.tag_names AS tag,
-      a.category_names AS category,
-      ((((setweight(a.title, 'A'::"char") || setweight(a.subtitle, 'B'::"char")) || setweight(a.content, 'C'::"char")) || setweight(array_to_tsvector((a.tag_names)::text[]), 'D'::"char")) || setweight(array_to_tsvector((a.category_names)::text[]), 'D'::"char")) AS document
-     FROM ( SELECT articles.id AS searchable_id,
-              'Article'::text AS searchable_type,
-              to_tsvector(COALESCE(articles.title, ''::text)) AS title,
-              to_tsvector(COALESCE(articles.subtitle, ''::text)) AS subtitle,
-              to_tsvector(COALESCE(articles.content, ''::text)) AS content,
-                  CASE
-                      WHEN (count(tags.*) = 0) THEN (ARRAY[]::text[])::character varying[]
-                      ELSE array_remove(array_agg(tags.name), NULL::character varying)
-                  END AS tag_names,
-                  CASE
-                      WHEN (count(categories.*) = 0) THEN (ARRAY[]::text[])::character varying[]
-                      ELSE array_remove(array_agg(categories.name), NULL::character varying)
-                  END AS category_names
-             FROM ((((articles
-               LEFT JOIN taggings ON (((taggings.taggable_id = articles.id) AND ((taggings.taggable_type)::text = 'Article'::text))))
-               LEFT JOIN tags ON ((tags.id = taggings.tag_id)))
-               LEFT JOIN categorizations ON ((categorizations.article_id = articles.id)))
-               LEFT JOIN categories ON ((categories.id = categorizations.category_id)))
-            WHERE ((articles.published_at < now()) AND (articles.publication_status = 1))
-            GROUP BY articles.id, 'Article'::text
-          UNION
-           SELECT pages.id AS searchable_id,
-              'Page'::text AS searchable_type,
-              to_tsvector(COALESCE(pages.title, ''::text)) AS title,
-              to_tsvector(COALESCE(pages.subtitle, ''::text)) AS subtitle,
-              to_tsvector(COALESCE(pages.content, ''::text)) AS content,
-                  CASE
-                      WHEN (count(tags.*) = 0) THEN (ARRAY[]::text[])::character varying[]
-                      ELSE array_agg(tags.name)
-                  END AS tag_names,
-              ARRAY[]::text[] AS category_names
-             FROM ((pages
-               LEFT JOIN taggings ON (((taggings.taggable_id = pages.id) AND ((taggings.taggable_type)::text = 'Page'::text))))
-               LEFT JOIN tags ON ((tags.id = taggings.tag_id)))
-            WHERE ((pages.published_at < now()) AND (pages.publication_status = 1))
-            GROUP BY pages.id, 'Page'::text
-          UNION
-           SELECT episodes.id AS searchable_id,
-              'Episode'::text AS searchable_type,
-              to_tsvector((COALESCE(episodes.title, ''::character varying))::text) AS title,
-              to_tsvector((COALESCE(episodes.subtitle, ''::character varying))::text) AS subtitle,
-              to_tsvector((COALESCE(episodes.content, ''::character varying))::text) AS content,
-              ARRAY[]::text[] AS tag_names,
-              ARRAY[]::text[] AS category_names
-             FROM episodes
-            GROUP BY episodes.id, 'Episode'::text) a;
-  SQL
-  add_index "search_results", ["category"], name: "index_search_results_on_category", using: :gin
-  add_index "search_results", ["content"], name: "index_search_results_on_content", using: :gist
-  add_index "search_results", ["document"], name: "index_search_results_on_document", using: :gist
-  add_index "search_results", ["searchable_id", "searchable_type"], name: "index_search_results_on_searchable_id_and_searchable_type", unique: true
-  add_index "search_results", ["subtitle"], name: "index_search_results_on_subtitle", using: :gist
-  add_index "search_results", ["tag"], name: "index_search_results_on_tag", using: :gin
-  add_index "search_results", ["title"], name: "index_search_results_on_title", using: :gist
-
 end


### PR DESCRIPTION
We are no longer doing `/search` or `/search-advanced` internally. 
We're redirecting to DuckDuckGo instead.

This SQL view is unused.

A follow up PR will remove the `scenic` gem and the `.sql` view files.