### PR TITLE
Remove unused popper.js (from Bootstrap)

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -3,7 +3,6 @@
 
 // /admin site
 //= link admin.css
-//= link popper.js
 //= link bootstrap.min.js
 
 // Mini sites

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -32,7 +32,6 @@
 
     <%= stylesheet_link_tag "admin", media: "all" %>
     <%= javascript_importmap_tags %>
-    <%= javascript_import_module_tag "popper" %>
     <%= javascript_import_module_tag "bootstrap" %>
     <%= yield(:head) %>
 

--- a/app/views/steal_something_from_work_day/show.html.erb
+++ b/app/views/steal_something_from_work_day/show.html.erb
@@ -25,11 +25,11 @@
       <%= render_markdown "[[https://www.youtube.com/watch?v=33QwamMHVlA]]" %>
     </div>
 
-    <%# HACK these BRs are to account for the CSS weirdness around the YouTube embed %>
+    <%# HACK: these BRs are to account for the CSS weirdness around the YouTube embed %>
     <br><br><br><br><br>
   </main>
 </div><!-- .main-wrapper -->
+
 <% content_for :head do %>
-  <%= javascript_import_module_tag "popper" %>
   <%= javascript_import_module_tag "bootstrap" %>
 <% end %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -4,7 +4,6 @@ pin 'application', preload: true
 
 # Our JS files
 pin 'support'
-pin 'popper',    to: 'popper.js'
 pin 'bootstrap', to: 'bootstrap.min.js'
 
 # Hotwired JS https://hotwired.dev

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,4 +10,4 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w[bootstrap.min.js popper.js admin.css]
+# Rails.application.config.assets.precompile += %w[bootstrap.min.js admin.css]


### PR DESCRIPTION
We're not using popovers anywhere, and we have no plans to

https://getbootstrap.com/docs/5.3/components/popovers/

Especially because it requires this JS

Not using them (having never used them) allows us to delete one more Javascript file :) 