### PR TITLE
Enable config.autoload_lib in app.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,9 +33,7 @@ module Crimethinc
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    # TODO: do this at its own PR after releasing Rails 7.1 upgrade
-    # TODO: confirm that all Heroku tasks still run after adding this line
-    # config.autoload_lib ignore: %w[assets generators tasks]
+    config.autoload_lib ignore: %w[assets generators tasks]
 
     # By default `form_with` generates remote forms. We don't really
     # use this right now, so it is easier to have it default to `false`.


### PR DESCRIPTION
Part of the Rails 7/7.1 upgrade process.