### PR TITLE
Fix Gemfile deprecation warning: windows platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,7 +126,7 @@ gem 'redis'
 gem 'redis-store'
 
 # windows dev
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'tzinfo-data', platforms: %i[windows jruby]
 
 # i18n
 gem 'rack-contrib'


### PR DESCRIPTION
> [DEPRECATED] Platform :mingw, :mswin, :x64_mingw is deprecated. Please use platform :windows instead.
