### PR TITLE
DEPRECATION WARNING: change upload_file to TransferManager#upload_file

### DIFF
--- a/lib/tasks/db/export.rake
+++ b/lib/tasks/db/export.rake
@@ -93,7 +93,7 @@ namespace :db do
       # Make S3 client to make a public file
       client = Aws::S3::Client.new
 
-      # Use TransferManager instead of deprecated upload_file method
+      # Make TransferManager to upload a file
       transfer_manager = Aws::S3::TransferManager.new client: client
 
       # Upload the file


### PR DESCRIPTION
AWS::S3 gem changed their API

`rake db:export:upload` was giving this deprecation warning:


```
==> Uploading local development DB dump to S3…
#################### DEPRECATION WARNING ####################
Called deprecated method `upload_file` of Aws::S3::Object. Use `Aws::S3::TransferManager#upload_file` instead.
Method `upload_file` will be removed in next major version.
#############################################################
lib/tasks/db/export.rake:105:in 'block (3 levels) in <top (required)>'

Seahorse::Client::NetworkingError: 
SSL_connect returned=1 errno=0 peeraddr=52.92.250.178:443 state=error: 
certificate verify failed (unable to get certificate CRL) (Seahorse::Client::NetworkingError)

lib/tasks/db/export.rake:105:in 'block (3 levels) in <top (required)>'
Tasks: TOP => db:export => db:export:upload 
```
