### PR TITLE
Sort admin/articles#draft by updated_at, most recent at the top

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -11,7 +11,7 @@ module Admin
     end
 
     def draft
-      @articles = Article.draft.root.page(params[:page])
+      @articles = Article.reorder(updated_at: :desc).draft.root.page(params[:page])
 
       # TEMP: workaround, for now
       @title    = PageTitle.new %i[Admin Articles Draft]


### PR DESCRIPTION
This is to make it easier to find  recently edited drafts in `/admin/articles/draft`, sorted by `updated_at`
