### PR TITLE
[2025] Article archives

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Metrics/BlockLength:
     - 'config/routes.rb'
 
 Metrics/ClassLength:
-  Max: 135
+  Max: 145
 
 Metrics/CyclomaticComplexity:
   Max: 13
@@ -58,7 +58,7 @@ Naming/VariableNumber:
   EnforcedStyle: snake_case
 
 # TODO: https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsenvironmentvariableaccess
-#       Consider using `Rails.application.config.foo` instead of `ENV["FOO"]`
+#       Consider using `Rails.application.config.foo` instead of `ENV['FOO']`
 Rails/EnvironmentVariableAccess:
   Enabled: false
 

--- a/app/assets/stylesheets/2025/fonts.css
+++ b/app/assets/stylesheets/2025/fonts.css
@@ -114,6 +114,8 @@ Fonts
   src: url("alrightsans-ultraitalic-webfont.woff2") format("woff2");
 }
 
+/* -------------------------------------------------------------------------- */
+
 /* arabic */
 @font-face {
   font-family: 'Markazi Text';
@@ -122,36 +124,6 @@ Fonts
   font-display: swap;
   src: url('markazi-arabic.woff2') format('woff2');
   unicode-range: U+0600-06FF, U+0750-077F, U+0870-088E, U+0890-0891, U+0897-08E1, U+08E3-08FF, U+200C-200E, U+2010-2011, U+204F, U+2E41, U+FB50-FDFF, U+FE70-FE74, U+FE76-FEFC, U+102E0-102FB, U+10E60-10E7E, U+10EC2-10EC4, U+10EFC-10EFF, U+1EE00-1EE03, U+1EE05-1EE1F, U+1EE21-1EE22, U+1EE24, U+1EE27, U+1EE29-1EE32, U+1EE34-1EE37, U+1EE39, U+1EE3B, U+1EE42, U+1EE47, U+1EE49, U+1EE4B, U+1EE4D-1EE4F, U+1EE51-1EE52, U+1EE54, U+1EE57, U+1EE59, U+1EE5B, U+1EE5D, U+1EE5F, U+1EE61-1EE62, U+1EE64, U+1EE67-1EE6A, U+1EE6C-1EE72, U+1EE74-1EE77, U+1EE79-1EE7C, U+1EE7E, U+1EE80-1EE89, U+1EE8B-1EE9B, U+1EEA1-1EEA3, U+1EEA5-1EEA9, U+1EEAB-1EEBB, U+1EEF0-1EEF1;
-}
-
-/* vietnamese */
-@font-face {
-  font-family: 'Markazi Text';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('markazi-vietnamese.woff2') format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
-}
-
-/* latin-ext */
-@font-face {
-  font-family: 'Markazi Text';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('latin-ext-arabic.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-/* latin */
-@font-face {
-  font-family: 'Markazi Text';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('markazi-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* arabic */
@@ -164,36 +136,6 @@ Fonts
   unicode-range: U+0600-06FF, U+0750-077F, U+0870-088E, U+0890-0891, U+0897-08E1, U+08E3-08FF, U+200C-200E, U+2010-2011, U+204F, U+2E41, U+FB50-FDFF, U+FE70-FE74, U+FE76-FEFC, U+102E0-102FB, U+10E60-10E7E, U+10EC2-10EC4, U+10EFC-10EFF, U+1EE00-1EE03, U+1EE05-1EE1F, U+1EE21-1EE22, U+1EE24, U+1EE27, U+1EE29-1EE32, U+1EE34-1EE37, U+1EE39, U+1EE3B, U+1EE42, U+1EE47, U+1EE49, U+1EE4B, U+1EE4D-1EE4F, U+1EE51-1EE52, U+1EE54, U+1EE57, U+1EE59, U+1EE5B, U+1EE5D, U+1EE5F, U+1EE61-1EE62, U+1EE64, U+1EE67-1EE6A, U+1EE6C-1EE72, U+1EE74-1EE77, U+1EE79-1EE7C, U+1EE7E, U+1EE80-1EE89, U+1EE8B-1EE9B, U+1EEA1-1EEA3, U+1EEA5-1EEA9, U+1EEAB-1EEBB, U+1EEF0-1EEF1;
 }
 
-/* vietnamese */
-@font-face {
-  font-family: 'Markazi Text';
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-  src: url('markazi-vietnamese.woff2') format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
-}
-
-/* latin-ext */
-@font-face {
-  font-family: 'Markazi Text';
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-  src: url('latin-ext-arabic.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-/* latin */
-@font-face {
-  font-family: 'Markazi Text';
-  font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-  src: url('markazi-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-
 /* arabic */
 @font-face {
   font-family: 'Markazi Text';
@@ -202,36 +144,6 @@ Fonts
   font-display: swap;
   src: url('markazi-arabic.woff2') format('woff2');
   unicode-range: U+0600-06FF, U+0750-077F, U+0870-088E, U+0890-0891, U+0897-08E1, U+08E3-08FF, U+200C-200E, U+2010-2011, U+204F, U+2E41, U+FB50-FDFF, U+FE70-FE74, U+FE76-FEFC, U+102E0-102FB, U+10E60-10E7E, U+10EC2-10EC4, U+10EFC-10EFF, U+1EE00-1EE03, U+1EE05-1EE1F, U+1EE21-1EE22, U+1EE24, U+1EE27, U+1EE29-1EE32, U+1EE34-1EE37, U+1EE39, U+1EE3B, U+1EE42, U+1EE47, U+1EE49, U+1EE4B, U+1EE4D-1EE4F, U+1EE51-1EE52, U+1EE54, U+1EE57, U+1EE59, U+1EE5B, U+1EE5D, U+1EE5F, U+1EE61-1EE62, U+1EE64, U+1EE67-1EE6A, U+1EE6C-1EE72, U+1EE74-1EE77, U+1EE79-1EE7C, U+1EE7E, U+1EE80-1EE89, U+1EE8B-1EE9B, U+1EEA1-1EEA3, U+1EEA5-1EEA9, U+1EEAB-1EEBB, U+1EEF0-1EEF1;
-}
-
-/* vietnamese */
-@font-face {
-  font-family: 'Markazi Text';
-  font-style: normal;
-  font-weight: 600;
-  font-display: swap;
-  src: url('markazi-vietnamese.woff2') format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
-}
-
-/* latin-ext */
-@font-face {
-  font-family: 'Markazi Text';
-  font-style: normal;
-  font-weight: 600;
-  font-display: swap;
-  src: url('latin-ext-arabic.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-
-/* latin */
-@font-face {
-  font-family: 'Markazi Text';
-  font-style: normal;
-  font-weight: 600;
-  font-display: swap;
-  src: url('markazi-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* arabic */
@@ -244,6 +156,39 @@ Fonts
   unicode-range: U+0600-06FF, U+0750-077F, U+0870-088E, U+0890-0891, U+0897-08E1, U+08E3-08FF, U+200C-200E, U+2010-2011, U+204F, U+2E41, U+FB50-FDFF, U+FE70-FE74, U+FE76-FEFC, U+102E0-102FB, U+10E60-10E7E, U+10EC2-10EC4, U+10EFC-10EFF, U+1EE00-1EE03, U+1EE05-1EE1F, U+1EE21-1EE22, U+1EE24, U+1EE27, U+1EE29-1EE32, U+1EE34-1EE37, U+1EE39, U+1EE3B, U+1EE42, U+1EE47, U+1EE49, U+1EE4B, U+1EE4D-1EE4F, U+1EE51-1EE52, U+1EE54, U+1EE57, U+1EE59, U+1EE5B, U+1EE5D, U+1EE5F, U+1EE61-1EE62, U+1EE64, U+1EE67-1EE6A, U+1EE6C-1EE72, U+1EE74-1EE77, U+1EE79-1EE7C, U+1EE7E, U+1EE80-1EE89, U+1EE8B-1EE9B, U+1EEA1-1EEA3, U+1EEA5-1EEA9, U+1EEAB-1EEBB, U+1EEF0-1EEF1;
 }
 
+/* -------------------------------------------------------------------------- */
+
+/* vietnamese */
+@font-face {
+  font-family: 'Markazi Text';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('markazi-vietnamese.woff2') format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+
+/* vietnamese */
+@font-face {
+  font-family: 'Markazi Text';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url('markazi-vietnamese.woff2') format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+
+/* vietnamese */
+@font-face {
+  font-family: 'Markazi Text';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url('markazi-vietnamese.woff2') format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+
+
 /* vietnamese */
 @font-face {
   font-family: 'Markazi Text';
@@ -252,6 +197,38 @@ Fonts
   font-display: swap;
   src: url('markazi-vietnamese.woff2') format('woff2');
   unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+
+/* -------------------------------------------------------------------------- */
+
+/* latin-ext */
+@font-face {
+  font-family: 'Markazi Text';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('latin-ext-arabic.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* latin-ext */
+@font-face {
+  font-family: 'Markazi Text';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url('latin-ext-arabic.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* latin-ext */
+@font-face {
+  font-family: 'Markazi Text';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url('latin-ext-arabic.woff2') format('woff2');
+  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
 /* latin-ext */
@@ -264,6 +241,39 @@ Fonts
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
+/* -------------------------------------------------------------------------- */
+
+
+/* latin */
+@font-face {
+  font-family: 'Markazi Text';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url('markazi-latin.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* latin */
+@font-face {
+  font-family: 'Markazi Text';
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+  src: url('markazi-latin.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* latin */
+@font-face {
+  font-family: 'Markazi Text';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: url('markazi-latin.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
 /* latin */
 @font-face {
   font-family: 'Markazi Text';
@@ -273,3 +283,4 @@ Fonts
   src: url('markazi-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
+

--- a/app/assets/stylesheets/2025/headings.css
+++ b/app/assets/stylesheets/2025/headings.css
@@ -2,14 +2,18 @@
 H1-H6 headings
 */
 
-h1, h2, h3, h4, h5, h6,
-.h1, .h2, .h3, .h4, .h5, .h6 {
-  font-family: 'Markazi Text';
-  line-height: 1;
+article,
+.titles {
+  h1, h2, h3, h4, h5, h6,
+  .h1, .h2, .h3, .h4, .h5, .h6 {
+    font-family: 'Markazi Text';
+    font-weight: bold;
+    line-height: 1;
 
-  small {
-    font-family: var(--bs-font-sans-serif);
-    font-weight: normal;
-    font-size: .5em;
+    small {
+      font-family: var(--bs-font-sans-serif);
+      font-weight: normal;
+      font-size: .5em;
+    }
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,6 +79,7 @@ class ApplicationController < ActionController::Base
 
   def pages_for_2025_theme
     %w[
+      article_archives#index
       home#index
       languages#index
       languages#show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,14 +9,17 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  before_action :authorize, if: :staging?
+  before_action :check_for_redirection
+  before_action :strip_file_extension
+
   before_action :set_current_locale
   before_action :set_current_theme
   before_action :set_site_locale
   before_action :set_subdomain_locales
+  before_action :set_categories
+  before_action :set_years
 
-  before_action :check_for_redirection
-  before_action :strip_file_extension
-  before_action :authorize, if: :staging?
   before_action :set_page_share
 
   helper :meta
@@ -189,6 +192,7 @@ class ApplicationController < ActionController::Base
     # TODO: implement this algorithm
     'https://cdn.crimethinc.com/assets/share/crimethinc-site-share.png'
   end
+  # ...Page Share
 
   def set_site_locale
     @site_locale = LocaleService.find(locale: nil, lang_code: I18n.locale)
@@ -198,5 +202,12 @@ class ApplicationController < ActionController::Base
     # Site language/subdomain switcher
     @subdomain_locales = Locale.where abbreviation: Rails.application.config.subdomain_locales
   end
-  # ...Page Share
+
+  def set_categories
+    @categories = Category.all
+  end
+
+  def set_years
+    @years = (1996..Time.current.year).to_a.reverse
+  end
 end

--- a/app/controllers/article_archives_controller.rb
+++ b/app/controllers/article_archives_controller.rb
@@ -4,6 +4,9 @@ class ArticleArchivesController < ApplicationController
     @body_id = 'article-archives'
     @title   = PageTitle.new title_for :archives
 
+    # NOTE: @categories and @years are used on every page in the header search card
+    #       each is set in a before_action in application_controller
+
     @article_archive = ArticleArchive.new(year:  params[:year],
                                           month: params[:month],
                                           day:   params[:day],

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -117,7 +117,7 @@ module ArticlesHelper
       )
     end
 
-    links.join('-').html_safe
+    links.join('–').html_safe
   end
 
   def publication_status_badge_class article

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -15,11 +15,11 @@ module MarkdownHelper
       transliterated_header_ids: true
     ).to_html.html_safe
 
-    html = remove_wrapper_p_tag_from html: html if remove_wrapper_p_tag.present?
+    html = remove_wrapper_p_tag_from html if remove_wrapper_p_tag.present?
     html
   end
 
-  def remove_wrapper_p_tag_from html:
+  def remove_wrapper_p_tag_from html
     fragment = Nokogiri::HTML5.fragment html
     fragment.inner_html.gsub('<p>', '').gsub('</p>', '').strip.html_safe
   end

--- a/app/views/2025/article_archives/_card.html.erb
+++ b/app/views/2025/article_archives/_card.html.erb
@@ -1,0 +1,15 @@
+<% cache [:story_card, article, lite_mode?] do %>
+  <% unless article.blank? %>
+    <% if lite_mode? %>
+      <article class="h-entry" id="article-<%= article.id %>">
+    <% else %>
+      <article class="h-entry"
+               id="article-<%= article.id %>"
+               style="<%= story_card_background_image(article: article) %>">
+    <% end %>
+
+    <%= render_themed "articles/header",     article: article %>
+    <%= render_themed "articles/categories", article: article %>
+    </article>
+  <% end %>
+<% end %>

--- a/app/views/2025/article_archives/index.html.erb
+++ b/app/views/2025/article_archives/index.html.erb
@@ -1,0 +1,65 @@
+<% content_for(:head) do %>
+  <%= rel_next_prev_link_tags @article_archive.articles %>
+<% end %>
+
+<div class='container'>
+  <div class='row'>
+    <div class='col-md-6 col-lg-8'>
+      <header class=' pb-3 mb-4 border-bottom'>
+        <h1 class='fw-normal'>
+          <b><%= tt :archives %></b> :
+
+          <time datetime='<%= [@article_archive.year, @article_archive.month, @article_archive.day].compact.join '-' %>'>
+            <%= link_to_dates(year: @article_archive.year, month: @article_archive.month, day: @article_archive.day) %>
+          </time>
+        </h1>
+      </header>
+
+      ARTICLES Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </div>
+
+    <div class='col-md-6 col-lg-4'>
+      <header class='pb-3 mb-4 border-bottom'>
+
+      <h1>Explore The Archives</h1>
+      </header>
+
+      LISTS Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </div>
+
+
+  </div><!-- .row -->
+
+</div>
+
+<div class="h-feed">
+  <% @article_archive.each do |year, months| %>
+    <% months.sort.reverse_each do |month, articles| %>
+
+      <% unless @article_archive.day.present? || @article_archive.month.present? %>
+        <h1 class="year-month"><%= link_to_dates(year: year, month: month) %></h1>
+      <% end %>
+
+      <%= render_themed "articles/list", articles: articles %>
+
+    <% end %>
+  <% end %>
+</div>
+
+<%= paginate @article_archive %>
+
+<div class="pagination-container">
+  <ul class="pagination">
+    <% if @article_archive.paginator.next? %>
+      <li class="page">
+        <%= link_to @article_archive.paginator.next_label, @article_archive.paginator.next_path %>
+      </li>
+    <% end %>
+
+    <% if @article_archive.paginator.previous? %>
+      <li class="page">
+        <%= link_to @article_archive.paginator.previous_label, @article_archive.paginator.previous_path %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/2025/article_archives/index.html.erb
+++ b/app/views/2025/article_archives/index.html.erb
@@ -32,29 +32,15 @@
           <%= link_to 'Navigate by theme', '#categories' %>
         </h2>
 
-        <ul class='list-inline underlined-links lh-lg'>
-          <% @categories.each do |category| %>
-            <% classes = 'pe-2 me-1 border-end' unless category == @categories.last %>
-            <li class='list-inline-item me-0'>
-              <%= link_to category.name, category.path, class: classes %>
-            </li>
-          <% end %>
-        </ul>
+        <%= render_themed 'categories/list', categories: @categories %>
       </div>
 
       <div id='years' class='mb-5 pt-3'>
         <h2 class='h4 fw-bold'>
-        <%= link_to 'Navigate chronologically', '#years' %>
+          <%= link_to 'Navigate chronologically', '#years' %>
         </h2>
 
-        <ul class='list-inline underlined-links lh-lg'>
-          <% @years.each do |year| %>
-            <% classes = 'pe-2 me-1 border-end' unless year == @years.last %>
-            <li class='list-inline-item me-0'>
-              <%= link_to year, [:article_archives, year: year], class: classes %>
-            </li>
-          <% end %>
-        </ul>
+        <%= render_themed 'years/list', years: @years %>
       </div>
     </div><!-- /TEMP RIGHT COLUMN -->
   </div><!-- .row -->

--- a/app/views/2025/article_archives/index.html.erb
+++ b/app/views/2025/article_archives/index.html.erb
@@ -4,33 +4,63 @@
 
 <div class='container'>
   <div class='row'>
-    <div class='col-md-6 col-lg-8'>
-      <header class=' pb-3 mb-4 border-bottom'>
-        <h1 class='fw-normal'>
-          <b><%= tt :archives %></b> :
+    <div class='col-md-6 col-lg-8'><!-- TEMP LEFT COLUMN -->
+      <header class='titles pb-3 mb-4 border-bottom'>
+        <h1>
+          <%= tt :archives %>
 
-          <time datetime='<%= [@article_archive.year, @article_archive.month, @article_archive.day].compact.join '-' %>'>
-            <%= link_to_dates(year: @article_archive.year, month: @article_archive.month, day: @article_archive.day) %>
-          </time>
+          <span class='fw-normal'>
+            :
+            <time datetime='<%= [@article_archive.year, @article_archive.month, @article_archive.day].compact.join '-' %>'>
+              <%= link_to_dates(year: @article_archive.year, month: @article_archive.month, day: @article_archive.day) %>
+            </time>
+          </span>
         </h1>
       </header>
 
-      ARTICLES Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-    </div>
+      ARTICLES GO HERE Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </div><!-- /TEMP LEFT COLUMN -->
 
-    <div class='col-md-6 col-lg-4'>
-      <header class='pb-3 mb-4 border-bottom'>
-
-      <h1>Explore The Archives</h1>
+    <div class='col-md-6 col-lg-4'><!-- /TEMP RIGHT COLUMN -->
+      <header class='titles pb-3 mb-2 border-bottom fw-normal'>
+        <h1 class='fw-normal'>See also…</h1>
+        <h2 class='fw-normal'>Explore The Archives</h2>
       </header>
 
-      LISTS Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-    </div>
+      <div id='categories' class='mb-5 pt-3'>
+        <h2 class='h4 fw-bold'>
+          <%= link_to 'Navigate by theme', '#categories' %>
+        </h2>
 
+        <ul class='list-inline underlined-links lh-lg'>
+          <% @categories.each do |category| %>
+            <% classes = 'pe-2 me-1 border-end' unless category == @categories.last %>
+            <li class='list-inline-item me-0'>
+              <%= link_to category.name, category.path, class: classes %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
 
+      <div id='years' class='mb-5 pt-3'>
+        <h2 class='h4 fw-bold'>
+        <%= link_to 'Navigate chronologically', '#years' %>
+        </h2>
+
+        <ul class='list-inline underlined-links lh-lg'>
+          <% @years.each do |year| %>
+            <% classes = 'pe-2 me-1 border-end' unless year == @years.last %>
+            <li class='list-inline-item me-0'>
+              <%= link_to year, [:article_archives, year: year], class: classes %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div><!-- /TEMP RIGHT COLUMN -->
   </div><!-- .row -->
-
 </div>
+
+<% if false %>
 
 <div class="h-feed">
   <% @article_archive.each do |year, months| %>
@@ -63,3 +93,5 @@
     <% end %>
   </ul>
 </div>
+
+<% end %>

--- a/app/views/2025/article_archives/index.html.erb
+++ b/app/views/2025/article_archives/index.html.erb
@@ -16,6 +16,12 @@
             </time>
           </span>
         </h1>
+
+        <h2 class='fw-normal'>
+          <time datetime='<%= [@article_archive.year, @article_archive.month, @article_archive.day].compact.join '-' %>'>
+            <%= link_to_dates(year: @article_archive.year, month: @article_archive.month, day: @article_archive.day) %>
+          </time>
+        </h2>
       </header>
 
       ARTICLES GO HERE Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
@@ -28,18 +34,12 @@
       </header>
 
       <div id='categories' class='mb-5 pt-3'>
-        <h2 class='h4 fw-bold'>
-          <%= link_to 'Navigate by theme', '#categories' %>
-        </h2>
-
+        <h2 class='h4 fw-bold'><%= link_to tt(:categories_heading), '#categories' %></h2>
         <%= render_themed 'categories/list', categories: @categories %>
       </div>
 
       <div id='years' class='mb-5 pt-3'>
-        <h2 class='h4 fw-bold'>
-          <%= link_to 'Navigate chronologically', '#years' %>
-        </h2>
-
+        <h2 class='h4 fw-bold'><%= link_to tt(:chronological_heading), '#years' %></h2>
         <%= render_themed 'years/list', years: @years %>
       </div>
     </div><!-- /TEMP RIGHT COLUMN -->

--- a/app/views/2025/categories/_list.html.erb
+++ b/app/views/2025/categories/_list.html.erb
@@ -1,0 +1,11 @@
+<%# locals: (categories:) %>
+
+<ul class='list-inline underlined-links lh-lg'>
+  <% categories.each do |category| %>
+    <% classes = 'pe-2 me-1 border-end border-secondary' unless category == categories.last %>
+
+    <li class='list-inline-item me-0'>
+      <%= link_to category.name, category.path, class: classes %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/2025/years/_list.html.erb
+++ b/app/views/2025/years/_list.html.erb
@@ -1,0 +1,11 @@
+<%# locals: (years:) %>
+
+<ul class='list-inline underlined-links lh-lg'>
+  <% @years.each do |year| %>
+    <% classes = 'pe-2 me-1 border-end border-secondary' unless year == @years.last %>
+
+    <li class='list-inline-item me-0'>
+      <%= link_to year, [:article_archives, year: year], class: classes %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/layouts/2025/header/_search.html.erb
+++ b/app/views/layouts/2025/header/_search.html.erb
@@ -16,10 +16,8 @@
       <b><%= tt 'cards.search.category_heading' %></b>
 
       <p>
-        <%# TODO: extract to before_action in application controller %>
-        <% categories = Category.all %>
-        <% categories.each do |category| %>
-          <% classes = 'pe-2 me-1 border-end border-danger' unless category == categories.last %>
+        <% @categories.each do |category| %>
+          <% classes = 'pe-2 me-1 border-end border-danger' unless category == @categories.last %>
           <%= link_to category.name, [:category, slug: category.slug], class: classes %>
         <% end %>
       </p>
@@ -27,10 +25,8 @@
       <b><%= tt 'cards.search.chronological_heading' %></b>
 
       <p class='mb-0'>
-        <%# TODO: extract to before_action in application controller %>
-        <% years = (1996..Time.current.year).to_a.reverse %>
-        <% years.each do |year| %>
-          <% classes = 'pe-2 me-1 border-end border-danger' unless year == years.last %>
+        <% @years.each do |year| %>
+          <% classes = 'pe-2 me-1 border-end border-danger' unless year == @years.last %>
           <%= link_to year, [:article_archives, year: year], class: classes %>
         <% end %>
       </p>

--- a/app/views/layouts/2025/header/_search.html.erb
+++ b/app/views/layouts/2025/header/_search.html.erb
@@ -14,22 +14,10 @@
 
     <div class='col-12 col-lg-8'>
       <b><%= tt 'cards.search.category_heading' %></b>
-
-      <p>
-        <% @categories.each do |category| %>
-          <% classes = 'pe-2 me-1 border-end border-danger' unless category == @categories.last %>
-          <%= link_to category.name, [:category, slug: category.slug], class: classes %>
-        <% end %>
-      </p>
+      <%= render_themed 'categories/list', categories: @categories %>
 
       <b><%= tt 'cards.search.chronological_heading' %></b>
-
-      <p class='mb-0'>
-        <% @years.each do |year| %>
-          <% classes = 'pe-2 me-1 border-end border-danger' unless year == @years.last %>
-          <%= link_to year, [:article_archives, year: year], class: classes %>
-        <% end %>
-      </p>
+      <%= render_themed 'years/list', years: @years %>
     </div>
   </div><!-- /.row -->
 </div><!-- /#search -->

--- a/app/views/layouts/2025/header/_search.html.erb
+++ b/app/views/layouts/2025/header/_search.html.erb
@@ -13,10 +13,10 @@
     </div>
 
     <div class='col-12 col-lg-8'>
-      <b><%= tt 'cards.search.category_heading' %></b>
+      <b><%= tt :categories_heading %></b>
       <%= render_themed 'categories/list', categories: @categories %>
 
-      <b><%= tt 'cards.search.chronological_heading' %></b>
+      <b><%= tt :chronological_heading %></b>
       <%= render_themed 'years/list', years: @years %>
     </div>
   </div><!-- /.row -->

--- a/config/locales/en/2025.yml
+++ b/config/locales/en/2025.yml
@@ -59,6 +59,8 @@ en:
     zines:          Zines
 
     # phrases
+    categories_heading:      Browse by category
+    chronological_heading:   Browse chronologically
     ex_workers_collection:   Ex-Workers’ Collection
     featured_books:          Featured books
     just_published:          Just published
@@ -117,8 +119,6 @@ en:
 
       search:
         description: You can **search** over two decades of archives.
-        category_heading: Browse by category
-        chronological_heading: Browse chronologically
 
     footer:
       store_description: Books, posters, stickers, and more…

--- a/config/locales/en/2025.yml
+++ b/config/locales/en/2025.yml
@@ -27,6 +27,7 @@ en:
     about:          About
     adventure:      Adventure
     analysis:       Analysis
+    archives:       The Archives
     arts:           Arts
     books:          Books
     categories:     Categories


### PR DESCRIPTION
Article archives are routes like:

- `/2025`
- `/2024/12`


Though, not routes like:

- `/page/2`
- etc

**…yet**

Those routes currently point to `home#index` because the 2017 theme treated the home page page as `home#index page: 1`. The 2025 isn't doing that, so `/page/*` need to be moved to `article_archives#index`.

And maybe `article_archives#index` can get moved into `article#index` for easier discovery when working in the repo. (Needs more exploration/consideration)