### PR TITLE
Add Dependabot group for AWS gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,11 @@ updates:
         patterns:
           - erb_lint
           - rubocop*
+      aws:
+        patterns:
+          - aws-eventstream
+          - aws-partitions
+          - aws-sdk-core
+          - aws-sdk-kms
+          - aws-sdk-s3
+          - aws-sigv4


### PR DESCRIPTION
Now we can start add groups of related gems back into the dependabot config.
Smaller and logically/thematically related. 