### PR TITLE
On /about, add Mastodon/Bluesky, drop Twitter

### DIFF
--- a/config/locales/pages/ar/about.markdown
+++ b/config/locales/pages/ar/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/be/about.markdown
+++ b/config/locales/pages/be/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/bg/about.markdown
+++ b/config/locales/pages/bg/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/bn/about.markdown
+++ b/config/locales/pages/bn/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/cs/about.markdown
+++ b/config/locales/pages/cs/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/cz/about.markdown
+++ b/config/locales/pages/cz/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/da/about.markdown
+++ b/config/locales/pages/da/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/de/about.markdown
+++ b/config/locales/pages/de/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/dv/about.markdown
+++ b/config/locales/pages/dv/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/en/about.markdown
+++ b/config/locales/pages/en/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/es/about.markdown
+++ b/config/locales/pages/es/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/eu/about.markdown
+++ b/config/locales/pages/eu/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/fa/about.markdown
+++ b/config/locales/pages/fa/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/fi/about.markdown
+++ b/config/locales/pages/fi/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/fr/about.markdown
+++ b/config/locales/pages/fr/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/gl/about.markdown
+++ b/config/locales/pages/gl/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/gr/about.markdown
+++ b/config/locales/pages/gr/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/he/about.markdown
+++ b/config/locales/pages/he/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/hu/about.markdown
+++ b/config/locales/pages/hu/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/id/about.markdown
+++ b/config/locales/pages/id/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/it/about.markdown
+++ b/config/locales/pages/it/about.markdown
@@ -19,8 +19,11 @@
 _E-mail:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Vendita per corrispondenza
 

--- a/config/locales/pages/ja/about.markdown
+++ b/config/locales/pages/ja/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/ko/about.markdown
+++ b/config/locales/pages/ko/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/ku/about.markdown
+++ b/config/locales/pages/ku/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/nl/about.markdown
+++ b/config/locales/pages/nl/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/no/about.markdown
+++ b/config/locales/pages/no/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/pl/about.markdown
+++ b/config/locales/pages/pl/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/pt/about.markdown
+++ b/config/locales/pages/pt/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/ro/about.markdown
+++ b/config/locales/pages/ro/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/ru/about.markdown
+++ b/config/locales/pages/ru/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/sk/about.markdown
+++ b/config/locales/pages/sk/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/sl/about.markdown
+++ b/config/locales/pages/sl/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/sv/about.markdown
+++ b/config/locales/pages/sv/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/th/about.markdown
+++ b/config/locales/pages/th/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/tl/about.markdown
+++ b/config/locales/pages/tl/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/tr/about.markdown
+++ b/config/locales/pages/tr/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/uk/about.markdown
+++ b/config/locales/pages/uk/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/vi/about.markdown
+++ b/config/locales/pages/vi/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 

--- a/config/locales/pages/zh/about.markdown
+++ b/config/locales/pages/zh/about.markdown
@@ -19,8 +19,11 @@
 _Email:_ \\
 [contact@crimethinc.com](mailto:contact@crimethinc.com)
 
-_Twitter:_ \\
-[@crimethinc](https://twitter.com/crimethinc)
+_Mastodon:_ \\
+[@crimethinc@todon.eu](https://todon.eu/@CrimethInc)
+
+_Bluesky:_ \\
+[@crimethinc.bsky.social](https://bsky.app/profile/crimethinc.bsky.social)
 
 ## Mailorder
 


### PR DESCRIPTION
Goodbye, Twitter.
Hello, Mastodon & Bluesky.

This change was already made in the footer, long ago. This is just updating the /about page to match that.