### PR TITLE
Use string enum columns instead of integer enum columns

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -113,7 +113,7 @@ module Admin
       @article.canonical_id       = canonical_article.id
       @article.locale             = params[:locale]
       @article.short_path         = nil
-      @article.publication_status = :draft
+      @article.publication_status = 'draft'
 
       @article.tags       = canonical_article.tags
       @article.categories = canonical_article.categories

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -121,6 +121,6 @@ module ArticlesHelper
   end
 
   def publication_status_badge_class article
-    article.publication_status.casecmp('draft').zero? ? 'danger' : 'success'
+    article.draft? ? 'danger' : 'success'
   end
 end

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -3,7 +3,6 @@ module Publishable
   extend ActiveSupport::Concern
 
   included do
-    # enum :publication_status, PUBLICATION_STATUSES
     enum :publication_status,
          { draft: 'draft', published: 'published' },
          default:  :draft,

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -3,12 +3,11 @@ module Publishable
   extend ActiveSupport::Concern
 
   included do
-    enum :publication_status, PUBLICATION_STATUSES
-    enum :temp_publication_status,
+    # enum :publication_status, PUBLICATION_STATUSES
+    enum :publication_status,
          { draft: 'draft', published: 'published' },
-         # default: :draft,
-         prefix:  true
-    # validate: true
+         default:  :draft,
+         validate: true
 
     default_scope { order(published_at: :desc) }
 

--- a/app/models/locale.rb
+++ b/app/models/locale.rb
@@ -8,12 +8,10 @@ class Locale < ApplicationRecord
   validates :name_in_english, uniqueness: true
   validates :name, uniqueness: true
 
-  enum :language_direction, { ltr: 0, rtl: 1 }
-  enum :temp_language_direction,
+  enum :language_direction,
        { ltr: 'ltr', rtl: 'rtl' },
-       # default: :ltr,
-       prefix:  true
-  # validate: true
+       default:  :ltr,
+       validate: true
 
   default_scope { order abbreviation: :asc }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,12 +4,11 @@ class User < ApplicationRecord
   PASSWORD_MINIMUM_LENGTH = 30
   ROLES = %i[author editor publisher].freeze
 
-  enum :role, ROLES
-  enum :temp_role,
+  # enum :role, ROLES
+  enum :role,
        { author: 'author', editor: 'editor', publisher: 'publisher' },
-       # default: :author,
-       prefix: true
-  # validate: true
+       default:  :author,
+       validate: true
 
   validates :username, presence: true, uniqueness: true, on: %i[create update]
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@ class User < ApplicationRecord
   PASSWORD_MINIMUM_LENGTH = 30
   ROLES = %i[author editor publisher].freeze
 
-  # enum :role, ROLES
   enum :role,
        { author: 'author', editor: 'editor', publisher: 'publisher' },
        default:  :author,

--- a/app/views/admin/locales/_form.html.erb
+++ b/app/views/admin/locales/_form.html.erb
@@ -10,7 +10,7 @@
       <div class="mb-3">
         <%= form.label :language_direction, "Direction", class: "form-label" %>
         <%= form.select :language_direction,
-                        Locale.language_directions.keys,
+                        Locale.language_directions,
                         {},
                         class: "form-select form-select-lg text-uppercase" %>
       </div>

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require "rubygems"
+require "bundler/setup"
+
+# explicit rubocop config increases performance slightly while avoiding config confusion.
+ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
+
+load Gem.bin_path("rubocop", "rubocop")

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
-require "rubygems"
-require "bundler/setup"
+require 'rubygems'
+require 'bundler/setup'
 
 # explicit rubocop config increases performance slightly while avoiding config confusion.
-ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
+ARGV.unshift('--config', File.expand_path('../.rubocop.yml', __dir__))
 
-load Gem.bin_path("rubocop", "rubocop")
+load Gem.bin_path('rubocop', 'rubocop')

