### PR TITLE
dependabot: group all rubocop together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,4 @@ updates:
       bundler-lint:
         patterns:
           - erb_lint
-          - "rubocop"
+          - "rubocop*"


### PR DESCRIPTION
It's just a quick attenmp to reduce the amount of PRs and group all the rubocop gem together.
