### PR TITLE
Ignore /website-content folder for running static sit archiver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ storage/
 # rails credentials
 /config/master.key
 /config/credentials/production.key
+
+# static archive export repo
+website-content


### PR DESCRIPTION
To populate the static content export repo:
https://github.com/crimethinc/website-content

We run this rake task:
```ruby
bundle exec rake static:export
```

At the end of the local export, the rake task outputs a suggestion of what to run to update the [@crimethinc/website-content repo](https://github.com/crimethinc/website-content) repo. Which includes turning the newly created `website-content/` folder into a git repo.

So to avoid pushing that folder to pull request branches or `main`, this PR ignores the folder's path. 