### PR TITLE
Add link to locale subdomain from /admin/locales

### DIFF
--- a/app/helpers/locales_helper.rb
+++ b/app/helpers/locales_helper.rb
@@ -1,6 +1,16 @@
 module LocalesHelper
+  def locale_subdomain_url locale
+    abbreviation = if locale.is_a? Locale
+                     locale.abbreviation
+                   else
+                     locale
+                   end
+
+    "https://#{abbreviation}.crimethinc.com"
+  end
+
   def locale abbreviation
-    Locale.find_by(abbreviation: abbreviation.downcase)
+    Locale.find_by abbreviation: abbreviation.downcase
   end
 
   def locale_nav_item_classes_for locale

--- a/app/views/admin/locales/index.html.erb
+++ b/app/views/admin/locales/index.html.erb
@@ -18,7 +18,7 @@
         <td>
           <%= link_to "EDIT", [:edit, :admin, locale], class: "btn btn-light border-secondary btn-sm" %>
         </td>
-        <td class="text-uppercase"><%= locale.abbreviation %></td>
+        <td class="text-uppercase"><%= link_to locale.abbreviation, locale_subdomain_url(locale), target: :_blank %></td>
         <td><%= locale.name_in_english %></td>
         <td><%= locale.name %></td>
         <td><%= locale.slug %></td>


### PR DESCRIPTION
On `/admin/locales`, the locale abbreviation is now linked to a subdomained URL.

Example `ES` is linked to `https://es.crimethinc.com`