### PR TITLE
Redirect non-existent journals or issues

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -5,7 +5,11 @@ class IssuesController < ApplicationController
   def show
     @type     = 'issues'
     journal   = Journal.find_by(slug: show_params[:slug])
-    @issue    = Issue.find_by(issue: show_params[:issue_number], journal_id: journal.id)
+    return redirect_to :journals if journal.blank?
+
+    @issue = Issue.find_by(issue: show_params[:issue_number], journal_id: journal.id)
+    return redirect_to journal.path if @issue.blank?
+
     @tool     = @issue
     @editable = @issue
 


### PR DESCRIPTION
Instead of 500ing for requests like:

`/journals/rolling-thunder/13` (real journal, but not an issue that was never published)
we'll redirect to `/journals/rolling-thunder`

`/journals/aslkdfjalskfjdkl` (non-existent journal)
we'll redirect to `/journals`

