### PR TITLE
Fix #social_link_for, missing '.join' on Array

### DIFF
--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -40,7 +40,7 @@ module ArticlesHelper
           url_encode(article.title),
           '&amp;content=',
           article.image
-        ]
+        ].join
       end
 
     tag.li class: 'social-link' do


### PR DESCRIPTION
Fixing a small mistake in https://github.com/crimethinc/website/pull/3781/files#diff-97ab59d4b1f9bd5897694b4642a803d1543f96a9879c2ad1da666ffd55436c11