### PR TITLE
Ensure that the default publication_status for new Episodes is :draft

### DIFF
--- a/app/controllers/admin/episodes_controller.rb
+++ b/app/controllers/admin/episodes_controller.rb
@@ -14,7 +14,7 @@ module Admin
     end
 
     def new
-      @episode = Episode.new
+      @episode = Episode.for_admin.new
       @title = admin_title
     end
 
@@ -23,7 +23,7 @@ module Admin
     end
 
     def create
-      @episode = Episode.new(episode_params)
+      @episode = Episode.for_admin.new episode_params
 
       if @episode.save
         redirect_to [:admin, @episode], notice: 'Episode was successfully created.'

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -29,6 +29,7 @@ class EpisodesController < ApplicationController
   def set_episode
     if request.path.starts_with? '/draft'
       @episode = Episode.unscoped.find_by(draft_code: params[:draft_code])
+      @podcast = @episode.podcast
 
       redirect_to(@episode.path) if @episode&.published?
     else


### PR DESCRIPTION
# Before

After #4408, `.published` was making a **new** `Episode` have a `publication_status` of `:published` instead of `:draft`, like one would expect. Which was causing the `/admin/episodes/new` form have `publication_status` set to `:published` too. Which made it too easy to mistakenly save a work in progress episode, thinking that it'd be saved as a draft.

# After

Now `Episode.new` is chained with `.for_admin` to ensure that it's not set to `.published` when initialized.
`Episode.for_admin.new`