### PR TITLE
[Bug] Fix bad URLs from (maybe) some twitter app

### DIFF
--- a/app/middlewares/rack/clean_path.rb
+++ b/app/middlewares/rack/clean_path.rb
@@ -6,6 +6,7 @@ module Rack
       'index.html'           => '',
       '.html'                => '',
       '.xml'                 => '',
+      '.txt'                 => '',
       'index.php'            => '',
       '.php'                 => '',
       '.md'                  => '.markdown',
@@ -36,6 +37,7 @@ module Rack
     SMOOSHED_TWEET_TEXT_UNICODE_SEPARATORS = %w[
       %E2%80%8E
       %EF%BF%BD
+      %C2%A0
     ].freeze
 
     def initialize app


### PR DESCRIPTION
Some requests come in looking like this:

```
https://crimethinc.com/stopthewall%C2%A0pic.twitter.com/N77rSx1KTn
```

The actual URL that they want is:

```
https://crimethinc.com/stopthewall
```

This PR will _hopefully_ fix that bug.