### PR TITLE
Add PeerTube URL to Video

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,6 +32,7 @@ Rails/OutputSafety:
     - 'app/helpers/articles_helper.rb'
     - 'app/helpers/embeds_helper.rb'
     - 'app/helpers/markdown_helper.rb'
+    - 'app/helpers/videos_helper.rb'
     - 'app/models/article.rb'
 
 # Offense count: 8

--- a/app/controllers/admin/videos_controller.rb
+++ b/app/controllers/admin/videos_controller.rb
@@ -59,9 +59,10 @@ module Admin
 
     def video_params
       params.require(:video).permit(
-        :title, :subtitle, :content, :slug, :vimeo_id, :image, :locale,
+        :title, :subtitle, :content, :slug, :image, :locale,
         :image_description, :image_poster_frame, :published_at, :tweet,
-        :summary, :quality, :duration, :published_at_tz, :publication_status
+        :summary, :quality, :duration, :published_at_tz, :publication_status,
+        :peer_tube_url, :vimeo_id
       )
     end
   end

--- a/app/helpers/videos_helper.rb
+++ b/app/helpers/videos_helper.rb
@@ -4,4 +4,10 @@ module VideosHelper
 
     image_tag url, class: 'mb-3 rounded d-block'
   end
+
+  def video_embed_tag video
+    render_markdown("[[ #{video.video_url} ]]")
+      .sub('video-container', 'ratio ratio-16x9')
+      .html_safe
+  end
 end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -12,4 +12,8 @@ class Video < ApplicationRecord
   def download_url
     "https://vimeo.com/#{vimeo_id}#download"
   end
+
+  def video_url
+    peer_tube_url.presence || "https://vimeo.com/#{vimeo_id}"
+  end
 end

--- a/app/views/2017/videos/_video.html.erb
+++ b/app/views/2017/videos/_video.html.erb
@@ -1,4 +1,4 @@
-<%= render_markdown "[[ https://vimeo.com/#{video.vimeo_id} ]]" %>
+<%= video_embed_tag video %>
 
 <div class="e-content">
   <p class="video-info">

--- a/app/views/admin/videos/_form.html.erb
+++ b/app/views/admin/videos/_form.html.erb
@@ -9,8 +9,14 @@
       <%= render "admin/label_and_field_form_group", form: form, attr: :vimeo_id, label_text: "Vimeo ID" %>
       <p class="form-text text-muted">
         https://vimeo.com/<code class="fw-bold">676634993</code>
-        The number part of the Vimeo URL imediately after the
+        The number part of the Vimeo URL immediately after the
         <code>.com/</code>.
+      </p>
+
+      <%= render "admin/label_and_field_form_group", form: form, attr: :peer_tube_url, label_text: "PeerTube URL" %>
+      <p class="form-text text-muted">
+        Kolektiva is powered by PeerTube. Example URL:
+        <code class="fw-bold">https://kolektiva.media/w/33ZwhxfHhkRMNJxrEnZTAi</code>
       </p>
 
       <%= form.label :image_poster_frame, "Poster Frame Image", class: "form-label" %>

--- a/app/views/admin/videos/show.html.erb
+++ b/app/views/admin/videos/show.html.erb
@@ -28,9 +28,7 @@
     <div class="col-12 col-md-7">
       <b>Video</b>
 
-      <%= render_markdown("[[ https://vimeo.com/#{@video.vimeo_id} ]]")
-            .sub('video-container', 'ratio ratio-16x9')
-            .html_safe %>
+      <%= video_embed_tag @video %>
 
       <b>Image</b>
 
@@ -46,6 +44,13 @@
 
     <div class="col-12 col-md-5">
       <dl>
+        <dt>PeerTube URL</dt>
+        <dd>
+          <% if @video.peer_tube_url.present? %>
+            <%= link_to @video.peer_tube_url, @video.peer_tube_url, target: :_blank %>
+          <% end %>
+        </dd>
+
         <dt>Vimeo ID</dt>
         <dd><%= @video.vimeo_id %></dd>
 

--- a/db/migrate/20241021223548_add_peer_tube_url_to_videos.rb
+++ b/db/migrate/20241021223548_add_peer_tube_url_to_videos.rb
@@ -1,0 +1,5 @@
+class AddPeerTubeUrlToVideos < ActiveRecord::Migration[7.2]
+  def change
+    add_column :videos, :peer_tube_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_10_031633) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_21_223548) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -504,6 +504,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_10_031633) do
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.string "publication_status"
+    t.text "peer_tube_url"
     t.index ["canonical_id"], name: "index_videos_on_canonical_id"
   end
 


### PR DESCRIPTION
- added `peer_tube_url` to `Video` model
- added `video_url` to `Video` model to switch between PeerTube and Vimeo
- added `video_embed_tag` helper
- used `video_embed_tag` in `/videos`, `/videos#show`, `/admin/videos#show`

# TODO

- add a setting in `/admin` be able to switch from PeerTube as the default back to Vimeo, in case of an outage or shutdown 