### PR TITLE
[Rubocop] Replace require: with plugins: in config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,12 @@
 inherit_from: .rubocop_todo.yml
 
-require:
-  - rubocop-capybara
+plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+
+require:
+  - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rspec_rails
 


### PR DESCRIPTION
To tidy up a new Rubocop warnings:

```
rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in crimethinc/website/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in crimethinc/website/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in crimethinc/website/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```