### PR TITLE
Migrate rubocop requires to plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,8 +4,6 @@ plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
-
-require:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rspec_rails


### PR DESCRIPTION
> rubocop-capybara extension supports plugin, specify `plugins: rubocop-capybara` instead of `require: rubocop-capybara` in /Users/s/Developer/crimethinc/website/.rubocop.yml.
> For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
> 
> rubocop-factory_bot extension supports plugin, specify `plugins: rubocop-factory_bot` instead of `require: rubocop-factory_bot` in /Users/s/Developer/crimethinc/website/.rubocop.yml.
> For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
> 
> rubocop-rspec_rails extension supports plugin, specify `plugins: rubocop-rspec_rails` instead of `require: rubocop-rspec_rails` in /Users/s/Developer/crimethinc/website/.rubocop.yml.
> For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
> 
> 