### PR TITLE
Reorder Dependabot groups, match minor _and_ patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,26 @@
 version: 2
 updates:
   - package-ecosystem: bundler
-    directory: "/"
+    directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
     allow:
       # Allow both direct and indirect updates for all packages
-      - dependency-type: "all"
+      - dependency-type: all
     groups:
-      bundler-prod:
-        dependency-type: "production"
-        update-types:
-          - minor
-        exclude-patterns:
-          - rails
-      bundler-dev:
-        dependency-type: "development"
-        exclude-patterns:
-          - erb_lint
-          - "rubocop*"
+      # Dependabot creates groups in the order they appear in this config.
+      # If a dependency update could belong to more than one group,
+      # it is only assigned to the first group it matches with.
       bundler-lint:
         patterns:
           - erb_lint
-          - "rubocop*"
+          - rubocop*
+      bundler-dev:
+        dependency-type: development
+      bundler-all:
+        update-types:
+          - minor
+          - patch
+        exclude-patterns:
+          - rails


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

![Spongebob's Patrick taking it from over here and pushing it somewhere else](https://github.com/crimethinc/website/assets/47554/51b8142e-e550-4246-b72e-6c7a2b8c15e5)

# What does this pull request do?

Reorders the Dependabot grouped updates so that the more specific are listed first, followed by the more and more generic groups. This also specifies both minor _and patch_ versions so they properly roll into the group.

# Is there any background context you want to provide for reviewers?

I think I now fully understand how Dependabot grouped updates are supposed to work 😓 

# Acceptance Criteria
## These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema
