### PR TITLE
[TCE] correct css for *-large display sizes

### DIFF
--- a/app/assets/stylesheets/to_change_everything/_common.scss
+++ b/app/assets/stylesheets/to_change_everything/_common.scss
@@ -981,7 +981,11 @@
   }
 
   #government .left {
-    padding-top: 78%;
+    padding-top: 75%;
+  }
+
+  #profit .left {
+    padding-top: 75%;
   }
 
   #profit h2 {
@@ -1003,7 +1007,7 @@
   }
 
   #property .left {
-    padding-top: 62%;
+    padding-top: 75%;
   }
 
   #lastcrime h2 {


### PR DESCRIPTION
# What are the relevant GitHub issues?

closes: https://github.com/crimethinc/website/issues/4956
related to: https://github.com/crimethinc/website/issues/575

# What does this pull request do?

There were a couple of images that did not have the correct "large" variant uploaded to the CDN.

This is the same issue described in https://github.com/crimethinc/website/issues/575 for the large variants of the "profit", "government", and "property" sections. 

Unlike that change though, these panels also require a small css patch to remove the grey bars.

This is the variant used in the CSS rule:[^1]

```css
@media (min-width: 1201px) and (max-width: 1670px) {...}
```

The updated images that need to be added to the cdn are attached to this PR:

| `government-large.jpg` | `property-large.jpg` | `profit-large.jpg` | `reconciling-large.jpg` |
|-|-|-|-|
| ![government-large](https://github.com/user-attachments/assets/a77d5280-4713-4204-b717-28c5ab9f860e) | ![property-large](https://github.com/user-attachments/assets/8cb99d89-b355-4976-9528-ae74b4735202) | ![profit-large](https://github.com/user-attachments/assets/c3e1b490-9ffe-4d80-a715-961f336789ce) | ![reconciling-large](https://github.com/user-attachments/assets/00c065c9-6cfc-499d-9c52-5ddd8832087e) |

# How should this be manually tested?

To test locally:

1. observe the grey bars by setting the screen dimensions to 1280x800
   (DPR 1) in the browser dev tools
2. put the fixed image in the `website/public/tce/images/` directory.
3. apply this patch to load have the local image loaded [0001-TCE-patch-for-testing-css-for-large-display-sizes.patch](https://github.com/user-attachments/files/23490333/0001-TCE-patch-for-testing-css-for-large-display-sizes.patch)

   ```diff
   diff --git a/app/helpers/to_change_everything_helper.rb b/app/helpers/to_change_everything_helper.rb
   index a76f4d309..ebc401e82 100644
   --- a/app/helpers/to_change_everything_helper.rb
   +++ b/app/helpers/to_change_everything_helper.rb
   @@ -82,7 +82,18 @@ module ToChangeEverythingHelper
      end

      def url_for_tce_image *pieces
   -    [IMAGE_BASE_URL, pieces].join
   +    url = [IMAGE_BASE_URL, pieces].join
   +    if url.include? "reconciling-large"
   +      '/tce/images/reconciling-large.jpg'
   +    elsif url.include? "government-large"
   +      '/tce/images/government-large.jpg'
   +    elsif url.include? "property-large"
   +      '/tce/images/property-large.jpg'
   +    elsif url.include? "profit-large"
   +      '/tce/images/profit-large.jpg'
   +    else
   +      url
   +    end
      end

      def tce_image_tag filename
   ```
4. reload the page and see the grey bars disappear


# Is there any background context you want to provide for reviewers?

## before/after screenshots

|| before | after |
|-|------------|----------|
| **government** | <img width="40%"  alt="government before" src="https://github.com/user-attachments/assets/730233d6-2ed4-449e-b795-dcd7740d40b5" /> | <img width="40%"  alt="government after" src="https://github.com/user-attachments/assets/566274d1-cba3-41df-958f-a0ea2c056c4f" /> |
| **property** | <img width="40%"  alt="property before" src="https://github.com/user-attachments/assets/89e0e5fc-ad6f-490c-b9d1-2adeb1b84519" /> | <img width="40%"  alt="property after" src="https://github.com/user-attachments/assets/aa4ac2fb-181a-4d5e-8fa6-9a52ee3416f5" /> |
| **profit** | n/a[^2]| <img width="40%"  alt="profit after" src="https://github.com/user-attachments/assets/166a5696-b2e9-4bae-ba93-4c2e59d3c7a0" /> |
| **reconciling** | <img width="40%" alt="before" src="https://github.com/user-attachments/assets/ee87024f-e27f-453d-84de-3469293ce9c5" /> |<img width="40%" alt="after" src="https://github.com/user-attachments/assets/3cd43257-395c-4074-8ecc-7cb99e953be2" /> |





# Acceptance Criteria
## These should be checked by the reviewers

- [x] This pull request does not cause the database export script to become out of sync with the db schema


[^1]: There are a few web versions (e.g. czech, polish) that do not
      use the templatized version of the TCE, so they are unaffected by this
      change

[^2]: Profit does not have a grey bar initially, however changing the size of the image and the css of the government panel would cause a grey bar if the css for this panel was not also adjusted