### PR TITLE
Rename 'Lo-res' download to 'Ink lite'

### DIFF
--- a/app/views/2017/tools/_tool.html.erb
+++ b/app/views/2017/tools/_tool.html.erb
@@ -39,7 +39,7 @@
             print_black_and_white:    "Print B/W PDF",
             print_color_a4:           "Print Color A4 PDF",
             print_black_and_white_a4: "Print B/W A4 PDF",
-            lite:                     "Lo Res PDF",
+            lite:                     "Ink Lite PDF",
             epub:                     "ePub",
             mobi:                     "Mobi",
           }.each do |type, label| %>

--- a/app/views/admin/books/index.html.erb
+++ b/app/views/admin/books/index.html.erb
@@ -14,7 +14,7 @@
           "Print B/W PDF",
           "Print Color A4 PDF",
           "Print B/W A4 PDF",
-          "Lo Res PDF",
+          "Ink Lite PDF",
           "ePub",
           "Mobi",
         ].each do |type| %>

--- a/app/views/admin/books/show.html.erb
+++ b/app/views/admin/books/show.html.erb
@@ -55,7 +55,7 @@
     print_black_and_white_a4: "Print B/W A4",
     epub:                     "ePub",
     mobi:                     "Mobi",
-    lite:                     "Lo Res"
+    lite:                     "Ink Lite"
   }.each do |type, label| %>
 
     <% if @book.send("#{type}_download_present?") %>

--- a/config/locales/admin/cs.yml
+++ b/config/locales/admin/cs.yml
@@ -112,16 +112,14 @@ cs:
       name:  B/W A4 PDF
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
-      name: Lo Res PDF
-      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
+      name: Ink Lite PDF
+      description: Is there a printer toner frienly `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?
     - slug: mobi
       name: Mobi
       description: Is there a low resolution or single page view PDF uploaded?
-
-
   activerecord:
     errors:
       models:

--- a/config/locales/admin/cz.yml
+++ b/config/locales/admin/cz.yml
@@ -112,15 +112,14 @@ cz:
       name:  B/W A4 PDF
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
-      name: Lo Res PDF
-      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
+      name: Ink Lite PDF
+      description: Is there a printer toner frienly `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?
     - slug: mobi
       name: Mobi
       description: Is there a low resolution or single page view PDF uploaded?
-
 
   activerecord:
     errors:

--- a/config/locales/admin/de.yml
+++ b/config/locales/admin/de.yml
@@ -112,15 +112,14 @@ de:
       name:  B/W A4 PDF
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
-      name: Lo Res PDF
-      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
+      name: Ink Lite PDF
+      description: Is there a printer toner frienly `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?
     - slug: mobi
       name: Mobi
       description: Is there a low resolution or single page view PDF uploaded?
-
 
   activerecord:
     errors:

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -112,15 +112,14 @@ en:
       name:  B/W A4 PDF
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
-      name: Lo Res PDF
-      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
+      name: Ink Lite PDF
+      description: Is there a printer toner frienly `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?
     - slug: mobi
       name: Mobi
       description: Is there a low resolution or single page view PDF uploaded?
-
 
   activerecord:
     errors:

