### PR TITLE
Remove dependabot bundler-all group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,7 @@ updates:
       # Dependabot creates groups in the order they appear in this config.
       # If a dependency update could belong to more than one group,
       # it is only assigned to the first group it matches with.
-      bundler-lint:
+      linters:
         patterns:
           - erb_lint
           - rubocop*
-      bundler-dev:
-        dependency-type: development

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,3 @@ updates:
           - rubocop*
       bundler-dev:
         dependency-type: development
-      bundler-all:
-        update-types:
-          - minor
-          - patch
-        exclude-patterns:
-          - rails


### PR DESCRIPTION
This PR removes `bundler-all` and `bundler-dev` dependabot groups.

I/we need better visibility into what's getting PRed/merged and when. 

A PR description that contains multiple gems' changelogs etc, formatted as HTML, all smooshed together, makes it effectively impossible to read the commit messages after they're merged to `main`. And PR titles like "Bump the bundler-all group with 15 updates" aren't very helpful either. Sadly.

IMO, I'd rather have lots of really clear, discrete gem bump PRs, than fewer PRs that obfuscate what is happening in each one. 