### PR TITLE
Revert "Bump connection_pool from 2.5.5 to 3.0.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'image_processing'
 
 # TEMP: pin connection_pool and sidekiq until this is resolved:
 #      https://github.com/crimethinc/website/pull/4994
-gem 'connection_pool', '< 4'
+gem 'connection_pool', '< 3'
 
 # TEMP: pin until connection_pool can be updated to 3
 # job queue using Active Job

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crass (1.0.6)
     dalli (3.2.8)
     date (3.5.1)
@@ -561,7 +561,7 @@ DEPENDENCIES
   bugsnag
   byebug
   capybara
-  connection_pool (< 4)
+  connection_pool (< 3)
   dalli
   dotenv-rails
   down
@@ -662,7 +662,7 @@ CHECKSUMS
   choice (0.2.0) sha256=a19617f7dfd4921b38a85d0616446620de685a113ec6d1ecc85bdb67bf38c974
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
-  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   dalli (3.2.8) sha256=2e63595084d91fae2655514a02c5d4fc0f16c0799893794abe23bf628bebaaa5
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0


### PR DESCRIPTION
# Reverts crimethinc/website#5003

Still breaking deploy in Staging 

<img width="405" height="205" alt="Screenshot 2025-12-18 at 8 53 47 PM" src="https://github.com/user-attachments/assets/019f0146-0db6-4513-805a-4642c8db1eba" />

<img width="1120" height="598" alt="Screenshot 2025-12-18 at 8 54 13 PM" src="https://github.com/user-attachments/assets/f34a4da4-677f-409b-8063-c4e56e395bc0" />