--- a/config/locales/admin/es.yml
+++ b/config/locales/admin/es.yml
@@ -112,15 +112,14 @@ es:
       name:  B/W A4 PDF
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
-      name: Lo Res PDF
-      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
+      name: Ink Lite PDF
+      description: Is there a printer toner frienly `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?
     - slug: mobi
       name: Mobi
       description: Is there a low resolution or single page view PDF uploaded?
-
 
   activerecord:
     errors:

--- a/config/locales/admin/fr.yml
+++ b/config/locales/admin/fr.yml
@@ -112,15 +112,14 @@ fr:
       name:  B/W A4 PDF
       description: Is there an A4 sized B/W `PDF` for printing uploaded?
     - slug: lite
-      name: Lo Res PDF
-      description: Is there a "lo res" (smaller file size) `PDF` file uploaded?
+      name: Ink Lite PDF
+      description: Is there a printer toner frienly `PDF` file uploaded?
     - slug: epub
       name: ePub
       description: Is there a `.mobi` file uploaded?
     - slug: mobi
       name: Mobi
       description: Is there a low resolution or single page view PDF uploaded?
-
 
   activerecord:
     errors:

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -206,7 +206,7 @@ ar:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ ar:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ ar:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -211,7 +211,7 @@ be:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -237,7 +237,7 @@ be:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -255,7 +255,7 @@ be:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -211,7 +211,7 @@ bg:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -237,7 +237,7 @@ bg:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -255,7 +255,7 @@ bg:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -206,7 +206,7 @@ bn:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ bn:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ bn:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -233,7 +233,7 @@ cs:
       buy_now_button_text:             Kup zde
       zine_download_read_button_text:  Stáhni PDF pro Čtení
       zine_download_print_button_text: Stáhni PDF pro Tisk
-      zine_download_lite_button_text:  Stáhni Lo Res PDF
+      zine_download_lite_button_text:  Stáhni Ink Lite PDF
       zine_download_epub_button_text:  Stáhni ePub eKnihu
       zine_download_mobi_button_text:  Stáhni Mobi eKnihu
 
@@ -251,7 +251,7 @@ cs:
 
       admin_zine_read_download_text:  Zobrazit PDF
       admin_zine_print_download_text: Vytisknout PDF
-      admin_zine_lite_download_text:  Lo Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/cz.yml
+++ b/config/locales/cz.yml
@@ -205,7 +205,7 @@ cz:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -231,7 +231,7 @@ cz:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -249,7 +249,7 @@ cz:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -206,7 +206,7 @@ da:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ da:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ da:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -205,7 +205,7 @@ de:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -231,7 +231,7 @@ de:
       buy_now_button_text:             Jetzt kaufen
       zine_download_read_button_text:  Download PDF zum lesen
       zine_download_print_button_text: Download druckbare PDF
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -249,7 +249,7 @@ de:
 
       admin_zine_read_download_text:  Lesen PDF
       admin_zine_print_download_text: Drucken PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/dv.yml
+++ b/config/locales/dv.yml
@@ -206,7 +206,7 @@ dv:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ dv:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ dv:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -211,7 +211,7 @@ en:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -237,7 +237,7 @@ en:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -255,7 +255,7 @@ en:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -211,7 +211,7 @@ eu:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -237,7 +237,7 @@ eu:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -255,7 +255,7 @@ eu:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -206,7 +206,7 @@ fa:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ fa:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ fa:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -206,7 +206,7 @@ fi:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ fi:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ fi:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -210,7 +210,7 @@ gl:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -236,7 +236,7 @@ gl:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -254,7 +254,7 @@ gl:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/gr.yml
+++ b/config/locales/gr.yml
@@ -206,7 +206,7 @@ gr:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ gr:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ gr:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -206,7 +206,7 @@ he:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ he:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ he:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -211,7 +211,7 @@ hu:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -237,7 +237,7 @@ hu:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -255,7 +255,7 @@ hu:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -206,7 +206,7 @@ id:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ id:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ id:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -206,7 +206,7 @@ ja:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ ja:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ ja:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -206,7 +206,7 @@ ko:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ ko:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ ko:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/ku.yml
+++ b/config/locales/ku.yml
@@ -211,7 +211,7 @@ ku:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -237,7 +237,7 @@ ku:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -255,7 +255,7 @@ ku:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -206,7 +206,7 @@ nl:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ nl:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ nl:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -208,7 +208,7 @@
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -234,7 +234,7 @@
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -252,7 +252,7 @@
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -206,7 +206,7 @@ pl:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ pl:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ pl:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -219,7 +219,7 @@ pt:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -245,7 +245,7 @@ pt:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -263,7 +263,7 @@ pt:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -211,7 +211,7 @@ ro:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -237,7 +237,7 @@ ro:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -255,7 +255,7 @@ ro:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -206,7 +206,7 @@ ru:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ ru:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ ru:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/sh.yml
+++ b/config/locales/sh.yml
@@ -208,7 +208,7 @@ sh:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -234,7 +234,7 @@ sh:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -252,7 +252,7 @@ sh:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -211,7 +211,7 @@ sk:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -237,7 +237,7 @@ sk:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -255,7 +255,7 @@ sk:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -206,7 +206,7 @@ sl:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ sl:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ sl:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -206,7 +206,7 @@ sv:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ sv:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ sv:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -206,7 +206,7 @@ th:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ th:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ th:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/tl.yml
+++ b/config/locales/tl.yml
@@ -208,7 +208,7 @@ tl:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -234,7 +234,7 @@ tl:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -252,7 +252,7 @@ tl:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -206,7 +206,7 @@ tr:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ tr:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ tr:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -208,7 +208,7 @@ uk:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -234,7 +234,7 @@ uk:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -252,7 +252,7 @@ uk:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -210,7 +210,7 @@ vi:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -236,7 +236,7 @@ vi:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -254,7 +254,7 @@ vi:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -206,7 +206,7 @@ zh:
       print_black_and_white:    Print B/W PDF
       print_color_a4:           Print Color A4 PDF
       print_black_and_white_a4: Print B/W A4 PDF
-      lite:                     Lo Res PDF
+      lite:                     Ink Lite PDF
       epub:                     ePub
       mobi:                     Mobi
 
@@ -232,7 +232,7 @@ zh:
       buy_now_button_text:             Buy Now
       zine_download_read_button_text:  Download PDF for Reading
       zine_download_print_button_text: Download PDF for Printing
-      zine_download_lite_button_text:  Download Lo Res PDF
+      zine_download_lite_button_text:  Download Ink Lite PDF
       zine_download_epub_button_text:  Download ePub eBook
       zine_download_mobi_button_text:  Download Mobi eBook
 
@@ -250,7 +250,7 @@ zh:
 
       admin_zine_read_download_text:  Read PDF
       admin_zine_print_download_text: Print PDF
-      admin_zine_lite_download_text:  Lo-Res PDF
+      admin_zine_lite_download_text:  Ink Lite PDF
       admin_zine_epub_download_text:  Mobi
       admin_zine_mobi_download_text:  ePub
 


### PR DESCRIPTION
"Lo res" implies low quality images and such.

Instead, these downloads are redesigned to use less printer toner.

So we renamed them "Ink lite"