### PR TITLE
Deprecation warning: add ostruct gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,9 @@ gem 'sidekiq', '< 8'
 # syndication
 gem 'down' # downloading images from ActiveStorage/S3
 
+# for ruby standard library deprecations
+gem 'ostruct'
+
 # dev and testing
 group :development, :test do
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    ostruct (0.6.0)
     overcommit (0.64.0)
       childprocess (>= 0.6.3, < 6)
       iniparse (~> 1.4)
@@ -549,6 +550,7 @@ DEPENDENCIES
   markdown_media
   memory_profiler
   nokogiri
+  ostruct
   overcommit
   pandoc-ruby
   pg


### PR DESCRIPTION
> ~/.rubies/ruby-3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: 
> warning: `ostruct` was loaded from the standard library, 
> but will no longer be part of the default gems starting from Ruby 3.5.0.
>
> You can add ostruct to your `Gemfile` or `gemspec` to silence this warning.
