### PR TITLE
Add # anchor links to article content headings

### DIFF
--- a/app/assets/stylesheets/2017/views/_article.scss
+++ b/app/assets/stylesheets/2017/views/_article.scss
@@ -246,6 +246,49 @@
       margin-top: -.5em;
     }
 
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      display: flex;
+      align-items: baseline;
+    }
+
+    h1 a,
+    h2 a,
+    h3 a,
+    h4 a,
+    h5 a,
+    h6 a {
+      order: 0;
+      margin-left: -0.6em;
+      margin-right: 0.1em;
+      text-decoration: none;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    h1:hover a,
+    h2:hover a,
+    h3:hover a,
+    h4:hover a,
+    h5:hover a,
+    h6:hover a {
+      opacity: 0.25;
+    }
+
+    h1 a::after,
+    h2 a::after,
+    h3 a::after,
+    h4 a::after,
+    h5 a::after,
+    h6 a::after {
+      content: "#";
+      font-size: 0.7em;
+    }
+
     p {
       line-height: 1.6em;
       margin-bottom: 1em;

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -12,7 +12,8 @@ module MarkdownHelper
       MarkdownMedia.parse(text, include_media: media_mode?),
       input:                     :kramdown,
       remove_block_html_tags:    false,
-      transliterated_header_ids: true
+      transliterated_header_ids: true,
+      header_links:              true
     ).to_html.html_safe
 
     html = remove_wrapper_p_tag_from html if remove_wrapper_p_tag.present?

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -71,6 +71,7 @@ class Article < ApplicationRecord
       input:                     content_format.to_sym,
       remove_block_html_tags:    false,
       transliterated_header_ids: true,
+      header_links:              true,
       html_to_native:            true
     ).to_html.html_safe
   end


### PR DESCRIPTION
# Context

Our headings already get transliterated (slug safe) ID attributes on the heading tag:

```markdown
# Intro
```

```html
<h1 id='intro'>Intro</h1>
```

They are, of course, addressable in a URL by adding `#intro` (in this example) to the URL.
For a simple one word example, that's easy enough.
But for most headings, one has to either manually sluggify the heading content into an anchor or inspect the HTML to copy it from the `h1@id` value. Neither are friendly.

We use a Markdown parser called [kramdown](https://kramdown.gettalong.org).
By setting `header_links: true` when we render Markdown `.to_html`, we tell kramdown to generate links in the heading with the right anchor `href` value for us. 

Sadly, kramdown doesn't seem to have a way to specify what the link content should be or where to position it. It only creates an empty `<a>` tag before the heading content. 

That's what the CSS is for, to give it content `#` and position it out in the margin next to the article content. 

I've opened an issue in the kramdown gem repo, asking for options to specify these. All things being equal, I'd rather render the link text server side with the template and place it after the heading content. (Which I tried with CSS, but it gets weird if the heading wraps to multiple lines, which is common in our articles.)

---

# Before

<img width="1944" height="614" alt="Screenshot 2025-08-01 at 6 40 05 PM" src="https://github.com/user-attachments/assets/0c71a92a-7f51-418b-9e51-f3c7aa30bfb1" />

# Hover on a heading

Shows a `#` link to the left of the heading.

<img width="1944" height="612" alt="Screenshot 2025-08-01 at 6 40 13 PM" src="https://github.com/user-attachments/assets/1be67c1a-2a44-4110-b36e-d822b075748a" />

# Clicked link

Scrolls the page to that heading, changes the URL to `URL#heading-id`

<img width="1750" height="336" alt="Screenshot 2025-08-01 at 6 40 49 PM" src="https://github.com/user-attachments/assets/639dab5a-cff2-4248-bab6-825dbea84f57" />
