### PR TITLE
Make article body headings block not flex

### DIFF
--- a/app/assets/stylesheets/2017/views/_article.scss
+++ b/app/assets/stylesheets/2017/views/_article.scss
@@ -252,7 +252,7 @@
     h4,
     h5,
     h6 {
-      display: flex;
+      display: block;
       align-items: baseline;
     }
 


### PR DESCRIPTION
# Before 

<img width="531" height="131" alt="Screenshot 2025-12-07 at 11 27 18 PM" src="https://github.com/user-attachments/assets/ad34d3b3-1897-4415-a789-894ffa01e3a2" />


# After

<img width="586" height="140" alt="Screenshot 2025-12-07 at 11 27 08 PM" src="https://github.com/user-attachments/assets/7c50b5e6-98c6-4432-a208-204a683b9e28" />
