### PR TITLE
Change twitter:card=summary to =summary_large_image

### DIFF
--- a/app/views/2017/shared/head/_social_media_meta_tags.html.erb
+++ b/app/views/2017/shared/head/_social_media_meta_tags.html.erb
@@ -3,7 +3,7 @@
 
 <!-- Social media support: Twitter Cards and Facebook (Open Graph) -->
 <meta name="twitter:dnt" content="on">
-<meta name="twitter:card" content="summary">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@crimethinc">
 <meta name="twitter:site:id" content="14884161">
 <meta name="twitter:creator" content="@crimethinc">

--- a/app/views/shared/head/_social_media_meta_tags.html.erb
+++ b/app/views/shared/head/_social_media_meta_tags.html.erb
@@ -3,7 +3,7 @@
 
 <!-- Social media support: Twitter Cards and Facebook (Open Graph) -->
 <meta name="twitter:dnt" content="on">
-<meta name="twitter:card" content="summary">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@crimethinc">
 <meta name="twitter:site:id" content="14884161">
 <meta name="twitter:creator" content="@crimethinc">

--- a/app/views/steal_something_from_work_day/head/_social_media_meta_tags.html.erb
+++ b/app/views/steal_something_from_work_day/head/_social_media_meta_tags.html.erb
@@ -3,7 +3,7 @@
 
 <!-- Social media support: Twitter Cards and Facebook (Open Graph) -->
 <meta name="twitter:dnt" content="on">
-<meta name="twitter:card" content="summary">
+<meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="@crimethinc">
 <meta name="twitter:site:id" content="14884161">
 <meta name="twitter:creator" content="@crimethinc">


### PR DESCRIPTION
https://developer.x.com/en/docs/x-for-websites/cards/overview/summary-card-with-large-image

Currently the social share preview card on quoteunquote X quoteunquote is this:

<img width="717" height="345" alt="image" src="https://github.com/user-attachments/assets/e08c8fc4-7053-4c51-a8ee-1854d8277359" />

It'd be cooler if it were more like this:

<img width="695" height="458" alt="image" src="https://github.com/user-attachments/assets/e0b3baf1-429e-4896-a031-27590deb2261" />
