### PR TITLE
Expand Featureable to all Tools

### DIFF
--- a/app/lib/feature_flag.rb
+++ b/app/lib/feature_flag.rb
@@ -1,3 +1,4 @@
+# TODO: delete this file
 # Start your Rails server with this ENV var:
 #     TWO_POINT_OH_YEAH=true bundle exec rails server
 #

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,6 +1,5 @@
 class Book < ApplicationRecord
   include MultiPageTool
-  include Featureable
 
   def ask_for_donation?
     downloads_available?

--- a/app/models/concerns/featureable.rb
+++ b/app/models/concerns/featureable.rb
@@ -2,10 +2,10 @@ module Featureable
   extend ActiveSupport::Concern
 
   # TEMP: re-enable and expand coverage to include Journal, Issue, et al
-  # included do
-  #   scope :featured, -> { where.not(featured_at: nil) }
-  #   before_save :update_featured_at
-  # end
+  included do
+    scope :featured, -> { where.not(featured_at: nil) }
+    before_save :update_featured_at
+  end
 
   module ClassMethods
     def for_index fallback_sort: { title: :asc }, fallback_locale: 'en'

--- a/app/models/concerns/featureable.rb
+++ b/app/models/concerns/featureable.rb
@@ -1,7 +1,6 @@
 module Featureable
   extend ActiveSupport::Concern
 
-  # TEMP: re-enable and expand coverage to include Journal, Issue, et al
   included do
     scope :featured, -> { where.not(featured_at: nil) }
     before_save :update_featured_at

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -1,5 +1,6 @@
 class Episode < ApplicationRecord
   include Name
+  include Featureable
   include Publishable
 
   belongs_to :podcast

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,6 +1,5 @@
 class Issue < ApplicationRecord
   include MultiPageTool
-  include Featureable
 
   belongs_to :journal
 

--- a/app/models/logo.rb
+++ b/app/models/logo.rb
@@ -1,5 +1,7 @@
 class Logo < ApplicationRecord
   include Tool
+  include Featureable
+
   has_one_attached :image_jpg, dependent: :destroy
   has_one_attached :image_png, dependent: :destroy
   has_one_attached :image_pdf, dependent: :destroy

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -1,5 +1,6 @@
 class Podcast < ApplicationRecord
   include Name
+  include Featureable
 
   has_many :episodes, dependent: :destroy
 

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,5 +1,6 @@
 class Video < ApplicationRecord
   include Tool
+  include Featureable
 
   has_one_attached :image_poster_frame
 

--- a/db/migrate/20241125231604_add_featured_to_all_tools.rb
+++ b/db/migrate/20241125231604_add_featured_to_all_tools.rb
@@ -1,0 +1,33 @@
+class AddFeaturedToAllTools < ActiveRecord::Migration[7.2]
+  def change
+    # logos
+    change_table :logos, bulk: true do |t|
+      t.boolean  :featured_status, default: false, null: false
+      t.datetime :featured_at,     precision: nil
+    end
+
+    # podcasts
+    change_table :podcasts, bulk: true do |t|
+      t.boolean  :boolean,  default: false, null: false
+      t.datetime :datetime, precision: nil
+    end
+
+    # episodes
+    change_table :episodes, bulk: true do |t|
+      t.boolean  :boolean,  default: false, null: false
+      t.datetime :datetime, precision: nil
+    end
+
+    # issues
+    change_table :issues, bulk: true do |t|
+      t.boolean  :boolean,  default: false, null: false
+      t.datetime :datetime, precision: nil
+    end
+
+    # videos
+    change_table :videos, bulk: true do |t|
+      t.boolean  :boolean, default: false, null: false
+      t.datetime :datetime, precision: nil
+    end
+  end
+end

--- a/db/migrate/20241125231604_add_featured_to_all_tools.rb
+++ b/db/migrate/20241125231604_add_featured_to_all_tools.rb
@@ -8,26 +8,26 @@ class AddFeaturedToAllTools < ActiveRecord::Migration[7.2]
 
     # podcasts
     change_table :podcasts, bulk: true do |t|
-      t.boolean  :boolean,  default: false, null: false
-      t.datetime :datetime, precision: nil
+      t.boolean  :featured_status, default: false, null: false
+      t.datetime :featured_at, precision: nil
     end
 
     # episodes
     change_table :episodes, bulk: true do |t|
