### PR TITLE
Improve SSfWD social share preview text and image

### DIFF
--- a/app/views/steal_something_from_work_day/head/_social_media_meta_tags.html.erb
+++ b/app/views/steal_something_from_work_day/head/_social_media_meta_tags.html.erb
@@ -9,8 +9,8 @@
 <meta name="twitter:creator" content="@crimethinc">
 <meta name="twitter:creator:id" content="14884161">
 <meta name="twitter:url" content="<%= request.url %>" property="og:url">
-<meta name="twitter:title" content="<%= meta_title(find_the_thing) %>" property="og:title">
-<meta name="twitter:description" content="<%= meta_description(find_the_thing) %>" property="og:description">
+<meta name="twitter:title" content="<%= t 'steal_something_from_work_day.title' %>" property="og:title">
+<meta name="twitter:description" content="<%= t 'steal_something_from_work_day.subtitle' %>" property="og:description">
 <meta name="twitter:image" content="<%= meta_image(find_the_thing) %>" property="og:image">
-<meta property="og:site_name" content="<%= t(:site_name) %>">
-<meta property="og:type" content="<%= meta_type(find_the_thing) %>">
+<meta property="og:site_name" content="https://cdn.crimethinc.com/assets/steal-something-from-work-day/steal-something-from-work-day-photo-card.jpg">
+<meta property="og:type" content="website">


### PR DESCRIPTION
# Before

<img width="247" height="242" alt="image" src="https://github.com/user-attachments/assets/ff7f142f-1abd-46da-9977-9fe1d8421e37" />

Generic preview for the whole site.

# After

<img width="247" height="181" alt="image" src="https://github.com/user-attachments/assets/3ed01958-b1da-490b-984d-eb3dedb05c70" />
