### PR TITLE
Removes obsolete badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Ruby on Rails app that powers https://crimethinc.com
 
 [![GitHub Actions Tests CI Build Status](https://github.com/crimethinc/website/actions/workflows/tests.yml/badge.svg)](https://github.com/crimethinc/website/actions?workflow=Tests)
 [![GitHub Actions System Tests CI Build Status](https://github.com/crimethinc/website/actions/workflows/tests_system.yml/badge.svg)](https://github.com/crimethinc/website/actions?workflow=Tests)
-[![Maintainability](https://api.codeclimate.com/v1/badges/22ef4ea6475be7057b87/maintainability)](https://codeclimate.com/github/crimethinc/website/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/22ef4ea6475be7057b87/test_coverage)](https://codeclimate.com/github/crimethinc/website/test_coverage)
 
 ## Short Version
 


### PR DESCRIPTION
# What does this pull request do?

Very simply, it removes "Maintainability" and "Test Coverage" badges from the README.