### PR TITLE
Expand Poster#image and #meta_image to check for back images too

### DIFF
--- a/app/models/poster.rb
+++ b/app/models/poster.rb
@@ -10,19 +10,27 @@ class Poster < ApplicationRecord
   has_one_attached :image_back_color_download
   has_one_attached :image_back_black_and_white_download
 
+  # TEMP: duplicate of #image, for now (2025-07-17)
   def meta_image
     return if preferred_front_image.blank?
 
     Rails.application.routes.url_helpers.rails_blob_url preferred_front_image
   end
 
-  alias front_image image
+  # TEMP: duplicate of #meta_image, for now (2025-07-17)
+  def image
+    return if preferred_front_image.blank?
+
+    Rails.application.routes.url_helpers.rails_blob_url preferred_front_image
+  end
 
   private
 
   def preferred_front_image
-    return image_front_color_image if image_front_color_image.attached?
+    return image_front_color_image           if image_front_color_image.attached?
     return image_front_black_and_white_image if image_front_black_and_white_image.attached?
+    return image_back_color_image            if image_back_color_image.attached?
+    return image_back_black_and_white_image  if image_back_black_and_white_image.attached?
 
     nil
   end


### PR DESCRIPTION
Try try again… 

#4708 #4707

Now, `Poster#image` and `Poster#meta_image` are explicitly defined in `Poster`, overriding `SinglePageTool`

They are duplicates of each other, for now

They both call `private` `Poster#preferred_front_image` which checks for an `ActiveStorage` attached image on any of these four:

- `Poster#image_front_color_image`
- `Poster#image_front_black_and_white_image`
- `Poster#image_back_color_image`
- `Poster#image_back_black_and_white_image`

Because for some reason, there are posters with a back image but not front. 🤦🏻‍♀️