### PR TITLE
Add more pen test looking URL segments to Teapot 418 middleware

### DIFF
--- a/app/middlewares/rack/teapot.rb
+++ b/app/middlewares/rack/teapot.rb
@@ -13,14 +13,17 @@ module Rack
         ads.txt
         afacacaeusaaa
         asp.net
+        cdnbuster
+        connector.asp
         error.asp
+        FCKeditor
+        filemanager
+        jars
         kindeditor
         README.txt
         wp
-        wp-login
         wp-admin
-        cdnbuster
-        jars
+        wp-login
       ]
     ).freeze
 


### PR DESCRIPTION
We get exploratory requests looking for common software: wp-admin, asp.net, etc

This adds FCKeditor related path segments to the ban list

![](https://http.cat/418.jpg)