### PR TITLE
Add locale subdomains: ceb es-419 fo fr-qu li lt ms mt

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,15 +44,17 @@ module Crimethinc
     config.subdomain_locales = %i[
       ar
       be bg bn
-      ca cs cz
+      ca cs cz ceb
       da de dv
       en es eu
-      fa fi fr
+      fa fi fo fr
       gl gr
       he hu
       id in it
       ja
       ko ku
+      li lt
+      ms mt
       nl no
       pl pt
       ro ru
@@ -62,6 +64,10 @@ module Crimethinc
       vi
       zh
     ]
+
+    # Regional locales that have a hyphen in their IANA identifier
+    config.subdomain_locales << :'es-419' # Spanish (Latin America) # rubocop:disable Naming/VariableNumber
+    config.subdomain_locales << :'fr-qu'  # French  (Canadian/Quebecois)
 
     path_ltr_locales = %i[
       turkce


### PR DESCRIPTION
We have something translated to all of these languages. Either the site, To Change Everything, tools (books, zines, etc), or most commonly articles.

The goal is to have a subdomain with a site translation for any language that we have content for.

More work is needed to fully support these as subdomains (DNS, YAML files, etc).
This is just one of the first steps. 


| code   | Language/dialect           |
| ------ | -------------------------- |
| fr-qu  | French Canadian/Quebecois  |
| es-419 | Spanish (Latin America)    |
| ceb    | Cebuano                    |
| fo     | Faroese                    |
| li     | Lithuanian, redirect to LT |
| lt     | Lithuanian, actual         |
| ms     | Malay                      |
| mt     | Maltese                    |
