### PR TITLE
Version bump active_support.cache_format_version from 6.1 to 7.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module Crimethinc
 
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.active_support.cache_format_version = 7.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -227,21 +227,6 @@
 # Rails.application.config.active_record.generate_secure_token_on = :initialize
 
 ###
-# ** Please read carefully, this must be configured in config/application.rb **
-#
-# Change the format of the cache entry.
-#
-# Changing this default means that all new cache entries added to the cache
-# will have a different format that is not supported by Rails 7.0
-# applications.
-#
-# Only change this value after your application is fully deployed to Rails 7.1
-# and you have no plans to rollback.
-# When you're ready to change format, add this to `config/application.rb` (NOT
-# this file):
-# config.active_support.cache_format_version = 7.1
-
-###
 # Configure Action View to use HTML5 standards-compliant sanitizers when they are supported on your
 # platform.
 #


### PR DESCRIPTION
We really should've done this when we upgraded from Rails 6.1 to 7.0

> ** Please read carefully, this must be configured in config/application.rb **
#
> Change the format of the cache entry.
#
> Changing this default means that all new cache entries added to the cache
> will have a different format that is not supported by Rails 7.0
> applications.
#
> Only change this value after your application is fully deployed to Rails 7.1
> and you have no plans to rollback.
> When you're ready to change format, add this to `config/application.rb` (NOT
> this file):
> config.active_support.cache_format_version = 7.1
