### PR TITLE
Un-ignore and add /admin/tags views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ ISSUES.md
 /vendor/gems
 /coverage
 .idea/
-TAGS
+/TAGS
 .env
 database-dumps
 Brewfile.lock.json

--- a/app/views/admin/tags/_form.html.erb
+++ b/app/views/admin/tags/_form.html.erb
@@ -1,0 +1,17 @@
+<div class='col-12 col-md-9 col-lg-6'>
+  <%= form_with(model: [:admin, @tag]) do |form| %>
+    <%= render "admin/form_errors", thing: @tag %>
+
+    <%= render "admin/label_and_field_form_group", form: form, attr: :name %>
+
+    <%= render "admin/label_and_field_form_group", form: form, attr: :slug %>
+    <p class="form-text text-muted">
+      Leave blank to auto-generate <code>slug</code> based on <code>name</code>.
+    </p>
+
+    <%= render "admin/label_and_area_form_group", form: form, attr: :description, rows: 4 %>
+    <p class="form-text text-muted">Formatted as <b>Markdown</b>.</p>
+
+    <%= render "admin/form_actions", cancel_url: [:admin, :tags] %>
+  <% end %>
+</div>

--- a/app/views/admin/tags/edit.html.erb
+++ b/app/views/admin/tags/edit.html.erb
@@ -1,0 +1,7 @@
+<%= render "admin/page_header", thing: @tag %>
+<%= render "form" %>
+
+<%= render "admin/danger_zone",
+           thing: @tag,
+           label: "tag",
+           path: [:admin, @tag] %>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -1,0 +1,29 @@
+<%= render "admin/page_header", thing: @tags %>
+
+<table class="table table-striped table-sm mb-5">
+  <thead class="table-dark">
+    <tr>
+      <th></th>
+      <th>Name</th>
+      <th>Slug</th>
+      <th>Description</th>
+      <th class='text-end'>Articles</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @tags.each do |tag| %>
+      <tr>
+        <td>
+          <%= link_to "EDIT", [:edit, :admin, tag], class: "btn btn-outline-primary btn-sm" %>
+        </td>
+        <td><b><%= link_to tag.name, [:admin, tag] %></b></td>
+        <td><%= tag.slug %></td>
+        <td><%= truncate(tag.description, length: 80) %></td>
+        <td class='text-end'><%= tag.articles.count %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @tags, views_prefix: 'admin', theme: 'twitter-bootstrap-4' %>

--- a/app/views/admin/tags/new.html.erb
+++ b/app/views/admin/tags/new.html.erb
@@ -1,0 +1,2 @@
+<%= render "admin/page_header", thing: @tag %>
+<%= render "form",              tag:  @tag %>

--- a/app/views/admin/tags/show.html.erb
+++ b/app/views/admin/tags/show.html.erb
@@ -1,0 +1,48 @@
+<%= render "admin/page_header", thing: @tag %>
+
+<article>
+  <header>
+    <h1>
+      <%= link_to [:admin, @tag], class: "p-name" do %>
+        <span class="h1 name"><%= @tag.name %></span>
+      <% end %>
+    </h1>
+  </header>
+
+  <hr>
+  <p>
+    <strong>Name:</strong>
+    <%= @tag.name %>
+  </p>
+
+  <p>
+    <strong>Slug:</strong>
+    <%= @tag.slug %>
+  </p>
+
+  <p>
+    <strong>URL:</strong>
+    <%= link_to @tag.path, @tag.path %>
+  </p>
+
+  <p>
+    <strong>Description (raw):</strong>
+  </p>
+
+  <div class="card mb-3">
+    <div class="card-body">
+      <pre class="mb-0"><code><%= @tag.description %></code></pre>
+    </div>
+  </div>
+
+  <p>
+    <strong>Description (rendered):</strong>
+  </p>
+
+  <div class="card mb-3">
+    <div class="card-body">
+      <%= render_markdown @tag.description %>
+    </div>
+  </div>
+
+</article>


### PR DESCRIPTION
In https://github.com/crimethinc/website/pull/5174, /admin/tags views were missed because `.gitignore` had a `TAGS` entry in it

Then production was returning a `406` HTTP status code for `/admin/tags/*`