-      t.boolean  :boolean,  default: false, null: false
-      t.datetime :datetime, precision: nil
+      t.boolean  :featured_status, default: false, null: false
+      t.datetime :featured_at, precision: nil
     end
 
-    # issues
-    change_table :issues, bulk: true do |t|
-      t.boolean  :boolean,  default: false, null: false
-      t.datetime :datetime, precision: nil
+    # journals
+    change_table :journals, bulk: true do |t|
+      t.boolean  :featured_status, default: false, null: false
+      t.datetime :featured_at, precision: nil
     end
 
     # videos
     change_table :videos, bulk: true do |t|
-      t.boolean  :boolean, default: false, null: false
-      t.datetime :datetime, precision: nil
+      t.boolean  :featured_status, default: false, null: false
+      t.datetime :featured_at, precision: nil
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_21_223548) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
   create_schema "heroku_ext"
 
   # These are extensions that must be enabled in order to support this database
@@ -193,6 +193,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_21_223548) do
     t.integer "canonical_id"
     t.string "draft_code"
     t.string "publication_status"
+    t.boolean "boolean", default: false, null: false
+    t.datetime "datetime", precision: nil
     t.index ["canonical_id"], name: "index_episodes_on_canonical_id"
     t.index ["podcast_id"], name: "index_episodes_on_podcast_id"
   end
@@ -250,6 +252,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_21_223548) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "publication_status"
+    t.boolean "boolean", default: false, null: false
+    t.datetime "datetime", precision: nil
     t.index ["canonical_id"], name: "index_issues_on_canonical_id"
   end
 
@@ -300,6 +304,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_21_223548) do
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.string "publication_status"
+    t.boolean "featured_status", default: false, null: false
+    t.datetime "featured_at", precision: nil
     t.index ["canonical_id"], name: "index_logos_on_canonical_id"
   end
 
@@ -350,6 +356,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_21_223548) do
     t.string "episode_prefix"
     t.string "locale", default: "en"
     t.integer "canonical_id"
+    t.boolean "boolean", default: false, null: false
+    t.datetime "datetime", precision: nil
     t.index ["canonical_id"], name: "index_podcasts_on_canonical_id"
   end
 
@@ -492,6 +500,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_21_223548) do
     t.integer "canonical_id"
     t.string "publication_status"
     t.text "peer_tube_url"
+    t.boolean "boolean", default: false, null: false
+    t.datetime "datetime", precision: nil
     t.index ["canonical_id"], name: "index_videos_on_canonical_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,8 +61,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.string "year"
     t.string "month"
     t.string "day"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.integer "collection_id"
     t.string "short_path"
     t.text "image_mobile"
@@ -76,6 +74,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.integer "position"
     t.boolean "hide_from_index", default: false
     t.text "notes"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
     t.index ["canonical_id"], name: "index_articles_on_canonical_id"
     t.index ["collection_id"], name: "index_articles_on_collection_id"
@@ -111,8 +111,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.text "cover_style"
     t.text "binding_style"
     t.text "table_of_contents"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.boolean "back_image_present", default: false
     t.boolean "front_image_present", default: false
     t.boolean "lite_download_present", default: false
@@ -131,6 +129,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
     t.index ["canonical_id"], name: "index_books_on_canonical_id"
   end
@@ -138,31 +138,31 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
   create_table "categories", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "slug"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "categorizations", id: :serial, force: :cascade do |t|
     t.integer "category_id"
     t.integer "article_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "definitions", force: :cascade do |t|
     t.string "title"
     t.text "content"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.string "subtitle"
     t.string "filed_under"
     t.string "draft_code"
     t.string "slug"
-    t.datetime "published_at", precision: nil
-    t.datetime "featured_at", precision: nil
+    t.datetime "published_at"
+    t.datetime "featured_at"
     t.boolean "featured_status", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
     t.index ["canonical_id"], name: "index_definitions_on_canonical_id"
   end
@@ -184,17 +184,17 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.string "audio_type", default: "audio/mpeg"
     t.string "tags"
     t.datetime "published_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "slug"
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.string "episode_number"
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.string "draft_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
-    t.boolean "boolean", default: false, null: false
-    t.datetime "datetime", precision: nil
+    t.boolean "featured_status", default: false, null: false
+    t.datetime "featured_at", precision: nil
     t.index ["canonical_id"], name: "index_episodes_on_canonical_id"
     t.index ["podcast_id"], name: "index_episodes_on_podcast_id"
   end
