### PR TITLE
Fix /page/:page routes for 2025 theme

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,6 +82,7 @@ class ApplicationController < ActionController::Base
 
   def pages_for_2025_theme
     %w[
+      articles#index
       article_archives#index
       home#index
       languages#index

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,16 +1,24 @@
 class HomeController < ApplicationController
-  def index
-    @body_id = 'home'
-    @homepage = true
+  before_action :redirect_pagination
 
+  def index
     articles_for_current_page = Article.includes(:categories).english.live.published.root
 
-    # Homepage featured article
-    @latest_article = articles_for_current_page.first if first_page?
+    if Current.theme == '2017'
+      @body_id = 'home'
+      @homepage = true
 
-    if Current.theme == '2025'
+      # Homepage featured article
+      @latest_article = articles_for_current_page.first if first_page?
+
+      # Feed artciles
+      @articles = articles_for_current_page.page(params[:page]).per(6).padding(1)
+    else
       # Feed artciles, needed for pagination
       @articles = articles_for_current_page.page(params[:page]).per(14).padding(1)
+
+      # Homepage featured article
+      @latest_article = articles_for_current_page.first
 
       # Recent article
       @just_published_articles = @articles[0..3]
@@ -39,9 +47,6 @@ class HomeController < ApplicationController
 
       # Ex-Workers’ Collection
       @ex_workers_collection = Article.featured
-    else
-      # Feed artciles
-      @articles = articles_for_current_page.page(params[:page]).per(6).padding(1)
     end
 
     render "#{Current.theme}/home/index"
@@ -51,5 +56,11 @@ class HomeController < ApplicationController
 
   def first_page?
     params[:page].blank?
+  end
+
+  def redirect_pagination
+    return if params[:page].blank?
+
+    redirect_to [:articles, { page: params[:page] }]
   end
 end

--- a/app/views/2025/articles/index.html.erb
+++ b/app/views/2025/articles/index.html.erb
@@ -1,31 +1,39 @@
-<%# TODO delete this view %>
-<header>
-  <h1>
-    <%= link_to "Archives", [:library] %> :
-    <time>
-      <%= link_to_dates(year: @articles_year, month: @articles_month, day: @articles_day) %>
-    </time>
-  </h1>
-</header>
-
-<% if @articles.nil? %>
-  <h2>No archives for this time period.</h2>
-<% else %>
-  <ol class="h-feed">
-    <% @articles.each do |article| %>
-      <li>
-        <article class="h-entry">
-          <header>
-            <%= render_themed "articles/titles", header: article, linked: true %>
-          </header>
-
-          <footer>
-            <%= render_themed "articles/published_on", article: article %>
-            <%= render_themed "articles/categories",   article: article %>
-            <%= render_themed "articles/tags",         article: article %>
-          </footer>
-        </article>
-      </li>
-    <% end %>
-  </ol>
+<% content_for(:head) do %>
+  <%= rel_next_prev_link_tags @articles %>
 <% end %>
+
+<div class='container'>
+  <div class='row'>
+    <div class='col-md-6 col-lg-8'>
+      <header class='titles pb-3 mb-4 border-bottom'>
+        <h1><%= tt :articles %></h1>
+        <h2 class='fw-light'><%= tt :page %> <%= @page_number %></h2>
+      </header>
+
+      <div class='h-feed'>
+        <% @articles.each do |article| %>
+          <%= render_themed 'articles/article', article: article %>
+        <% end %>
+      </div>
+
+      <%= paginate @articles, theme: 'twitter-bootstrap-4' %>
+    </div>
+
+    <div class='col-md-6 col-lg-4'>
+      <header class='titles pb-3 mb-2 border-bottom fw-normal'>
+        <h1 class='fw-normal'>See also…</h1>
+        <h2 class='fw-normal'>Explore The Archives</h2>
+      </header>
+
+      <div id='categories' class='mb-5 pt-3'>
+        <h2 class='h4 fw-bold'><%= link_to tt(:categories_heading), '#categories' %></h2>
+        <%= render_themed 'categories/list', categories: @categories %>
+      </div>
+
+      <div id='years' class='mb-5 pt-3'>
+        <h2 class='h4 fw-bold'><%= link_to tt(:chronological_heading), '#years' %></h2>
+        <%= render_themed 'years/list', years: @years %>
+      </div>
+    </div>
+  </div><!-- .row -->
+</div><!-- .container -->

--- a/app/views/2025/home/sections/_articles.html.erb
+++ b/app/views/2025/home/sections/_articles.html.erb
@@ -31,7 +31,11 @@
       <% end %>
     </ol>
 
-    <p class='fw-bold'><%= link_to_next_page articles, "#{tt :more_articles} →" %></p>
+    <p class='fw-bold'>
+      <%= link_to [:articles, page: 2] do %>
+        <%= tt :more_articles %> →
+      <% end %>
+    </p>
   </div>
 
   <div class='col-12 col-lg-4'>
@@ -50,7 +54,12 @@
       <% end %>
     </ol>
 
-    <p class='fw-bold text-end'><%= link_to_next_page articles, "#{tt :more_articles} →" %></p>
+    <p class='fw-bold text-end'>
+      <%= link_to [:articles, page: 2] do %>
+        <%= tt :more_articles %> →
+      <% end %>
+    </p>
+
   </div>
 </section>
 <!-- /Recent and previous articles -->

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,4 +1,12 @@
 Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
   config.window = 1
   config.outer_window = 3
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  config.params_on_first_page = true # forces /page/1 instead of /
 end

--- a/config/locales/en/2025.yml
+++ b/config/locales/en/2025.yml
@@ -28,6 +28,7 @@ en:
     adventure:      Adventure
     analysis:       Analysis
     archives:       The Archives
+    articles:       Articles
     arts:           Arts
     books:          Books
     categories:     Categories
@@ -42,6 +43,7 @@ en:
     logos:          Logos
     music:          Music
     news:           News
+    page:           Page
     podcasts:       Podcasts
     posters:        Posters
     published:      Published

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,8 +26,8 @@ Rails.application.routes.draw do
   # Homepage
   root to: 'home#index'
 
-  get 'page(/1)', to: redirect { |_, _| '/' }
-  get 'page/:page', to: 'home#index'
+  get 'page', to: redirect('/page/1'), as: :page_one
+  get 'page/:page', to: 'articles#index', as: :articles
 
   # To Change Everything (TCE)
   get 'tce(/:lang)',


### PR DESCRIPTION
Most notable change is:

Before
in 2017 theme, routes like `/page/2` were handled by `home#index`
They were the homepage with a different collection of articles, and no "latest article"

Now
in 2025 theme, routes like `/page/2` are handled by `articles#index`
They are the same `article_archives#index`

So, in the transitional time from 2017 theme to 2025, the `articles#index` controller action receives the `/page/2` request, then does the same setup and render as `home#index` (literally copy/pasted from `home#index`)

After the transition is launched and announced, we can delete all of the double dispatch code
