### PR TITLE
Enable Rails 7.1 default for action_dispatch.default_headers

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -23,14 +23,13 @@
 # Remove the default X-Download-Options headers since it is used only by Internet Explorer.
 # If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
 #++
-# TODO: enable this one by itself, after the rest
-# Rails.application.config.action_dispatch.default_headers = {
-#   'X-Frame-Options'                   => 'SAMEORIGIN',
-#   'X-XSS-Protection'                  => '0',
-#   'X-Content-Type-Options'            => 'nosniff',
-#   'X-Permitted-Cross-Domain-Policies' => 'none',
-#   'Referrer-Policy'                   => 'strict-origin-when-cross-origin'
-# }
+Rails.application.config.action_dispatch.default_headers = {
+  'X-Frame-Options'                   => 'SAMEORIGIN',
+  'X-XSS-Protection'                  => '0',
+  'X-Content-Type-Options'            => 'nosniff',
+  'X-Permitted-Cross-Domain-Policies' => 'none',
+  'Referrer-Policy'                   => 'strict-origin-when-cross-origin'
+}
 
 ###
 # Do not treat an `ActionController::Parameters` instance


### PR DESCRIPTION
# `action_dispatch.default_headers`

Second to last Rails 7.1 framework default to enable before version bumping `config.load_defaults 7.0` to `config.load_defaults 7.1`