### PR TITLE
Version bump redis from 4.8 to 5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.8.0)
+    redis (5.0.6)
+      redis-client (>= 0.9.0)
     redis-client (0.14.1)
       connection_pool
     redis-store (1.9.2)


### PR DESCRIPTION
The reds server version that we're running in production has been upgraded from v6 to v7. So we can update our redis gem now. 