### PR TITLE
Fix social share preview for Posters

### DIFF
--- a/app/models/logo.rb
+++ b/app/models/logo.rb
@@ -17,7 +17,7 @@ class Logo < ApplicationRecord
   end
 
   def front_image
-    Rails.application.routes.url_helpers.rails_blob_path image_jpg, only_path: true
+    Rails.application.routes.url_helpers.rails_blob_path image_jpg
   end
 
   def meta_description
@@ -25,7 +25,7 @@ class Logo < ApplicationRecord
   end
 
   def meta_image
-    Rails.application.routes.url_helpers.rails_blob_url image_jpg, only_path: true
+    Rails.application.routes.url_helpers.rails_blob_url image_jpg
   end
   alias image meta_image
 

--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -9,4 +9,20 @@ class Poster < ApplicationRecord
   has_one_attached :image_front_black_and_white_download
   has_one_attached :image_back_color_download
   has_one_attached :image_back_black_and_white_download
+
+  def meta_image
+    return if preferred_front_image.blank?
+
+    Rails.application.routes.url_helpers.rails_blob_url preferred_front_image
+  end
+  alias image meta_image
+
+  private
+
+  def preferred_front_image
+    return image_front_color_image if image_front_color_image.attached?
+    return image_front_black_and_white_image if image_front_black_and_white_image.attached?
+
+    nil
+  end
 end


### PR DESCRIPTION
# Before

`Poster#meta_image` was returning an `ActiveStorage` object `to_s`, instead of a URL.
The view is expecting a plain string URL, which it'll use in a `<meta>` tag.

```html
<meta name="twitter:image" content="#<ActiveStorage::Attached::One:0x00007f2a3e2b8468>" property="og:image">
```

# After

`Poster#meta_image` returns the `url_for` of an `ActiveStorage` attachment on `Poster`.
It prefers `#image_front_color_image`, then `image_front_black_and_white_image`.
If neither is `.attached?`, it returns `nil`, allowing the `meta_image` view to fall back to the site wide default image (for now).

```html
<meta name="twitter:image" content="https://crimethinc.com/rails/active_storage/blobs/proxy/eyJfcmFpbHMiOnsiZGF0YSI6MjE1LCJwdXIiOiJibG9iX2lkIn19--8cdcc186c36ac03e15371c5a6cbc1181765fe9e6/where-are-we-going_front_black_and_white.gif" property="og:image">
```



