### PR TITLE
Preload turbo in importmap.rb (to fix CSS?)

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -10,6 +10,6 @@ pin 'bootstrap', to: 'bootstrap.min.js'
 # Hotwired JS https://hotwired.dev
 pin '@hotwired/stimulus',         to: 'stimulus.min.js',     preload: true
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
-pin '@hotwired/turbo-rails',      to: 'turbo.min.js'
+pin '@hotwired/turbo-rails',      to: 'turbo.min.js',        preload: true
 
 pin_all_from 'app/javascript/controllers', under: 'controllers'


### PR DESCRIPTION
Trying to fix the CSS intermittently only partially loading on (public facing) pages. Which also gets temporarily "fixed" after a manual refresh. 