### PR TITLE
A demonstrators guide footer nav

### DIFF
--- a/app/views/2017/shared/footer/_nav.html.erb
+++ b/app/views/2017/shared/footer/_nav.html.erb
@@ -9,7 +9,7 @@
         <b><%= link_to t("footer.nav.articles.feed"), %i[feed] %></b>
       </dt>
       <dd>
-        <% %w[arts adventure analysis current_events history how_to news technology a-demonstrators-guide].each do |category| %>
+        <% %w[arts adventure analysis current_events history how_to news technology a_demonstrators_guide].each do |category| %>
           <%= link_to t("footer.nav.articles.#{category}"), [:category, slug: category.dasherize] %>
         <% end %>
       </dd>

--- a/config/locales/ar/ar.yml
+++ b/config/locales/ar/ar.yml
@@ -47,6 +47,7 @@ ar:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/be/be.yml
+++ b/config/locales/be/be.yml
@@ -47,6 +47,7 @@ be:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/bg/bg.yml
+++ b/config/locales/bg/bg.yml
@@ -47,6 +47,7 @@ bg:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/ca/ca.yml
+++ b/config/locales/ca/ca.yml
@@ -47,6 +47,7 @@ ca:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/cs/cs.yml
+++ b/config/locales/cs/cs.yml
@@ -48,6 +48,7 @@ cs:
       articles:
         label: Články
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Dobrodružné
         analysis: Analýza
         arts: Umění

--- a/config/locales/cz/cz.yml
+++ b/config/locales/cz/cz.yml
@@ -47,6 +47,7 @@ cz:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/da/da.yml
+++ b/config/locales/da/da.yml
@@ -47,6 +47,7 @@ da:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/de/de.yml
+++ b/config/locales/de/de.yml
@@ -47,6 +47,7 @@ de:
       articles:
         label: Artikel
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Abenteuer
         analysis: Analysen
         arts: Kunst

--- a/config/locales/dv/dv.yml
+++ b/config/locales/dv/dv.yml
@@ -47,6 +47,7 @@ dv:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -425,6 +425,7 @@ en:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/es-419/es-419.yml
+++ b/config/locales/es-419/es-419.yml
@@ -43,6 +43,7 @@ es-419:
       articles:
         label: Artículos
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Aventura
         analysis: Análisis
         arts: Artes

--- a/config/locales/es/es.yml
+++ b/config/locales/es/es.yml
@@ -43,6 +43,7 @@ es:
       articles:
         label: Artículos
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Aventura
         analysis: Análisis
         arts: Artes

--- a/config/locales/eu/eu.yml
+++ b/config/locales/eu/eu.yml
@@ -47,6 +47,7 @@ eu:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/fa/fa.yml
+++ b/config/locales/fa/fa.yml
@@ -47,6 +47,7 @@ fa:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/fi/fi.yml
+++ b/config/locales/fi/fi.yml
@@ -47,6 +47,7 @@ fi:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/fr/fr.yml
+++ b/config/locales/fr/fr.yml
@@ -59,6 +59,7 @@ fr:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Aventure
         analysis: Analyse
         arts: Arts

--- a/config/locales/gl/gl.yml
+++ b/config/locales/gl/gl.yml
@@ -47,6 +47,7 @@ gl:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/gr/gr.yml
+++ b/config/locales/gr/gr.yml
@@ -47,6 +47,7 @@ gr:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/he/he.yml
+++ b/config/locales/he/he.yml
@@ -47,6 +47,7 @@ he:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/hu/hu.yml
+++ b/config/locales/hu/hu.yml
@@ -47,6 +47,7 @@ hu:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/id/id.yml
+++ b/config/locales/id/id.yml
@@ -47,6 +47,7 @@ id:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/it/it.yml
+++ b/config/locales/it/it.yml
@@ -59,6 +59,7 @@ it:
       articles:
         label: Articoli
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Avventura
         analysis: Analisi
         arts: Arte

--- a/config/locales/ja/ja.yml
+++ b/config/locales/ja/ja.yml
@@ -47,6 +47,7 @@ ja:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/ko/ko.yml
+++ b/config/locales/ko/ko.yml
@@ -47,6 +47,7 @@ ko:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/ku/ku.yml
+++ b/config/locales/ku/ku.yml
@@ -47,6 +47,7 @@ ku:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/nl/nl.yml
+++ b/config/locales/nl/nl.yml
@@ -47,6 +47,7 @@ nl:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/no/no.yml
+++ b/config/locales/no/no.yml
@@ -47,6 +47,7 @@
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/pl/pl.yml
+++ b/config/locales/pl/pl.yml
@@ -47,6 +47,7 @@ pl:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/pt/pt.yml
+++ b/config/locales/pt/pt.yml
@@ -59,6 +59,7 @@ pt:
       articles:
         label: Artigos
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Aventura
         analysis: Análises
         arts: Artess

--- a/config/locales/ro/ro.yml
+++ b/config/locales/ro/ro.yml
@@ -47,6 +47,7 @@ ro:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/ru/ru.yml
+++ b/config/locales/ru/ru.yml
@@ -47,6 +47,7 @@ ru:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/sh/sh.yml
+++ b/config/locales/sh/sh.yml
@@ -47,6 +47,7 @@ sh:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/sk/sk.yml
+++ b/config/locales/sk/sk.yml
@@ -47,6 +47,7 @@ sk:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/sl/sl.yml
+++ b/config/locales/sl/sl.yml
@@ -47,6 +47,7 @@ sl:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/sv/sv.yml
+++ b/config/locales/sv/sv.yml
@@ -47,6 +47,7 @@ sv:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/th/th.yml
+++ b/config/locales/th/th.yml
@@ -47,6 +47,7 @@ th:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/tl/tl.yml
+++ b/config/locales/tl/tl.yml
@@ -47,6 +47,7 @@ tl:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/tr/tr.yml
+++ b/config/locales/tr/tr.yml
@@ -47,6 +47,7 @@ tr:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/uk/uk.yml
+++ b/config/locales/uk/uk.yml
@@ -47,6 +47,7 @@ uk:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/vi/vi.yml
+++ b/config/locales/vi/vi.yml
@@ -47,6 +47,7 @@ vi:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts

--- a/config/locales/zh/zh.yml
+++ b/config/locales/zh/zh.yml
@@ -47,6 +47,7 @@ zh:
       articles:
         label: Articles
         feed: RSS
+        a_demonstrators_guide: A Demonstrator’s Guide
         adventure: Adventure
         analysis: Analysis
         arts: Arts


### PR DESCRIPTION
Add _A Demonstrator’s Guide_ category to footer nav sitemap 

This is a collection of articles with that title prefix: `A Demonstrator’s Guide to…`

https://crimethinc.com/categories/a-demonstrators-guide

- added underscored key to articles section of footer sitemap: `a_demonstrators_guide`
- added `a_demonstrators_guide` to `en.yml` and placeholder `a_demonstrators_guide: A Demonstrator’s Guide` to all other locale files
- added _A Demonstrator’s Guide_ category in production
- added all relevant articles to that category in production: 9 EN, non-EN translations of some of those 9

# Before 

<img width="2032" height="1162" alt="Screenshot 2026-01-28 at 4 44 20 PM" src="https://github.com/user-attachments/assets/4e9bdd4c-5c6e-46c2-ba04-d9aa94fca980" />

# After 

<img width="2032" height="1162" alt="Screenshot 2026-01-28 at 4 44 09 PM" src="https://github.com/user-attachments/assets/4ed00d05-d351-4b80-b614-5637755c307e" />
