### PR TITLE
Add better list item indentation on Pages

### DIFF
--- a/app/assets/stylesheets/2017/views/_page.scss
+++ b/app/assets/stylesheets/2017/views/_page.scss
@@ -127,7 +127,7 @@
     }
 
     ol {
-      list-style-type: square;
+      list-style-type: numerals;
     }
 
     ul {
@@ -141,7 +141,17 @@
     }
 
     li {
-      margin: 0 0 0.5em 1em;
+      margin: 0 0 0.5em 0;
+    }
+
+    .e-content {
+      li {
+        margin: 0 0 0.5em 1em;
+      }
+
+      ol li {
+        margin-left: 1.5em;
+      }
     }
 
     li li {


### PR DESCRIPTION
# Before

<img width="782" height="642" alt="image" src="https://github.com/user-attachments/assets/1cf3a2e8-abc9-4630-9a9c-fcaa44c2e578" />


# After 

<img width="757" height="626" alt="Screenshot 2026-03-13 at 12 29 42 PM" src="https://github.com/user-attachments/assets/6db6a237-7f7e-4bfe-af3a-d1060e741106" />
