### PR TITLE
Fix env var name typo, missing S

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,5 @@
-workers ENV.fetch('WEB_CONCURRENCY')              { 2 }
-max_threads_count = ENV.fetch('RAILS_MAX_THREAD') { 5 }
+workers ENV.fetch('WEB_CONCURRENCY')               { 2 }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 


### PR DESCRIPTION
Oops.

`RAILS_MAX_THREAD` in puma.rb `RAILS_MAX_THREADS` in env var. 😂