### PR TITLE
[#3776] Fix title tag for tool/s pages

### DIFF
--- a/app/controllers/logos_controller.rb
+++ b/app/controllers/logos_controller.rb
@@ -17,7 +17,7 @@ class LogosController < ApplicationController
     @body_id       = 'tools'
     @type          = 'logos'
     @editable      = @tool
-    @title         = PageTitle.new title_for :logos, @tool.name
+    @title         = PageTitle.new [title_for(:logos), @tool.name].compact
     @preview_width = 640
 
     render "#{Current.theme}/logos/show"

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -84,7 +84,7 @@ class ToolsController < ApplicationController
   end
 
   def set_title
-    @title = PageTitle.new title_for [@type.capitalize.to_sym, @tool&.name].compact
+    @title = PageTitle.new [title_for(@type.to_sym), @tool&.name].compact
   end
 
   def set_editable

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -15,7 +15,7 @@ class VideosController < ApplicationController
     @editable = @video
     @html_id  = 'page'
     @body_id  = 'video'
-    @title    = PageTitle.new title_for :videos, @video.title
+    @title    = PageTitle.new [title_for(:videos), @video.title].compact
 
     render "#{Current.theme}/videos/show"
   end


### PR DESCRIPTION
# How does this pull request make you feel (in animated GIF format)?

Finally

# What are the relevant GitHub issues?

Fixes #3776

# What does this pull request do?

Corrects the arguments when creating a new `PageTitle` object 

# How should this be manually tested?

Go to the tools' index and show pages. 
Open another tab, so you can see the title displayed.
Then confirm that you see the correct title, not a "translation missing" error


# Screenshots, before and after

<img width="1392" alt="Screenshot 2024-02-25 at 3 09 21 PM" src="https://github.com/crimethinc/website/assets/4361/cbdf50f4-0626-4f39-a77c-2b85e66fe6ee">
<img width="1392" alt="Screenshot 2024-02-25 at 3 09 38 PM" src="https://github.com/crimethinc/website/assets/4361/c8aaef34-5554-4cbc-80f4-5a2ae1a70a1c">


<img width="1392" alt="Screenshot 2024-02-25 at 3 10 29 PM" src="https://github.com/crimethinc/website/assets/4361/576e8c88-fcdd-4a01-ac8f-c46d8dba49df">
<img width="1392" alt="Screenshot 2024-02-25 at 3 10 01 PM" src="https://github.com/crimethinc/website/assets/4361/b2471dc9-12fe-4ec6-8a9c-35600a6cf91e">

<img width="1392" alt="Screenshot 2024-02-25 at 3 11 48 PM" src="https://github.com/crimethinc/website/assets/4361/90d461b4-aae7-4785-bf2e-a2595df91285">
<img width="1392" alt="Screenshot 2024-02-25 at 3 11 26 PM" src="https://github.com/crimethinc/website/assets/4361/e0692682-aaf6-4eac-a0cf-e21f4b9b295d">


<img width="1392" alt="Screenshot 2024-02-25 at 3 04 16 PM" src="https://github.com/crimethinc/website/assets/4361/07662704-d606-44e4-aa72-8e13126ca5d7">
<img width="1392" alt="Screenshot 2024-02-25 at 3 05 12 PM" src="https://github.com/crimethinc/website/assets/4361/0213f8e2-b524-4811-b6d4-67d04a6c6394">

