### PR TITLE
Alias Poster#front_image to Poster#image

### DIFF
--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -15,7 +15,8 @@ class Poster < ApplicationRecord
 
     Rails.application.routes.url_helpers.rails_blob_url preferred_front_image
   end
-  alias image meta_image
+
+  alias front_image image
 
   private
 


### PR DESCRIPTION
# Before 

`/posters` is 500ing with error:

```ruby
ActionView::Template::Error • posters#index
wrong number of arguments (given 1, expected 0)
```

<img width="962" height="612" alt="image" src="https://github.com/user-attachments/assets/a5c0e7dc-d922-48ca-89dd-71d066e19fe5" />


---


In #4707 I broke, `Poster#front_image`

In this, I `alias`  `Poster#front_image` to  `Poster#image` …which seems to work.

I think we over corrected in refactoring Tools to shared concerns as much as as (mostly I!) did. 
I think I'll unfactor a fair bit of it back to more concrete, less abstract.
Even if that means a bit of duplicate code, it'll at least be clearer and tighter scoped.

# After

I think I've fixed it?

There are also a dozen `Posters` that don't have an attached front image, so they need to be corrected in production database/admin.