### PR TITLE
Hide draft episodes from public podcasts/* pages

### DIFF
--- a/app/controllers/admin/episodes_controller.rb
+++ b/app/controllers/admin/episodes_controller.rb
@@ -52,7 +52,7 @@ module Admin
     end
 
     def set_episode
-      @episode = Episode.find(params[:id])
+      @episode = Episode.for_admin.find params[:id]
       redirect_to %i[admin podcasts] if @episode.blank?
     end
 

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -28,7 +28,7 @@ class EpisodesController < ApplicationController
 
   def set_episode
     if request.path.starts_with? '/draft'
-      @episode = Episode.find_by(draft_code: params[:draft_code])
+      @episode = Episode.unscoped.find_by(draft_code: params[:draft_code])
 
       redirect_to(@episode.path) if @episode&.published?
     else

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -10,6 +10,8 @@ module Publishable
 
     default_scope { order(published_at: :desc) }
 
+    scope :for_admin, -> { unscoped.order(published_at: :desc) }
+
     scope :chronological, -> { order(published_at: :desc) }
     scope :root,          -> { where(collection_id: nil) }
     scope :live,          -> { where(published_at: ...Time.now.utc) }

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -5,7 +5,7 @@ class Episode < ApplicationRecord
 
   belongs_to :podcast
 
-  default_scope { order(id: :desc) }
+  default_scope { order(id: :desc).published }
 
   before_validation :generate_draft_code, on: %i[create update]
   after_create :generate_slug

--- a/app/views/admin/podcasts/index.html.erb
+++ b/app/views/admin/podcasts/index.html.erb
@@ -22,7 +22,7 @@
       </thead>
 
       <tbody>
-        <% podcast.episodes.each do |episode| %>
+        <% podcast.episodes.for_admin.each do |episode| %>
           <tr>
             <td><%= link_to "EDIT", [:edit, :admin, episode], class: "btn btn-outline-primary btn-sm" %></td>
             <td>


### PR DESCRIPTION
# Before

A draft `Episode` would show up on `/podcasts` when it shouldn't yet

# After 

Draft `Episode`s won't show up on `/podcasts`. 
But still will in `/admin/podcasts/*`, as it should. 