### PR TITLE
Disable vips, for now

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,9 @@ module Crimethinc
     config.load_defaults 7.0
     config.active_support.cache_format_version = 7.1
 
+    # TEMP: re-enable mini magick until variant syntax is changed to vips in ActiveStorageHelper#image_variant_by_width
+    config.active_storage.variant_processor = :mini_magick
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.


### PR DESCRIPTION
Rails 7 or 7.1 enabled `:vips` as the default `active_storage.variant_processor`

But our helper method `ActiveStorageHelper#image_variant_by_width`  uses `mini_magick` syntax/args.

This PR puts it back to `:mini_magick` until we change that method to use `vips` args.

---

To change to vips:
- `Rails.application.config.active_storage.variant_processor = :mini_magick`
- https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#active-storage-default-variant-processor-changed-to-vips
- https://elements.heroku.com/buildpacks/brandoncc/heroku-buildpack-vips
- https://gorails.com/forum/rails-6-0-heroku-active-storage-vips

