### PR TITLE
Fix article archive redirects for bad date URL fragments

### DIFF
--- a/app/controllers/article_archives_controller.rb
+++ b/app/controllers/article_archives_controller.rb
@@ -11,9 +11,7 @@ class ArticleArchivesController < ApplicationController
 
     # Redirect to somewhere else if showing this result set isn’t useful
     path =
-      if @article_archive.articles.length
-        :root
-      elsif @article_archive.articles.length == 1 && @article_archive.day.present?
+      if @article_archive.articles.length == 1 && @article_archive.day.present?
         @article_archive.articles.first.path
       elsif @article_archive.articles.empty?
         if @article_archive.day.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
   get '(/:year)(/:month)(/:day)/page(/1)', to: redirect { |_, req|
     req.path.split('page').first
   }
-  get '/(:year)/(:month)/(:day)/(page/:page)',
+  get '/(:year/(:month/(:day)))/(page/:page)',
       to:          'article_archives#index',
       constraints: { year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ },
       as:          :article_archives
@@ -58,6 +58,12 @@ Rails.application.routes.draw do
       controller:  'admin/articles',
       action:      'edit',
       constraints: { year: /\d{4}/, month: /\d{2}/, day: /\d{2}/ }
+
+  # Fallback route for mangled date URL fragments, example: .com/202 (one digit cut off a year)
+  get '/(:year/(:month/(:day)))/(page/:page)',
+      to:          'article_archives#index',
+      constraints: { year: /\d*/, month: /\d*/, day: /\d*/ },
+      as:          :article_archives_fallback
 
   # Draft Articles and Pages
   get 'drafts/articles/:draft_code',            to: 'articles#show',       as: :article_draft


### PR DESCRIPTION
- remove check for zero articles in an archive and redirect to root (that was my previous mistake)
- change the route for article archives to require previous date chunk in each success path segment
  - i.e., a month requires a year, a day requires a month and a year
  - previously, when we got a request like `/20` would cause a 500 bc it had a `params[:month]` of `20`, but a `params[:year]` of `nil`, then downstream things would fail
- add a fallback route to catch routes that look like dates that have been malformed, send it to the same articles archives controller, which will try its best then redirect it to `/library` if all else fails