### PR TITLE
Fixes support subscription cancelation

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -95,7 +95,7 @@ class SupportController < ApplicationController
   def cancel_subscription
     subscription = Stripe::Subscription.retrieve(params[:subscription_id])
 
-    if subscription&.delete
+    if subscription&.cancel
       SupportSession.find_by(token: params[:token]).destroy
       flash.now[:notice] = t('views.support.cancel_subscription.notice')
     else


### PR DESCRIPTION
The stripe gem deprecated subscription `delete`. The new way is now `cancel`.

# What does this pull request do?

This should fix the issue with canceling subscriptions, like this...

<img width="650" alt="Screenshot 2023-10-25 at 10 37 12 AM" src="https://github.com/crimethinc/website/assets/1372520/0daf2843-9fbb-4c86-9ecd-f2e10b2abfd7">

# How should this be manually tested?

Yes, I will try canceling my subscription once this goes live.