### PR TITLE
Fix SSfWD social share image URL

### DIFF
--- a/app/views/steal_something_from_work_day/head/_social_media_meta_tags.html.erb
+++ b/app/views/steal_something_from_work_day/head/_social_media_meta_tags.html.erb
@@ -9,8 +9,8 @@
 <meta name="twitter:creator" content="@crimethinc">
 <meta name="twitter:creator:id" content="14884161">
 <meta name="twitter:url" content="<%= request.url %>" property="og:url">
-<meta name="twitter:title" content="<%= t 'steal_something_from_work_day.title' %>" property="og:title">
+<meta name="twitter:title" content="<%= t 'steal_something_from_work_day.title' %> | <%= t :site_name %>" property="og:title">
 <meta name="twitter:description" content="<%= t 'steal_something_from_work_day.subtitle' %>" property="og:description">
-<meta name="twitter:image" content="<%= meta_image(find_the_thing) %>" property="og:image">
-<meta property="og:site_name" content="https://cdn.crimethinc.com/assets/steal-something-from-work-day/steal-something-from-work-day-photo-card.jpg">
+<meta name="twitter:image" content="https://cdn.crimethinc.com/assets/steal-something-from-work-day/steal-something-from-work-day-photo-card.jpg" property="og:image">
+<meta property="og:site_name" content="<%= t 'steal_something_from_work_day.title' %>">
 <meta property="og:type" content="website">


### PR DESCRIPTION
In https://github.com/crimethinc/website/pull/4719, I put the social share image URL in the `description` meta tag by mistake.