### PR TITLE
Add auto-merge for dependabot PR except when it's a major upgrade

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,14 @@
+name: auto-merge dependabot PRs
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,5 +10,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
-          target: minor
+          target: patch
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I give up, there's to many dependencies updates. There'll always be a risk of supply chain attack, even if we review dependencies updates manually. The key will probably be to keep the number of dependencies as low as possible, but I wanna try auto-merge to see if it reduces the amount of work.
