### PR TITLE
Version bump connection_pool from 3.0.1 to 3.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
-    connection_pool (3.0.1)
+    connection_pool (3.0.2)
     crass (1.0.6)
     dalli (3.2.8)
     date (3.5.0)
@@ -661,7 +661,7 @@ CHECKSUMS
   choice (0.2.0) sha256=a19617f7dfd4921b38a85d0616446620de685a113ec6d1ecc85bdb67bf38c974
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
-  connection_pool (3.0.1) sha256=819ea60fcbee0b557fec6dce41925ec7d24a137a6602587785a9e5a3aaaa6b6c
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   dalli (3.2.8) sha256=2e63595084d91fae2655514a02c5d4fc0f16c0799893794abe23bf628bebaaa5
   date (3.5.0) sha256=5e74fd6c04b0e65d97ad4f3bb5cb2d8efb37f386cc848f46310b4593ffc46ee5


### PR DESCRIPTION
# connection_pool from 3.0.1

v3.0.0 had breaking changes: changing positional args to keyword args

which was breaking `bundle assets:precompile` 

https://github.com/mperham/connection_pool/blob/main/Changes.md#300

> **BREAKING CHANGES** `ConnectionPool` and `ConnectionPool::TimedStack` now use keyword arguments rather than positional arguments everywhere. Expected impact is minimal as most people use the with API, which is unchanged.


```
-----> Preparing app for Rails asset pipeline
       Running: rake assets:precompile
       rake aborted!
       ArgumentError: wrong number of arguments (given 1, expected 0) (ArgumentError)
```

---

# connection_pool 3.0.2

`3.0.2` fixed it

https://github.com/mperham/connection_pool/blob/main/Changes.md#302

> Support :name keyword for backwards compatibility [#210]

