### PR TITLE
Add Dependabot grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,18 @@ updates:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
     groups:
-      bundler-deps:
-        patterns:
-          - "*"
+      bundler-prod:
+        dependency-type: "production"
+        update-types: minor
         exclude-patterns:
           - rails
-          - stripe
+      bundler-dev:
+        dependency-type: "development"
+        exclude-patterns:
+          - erb_lint
+          - "rubocop*"
+      bundler-lint:
+        patterns:
+          - erb_lint
+          - "rubocop*"        
+        

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,15 @@ updates:
   - package-ecosystem: bundler
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"
+    groups:
+      bundler-deps:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - rails
+          - stripe


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

👍🏻 

# What does this pull request do?

I noticed that there are a significant number of Dependabot updates on this repo, more than any other project I contribute to. I think this is a result of doing `daily` updates and `dependency-type: "all"`. (I noticed overwhelm mentioned in https://github.com/crimethinc/website/pull/3511#issue-1884302431)

I wanted to propose a way to make them slightly less onerous (I figured it was easier to just propose several changes directly rather than open an issue, and make any changes to this PR):

* Changes to `interval: weekly`. I usually set this for my projects. This schedule does not apply to Dependabot _security_ updates; they are opened immediately ([docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval)): 
   > `schedule` defines when Dependabot attempts a new update. However, it's not the only time you may receive pull requests. Updates can be triggered based on changes to your `dependabot.yml` file, or Dependabot security updates. 
* Uses newish ["Grouped update"](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) feature. I split them out into groups of production, development, and lint.

# How should this be manually tested?

Insights > Dependency Graph > Dependabot. Click on "Recent update jobs" then click on "Check for updates" button.

# Acceptance Criteria
## These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema
