### PR TITLE
ci: `actions/checkout` default branch is now `main`

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,7 +7,7 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           target: patch

--- a/.github/workflows/linter_erb.yml
+++ b/.github/workflows/linter_erb.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@master

--- a/.github/workflows/linter_fasterer.yml
+++ b/.github/workflows/linter_fasterer.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@master

--- a/.github/workflows/linter_rubocop.yml
+++ b/.github/workflows/linter_rubocop.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get -y install libpq-dev
 
       - name: Checkout repository
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@master

--- a/.github/workflows/tests_system.yml
+++ b/.github/workflows/tests_system.yml
@@ -26,7 +26,7 @@ jobs:
           sudo apt-get -y install libpq-dev
 
       - name: Checkout repository
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@master


### PR DESCRIPTION
The [`actions/checkout`](/actions/checkout) action is now using `main` as default branch. This PR make sure we always track the latest version and avoid getting behind.