### PR TITLE
[Bug] Redirect empty/bad archive requests to root

### DIFF
--- a/app/controllers/article_archives_controller.rb
+++ b/app/controllers/article_archives_controller.rb
@@ -11,7 +11,9 @@ class ArticleArchivesController < ApplicationController
 
     # Redirect to somewhere else if showing this result set isn’t useful
     path =
-      if @article_archive.articles.length == 1 && @article_archive.day.present?
+      if @article_archive.articles.length
+        :root
+      elsif @article_archive.articles.length == 1 && @article_archive.day.present?
         @article_archive.articles.first.path
       elsif @article_archive.articles.empty?
         if @article_archive.day.present?


### PR DESCRIPTION
Example of bad/empty request:

`https://crimethinc.com/20`

Instead of an error, we will now redirect to the homepage.