### PR TITLE
Fix search form label on /admin

### DIFF
--- a/app/views/admin/redirects/_search_form.html.erb
+++ b/app/views/admin/redirects/_search_form.html.erb
@@ -6,7 +6,7 @@
         <%= form.text_field attribute,
                             value:        params[attribute],
                             class:        'form-control form-control-lg',
-                            placeholder:  'FROM',
+                            placeholder:  placeholder,
                             autocomplete: :off %>
       </div>
 


### PR DESCRIPTION
Accidentally hardcoded to `'FROM'` in https://github.com/crimethinc/website/commit/aabd764b68cb2faa05909f4e45fae6b0e06a3bc1#diff-cbe6cf1ed6b7bf6ca51d69bc98c57eb0363da396b0ac5d5b9fd0719f2320a3db