### PR TITLE
Add temp new enum columns backed by strings, to replace integer enums

### DIFF
--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -4,6 +4,11 @@ module Publishable
 
   included do
     enum :publication_status, PUBLICATION_STATUSES
+    enum :temp_publication_status,
+         { draft: :draft, published: :published },
+         default: :draft,
+         prefix:  true
+    # validate: true,
 
     default_scope { order(published_at: :desc) }
 

--- a/app/models/locale.rb
+++ b/app/models/locale.rb
@@ -9,6 +9,11 @@ class Locale < ApplicationRecord
   validates :name, uniqueness: true
 
   enum :language_direction, { ltr: 0, rtl: 1 }
+  enum :temp_language_direction,
+       { ltr: :ltr, rtl: :rtl },
+       default: :ltr,
+       prefix:  true
+  # validate: true,
 
   default_scope { order abbreviation: :asc }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,11 @@ class User < ApplicationRecord
   ROLES = %i[author editor publisher].freeze
 
   enum :role, ROLES
+  enum :temp_roles,
+       { author: :author, editor: :editor, publisher: :publisher },
+       default: :author,
+       prefix:  true
+  # validate: true,
 
   validates :username, presence: true, uniqueness: true, on: %i[create update]
 

--- a/db/migrate/20240909055738_add_temp_string_enum_columns.rb
+++ b/db/migrate/20240909055738_add_temp_string_enum_columns.rb
@@ -1,0 +1,18 @@
+class AddTempStringEnumColumns < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users,       :temp_roles,              :string, null: true
+    add_column :locales,     :temp_language_direction, :string, null: true
+    add_column :articles,    :temp_publication_status, :string, null: true
+    add_column :books,       :temp_publication_status, :string, null: true
+    add_column :definitions, :temp_publication_status, :string, null: true
+    add_column :episodes,    :temp_publication_status, :string, null: true
+    add_column :issues,      :temp_publication_status, :string, null: true
+    add_column :journals,    :temp_publication_status, :string, null: true
+    add_column :logos,       :temp_publication_status, :string, null: true
+    add_column :pages,       :temp_publication_status, :string, null: true
+    add_column :posters,     :temp_publication_status, :string, null: true
+    add_column :stickers,    :temp_publication_status, :string, null: true
+    add_column :videos,      :temp_publication_status, :string, null: true
+    add_column :zines,       :temp_publication_status, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_09_055738) do
+  create_schema "heroku_ext"
+
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -74,6 +77,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_articles_on_canonical_id"
     t.index ["collection_id"], name: "index_articles_on_collection_id"
   end
@@ -129,6 +133,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.boolean "hide_from_index", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_books_on_canonical_id"
   end
 
@@ -161,6 +166,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.boolean "featured_status", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_definitions_on_canonical_id"
   end
 
@@ -190,6 +196,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.integer "publication_status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_episodes_on_canonical_id"
     t.index ["podcast_id"], name: "index_episodes_on_podcast_id"
   end
@@ -247,6 +254,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.boolean "hide_from_index", default: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_issues_on_canonical_id"
   end
 
@@ -268,6 +276,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.boolean "hide_from_index", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_journals_on_canonical_id"
   end
 
@@ -280,6 +289,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.integer "articles_count", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_language_direction"
   end
 
   create_table "logos", force: :cascade do |t|
@@ -297,6 +307,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.boolean "hide_from_index", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_logos_on_canonical_id"
   end
 
@@ -321,6 +332,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.integer "canonical_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_pages_on_canonical_id"
   end
 
@@ -384,6 +396,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.boolean "hide_from_index", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_posters_on_canonical_id"
   end
 
@@ -430,6 +443,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.boolean "hide_from_index", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_stickers_on_canonical_id"
   end
 
@@ -464,6 +478,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.integer "role", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_roles"
   end
 
   create_table "videos", id: :serial, force: :cascade do |t|
@@ -488,6 +503,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.integer "canonical_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_videos_on_canonical_id"
   end
 
@@ -542,6 +558,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_30_054014) do
     t.boolean "hide_from_index", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "temp_publication_status"
     t.index ["canonical_id"], name: "index_zines_on_canonical_id"
   end
 


### PR DESCRIPTION
In Rails, `enum`s are very cool and powerful

https://api.rubyonrails.org/classes/ActiveRecord/Enum.html

I've found that the `enum`s backed strings are more intuitive and easier to work with. Also easier to deprecate, replace, add to. 

This PR is the first of few to migrate the few enums (backed by integers) to ones backed by strings

1. add new columns, with `temp_` in the name and `prefix: true` to avoid method namespace collision with existing enums
2. backfill data migration to populate new column with the string equivalent of the integer column (`0` => `draft`, etc)
3. move references from the enums to the new enums
4. drop the old column and old enums
5. rename new enums and columns back to what they were before (remove `temp_` prefix and `prefix: true`)