### PR TITLE
Downgrade markdown_media from 2.0.0 to 1.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'jbuilder'
 # text utilities
 gem 'addressable'      # for current URL with a subdomain
 gem 'kramdown'         # for Markdown processing
-gem 'markdown_media'   # for [[ media embeds ]]
+gem 'markdown_media', '1.8' # for [[ media embeds ]]
 gem 'pandoc-ruby'      # for Word to HTML conversion
 gem 'reverse_markdown' # for HTML to Markdown conversion
 gem 'rubypants'        # for smart quotes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
-    markdown_media (2.0.0)
+    markdown_media (1.8.0)
       kramdown
     matrix (0.4.2)
     memory_profiler (1.0.2)
@@ -547,7 +547,7 @@ DEPENDENCIES
   listen
   lograge
   logstash-event
-  markdown_media
+  markdown_media (= 1.8)
   memory_profiler
   nokogiri
   overcommit


### PR DESCRIPTION
# Description

After upgrading `markdown_media` from 1.8 to 2.0 and deploying to production, YouTube videos aren't embedding anymore

We should revisit this PR https://github.com/veganstraightedge/markdown_media/pull/17 and see if we can find a middle ground: better privacy, still works on the site

<img width="960" alt="Screenshot 2024-06-18 at 9 19 40 PM" src="https://github.com/crimethinc/website/assets/4361/2563da1d-3be0-4516-a571-dbb3cf36ee06">