--- a/db/migrate/20240910031633_rename_enum_colums.rb
+++ b/db/migrate/20240910031633_rename_enum_colums.rb
@@ -1,0 +1,48 @@
+class RenameEnumColums < ActiveRecord::Migration[7.2]
+  def change
+    # users
+    rename_column :users, :role,      :old_role
+    rename_column :users, :temp_role, :role
+
+    # locales
+    rename_column :locales, :language_direction,      :old_language_direction
+    rename_column :locales, :temp_language_direction, :language_direction
+
+    # publishables
+    rename_column :articles,    :publication_status,      :old_publication_status
+    rename_column :articles,    :temp_publication_status, :publication_status
+
+    rename_column :books,       :publication_status,      :old_publication_status
+    rename_column :books,       :temp_publication_status, :publication_status
+
+    rename_column :definitions, :publication_status,      :old_publication_status
+    rename_column :definitions, :temp_publication_status, :publication_status
+
+    rename_column :episodes,    :publication_status,      :old_publication_status
+    rename_column :episodes,    :temp_publication_status, :publication_status
+
+    rename_column :issues,      :publication_status,      :old_publication_status
+    rename_column :issues,      :temp_publication_status, :publication_status
+
+    rename_column :journals,    :publication_status,      :old_publication_status
+    rename_column :journals,    :temp_publication_status, :publication_status
+
+    rename_column :logos,       :publication_status,      :old_publication_status
+    rename_column :logos,       :temp_publication_status, :publication_status
+
+    rename_column :pages,       :publication_status,      :old_publication_status
+    rename_column :pages,       :temp_publication_status, :publication_status
+
+    rename_column :posters,     :publication_status,      :old_publication_status
+    rename_column :posters,     :temp_publication_status, :publication_status
+
+    rename_column :stickers,    :publication_status,      :old_publication_status
+    rename_column :stickers,    :temp_publication_status, :publication_status
+
+    rename_column :videos,      :publication_status,      :old_publication_status
+    rename_column :videos,      :temp_publication_status, :publication_status
+
+    rename_column :zines,       :publication_status,      :old_publication_status
+    rename_column :zines,       :temp_publication_status, :publication_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_10_031633) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -68,7 +68,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.text "image_mobile"
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.integer "page_views", default: 0
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.text "word_doc"
@@ -77,7 +77,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.text "notes"
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_articles_on_canonical_id"
     t.index ["collection_id"], name: "index_articles_on_collection_id"
   end
@@ -126,14 +126,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.boolean "print_black_and_white_download_present"
     t.boolean "screen_single_page_view_download_present"
     t.boolean "screen_two_page_view_download_present"
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
     t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_books_on_canonical_id"
   end
 
@@ -162,11 +162,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.string "filed_under"
     t.string "draft_code"
     t.string "slug"
-    t.integer "publication_status"
+    t.integer "old_publication_status"
     t.datetime "published_at", precision: nil
     t.datetime "featured_at", precision: nil
     t.boolean "featured_status", default: false
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_definitions_on_canonical_id"
   end
 
@@ -195,8 +195,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.string "draft_code"
-    t.integer "publication_status", default: 0, null: false
-    t.string "temp_publication_status"
+    t.integer "old_publication_status", default: 0, null: false
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_episodes_on_canonical_id"
     t.index ["podcast_id"], name: "index_episodes_on_podcast_id"
   end
@@ -245,7 +245,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.boolean "screen_two_page_view_download_present"
     t.integer "journal_id"
     t.integer "issue"
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
@@ -254,7 +254,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.boolean "hide_from_index", default: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_issues_on_canonical_id"
   end
 
@@ -266,7 +266,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "slug"
     t.datetime "published_at", precision: nil
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.text "buy_url"
     t.text "content"
     t.text "summary"
@@ -276,7 +276,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.integer "canonical_id"
     t.integer "position"
     t.boolean "hide_from_index", default: false
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_journals_on_canonical_id"
   end
 
@@ -286,10 +286,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.string "name"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.integer "language_direction", default: 0
+    t.integer "old_language_direction", default: 0
     t.string "slug"
     t.integer "articles_count", default: 0
-    t.string "temp_language_direction"
+    t.string "language_direction"
   end
 
   create_table "logos", force: :cascade do |t|
@@ -302,12 +302,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.text "summary"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.integer "position"
     t.boolean "hide_from_index", default: false
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_logos_on_canonical_id"
   end
 
@@ -329,10 +329,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_pages_on_canonical_id"
   end
 
@@ -389,14 +389,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.boolean "front_black_and_white_download_present"
     t.boolean "back_color_download_present"
     t.boolean "back_black_and_white_download_present"
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
     t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_posters_on_canonical_id"
   end
 
@@ -434,7 +434,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.boolean "front_black_and_white_download_present"
     t.boolean "back_color_download_present"
     t.boolean "back_black_and_white_download_present"
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
@@ -443,7 +443,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_stickers_on_canonical_id"
   end
 
@@ -477,8 +477,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.string "password_digest"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.integer "role", default: 0, null: false
-    t.string "temp_role"
+    t.integer "old_role", default: 0, null: false
+    t.string "role"
   end
 
   create_table "videos", id: :serial, force: :cascade do |t|
@@ -500,10 +500,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_videos_on_canonical_id"
   end
 
@@ -549,7 +549,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.boolean "print_black_and_white_download_present"
     t.boolean "screen_single_page_view_download_present"
     t.boolean "screen_two_page_view_download_present"
-    t.integer "publication_status", default: 0, null: false
+    t.integer "old_publication_status", default: 0, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
@@ -558,7 +558,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_09_064134) do
     t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
-    t.string "temp_publication_status"
+    t.string "publication_status"
     t.index ["canonical_id"], name: "index_zines_on_canonical_id"
   end
 


### PR DESCRIPTION
Continuing:

- https://github.com/crimethinc/website/pull/3925 
- https://github.com/crimethinc/website/pull/3936

this PR does 3, 4, and 5 from #3925 

> 1. ...
> 2. ...
> 3. move references from the enums to the new enums
> 4. drop the old column and old enums
> 5. rename new enums and columns back to what they were before (remove `temp_` prefix and `prefix: true`)