@@ -252,8 +252,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "publication_status"
-    t.boolean "boolean", default: false, null: false
-    t.datetime "datetime", precision: nil
     t.index ["canonical_id"], name: "index_issues_on_canonical_id"
   end
 
@@ -261,8 +259,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.string "title"
     t.string "subtitle"
     t.text "description"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "slug"
     t.datetime "published_at", precision: nil
     t.text "buy_url"
@@ -274,7 +270,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.integer "canonical_id"
     t.integer "position"
     t.boolean "hide_from_index", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
+    t.boolean "featured_status", default: false, null: false
+    t.datetime "featured_at", precision: nil
     t.index ["canonical_id"], name: "index_journals_on_canonical_id"
   end
 
@@ -282,10 +282,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.string "abbreviation"
     t.string "name_in_english"
     t.string "name"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "slug"
     t.integer "articles_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "language_direction"
   end
 
@@ -297,12 +297,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.string "content_format"
     t.datetime "published_at", precision: nil
     t.text "summary"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.integer "position"
     t.boolean "hide_from_index", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
     t.boolean "featured_status", default: false, null: false
     t.datetime "featured_at", precision: nil
@@ -324,11 +324,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.string "slug"
     t.string "draft_code"
     t.datetime "published_at", precision: nil
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
     t.index ["canonical_id"], name: "index_pages_on_canonical_id"
   end
@@ -351,13 +351,13 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.text "itunes_url"
     t.text "overcast_url"
     t.text "pocketcasts_url"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "episode_prefix"
     t.string "locale", default: "en"
     t.integer "canonical_id"
-    t.boolean "boolean", default: false, null: false
-    t.datetime "datetime", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "featured_status", default: false, null: false
+    t.datetime "featured_at", precision: nil
     t.index ["canonical_id"], name: "index_podcasts_on_canonical_id"
   end
 
@@ -374,8 +374,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.text "slug"
     t.string "height"
     t.string "width"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "depth"
     t.string "front_image_format", default: "jpg"
     t.string "back_image_format", default: "jpg"
@@ -394,6 +392,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
     t.index ["canonical_id"], name: "index_posters_on_canonical_id"
   end
@@ -402,9 +402,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.string "source_path"
     t.string "target_path"
     t.boolean "temporary"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.integer "article_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "stickers", force: :cascade do |t|
@@ -432,14 +432,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.boolean "front_black_and_white_download_present"
     t.boolean "back_color_download_present"
     t.boolean "back_black_and_white_download_present"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
     t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
     t.index ["canonical_id"], name: "index_stickers_on_canonical_id"
   end
@@ -453,18 +453,18 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
   create_table "taggings", id: :serial, force: :cascade do |t|
     t.integer "tag_id"
     t.integer "taggable_id"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "taggable_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "tags", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "slug"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["canonical_id"], name: "index_tags_on_canonical_id"
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
@@ -472,8 +472,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "username"
     t.string "password_digest"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "role"
   end
 
@@ -493,15 +493,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.string "year"
     t.string "month"
     t.string "day"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "published_at_tz", default: "Pacific Time (US & Canada)", null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
     t.text "peer_tube_url"
-    t.boolean "boolean", default: false, null: false
-    t.datetime "datetime", precision: nil
+    t.boolean "featured_status", default: false, null: false
+    t.datetime "featured_at", precision: nil
     t.index ["canonical_id"], name: "index_videos_on_canonical_id"
   end
 
@@ -547,14 +547,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_25_231604) do
     t.boolean "print_black_and_white_download_present"
     t.boolean "screen_single_page_view_download_present"
     t.boolean "screen_two_page_view_download_present"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
     t.string "locale", default: "en"
     t.integer "canonical_id"
     t.boolean "featured_status", default: false
     t.datetime "featured_at", precision: nil
     t.integer "position"
     t.boolean "hide_from_index", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "publication_status"
     t.index ["canonical_id"], name: "index_zines_on_canonical_id"
   end


### PR DESCRIPTION
This adds `featured_status` and `featured_at` to tables for tools that didn't have it:

- logos
- podcasts
- episodes
- journals
- videos

