### PR TITLE
Version bump markdown_media from 1.8.0 to 2.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'jbuilder'
 # text utilities
 gem 'addressable'      # for current URL with a subdomain
 gem 'kramdown'         # for Markdown processing
-gem 'markdown_media', '1.8' # for [[ media embeds ]]
+gem 'markdown_media'   # for [[ media embeds ]]
 gem 'pandoc-ruby'      # for Word to HTML conversion
 gem 'reverse_markdown' # for HTML to Markdown conversion
 gem 'rubypants'        # for smart quotes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
-    markdown_media (1.8.0)
+    markdown_media (2.0.1)
       kramdown
     matrix (0.4.2)
     memory_profiler (1.0.2)
@@ -547,7 +547,7 @@ DEPENDENCIES
   listen
   lograge
   logstash-event
-  markdown_media (= 1.8)
+  markdown_media
   memory_profiler
   nokogiri
   overcommit


### PR DESCRIPTION
To fix YouTube embeds with `markdown_media` 2.X

This PR effectively reverts https://github.com/crimethinc/website/pull/3867 