### PR TITLE
Remove chromedriver Homebrew cask

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -23,8 +23,5 @@ brew 'postgresql@15'
 # Overcommit hooks
 brew 'yamllint'
 
-# System tests
-cask 'chromedriver'
-
 # Entity relationship diagram (ERD)
 brew 'graphviz'


### PR DESCRIPTION
Let Selenium Manager handle driver downloads automatically

The error is  because of a ChromeDriver 142 (my version installed via brew cask) vs Chrome 145 version (latest version, needed by Selenium) mismatch.

I was getting these failures locally when running system tests:


```
  1) Setting and changing an articles published_at date creates a new article
     Got 0 failures and 2 other errors:

     1.1) Failure/Error: visit '/signin'
          
          Selenium::WebDriver::Error::SessionNotCreatedError:
            session not created: This version of ChromeDriver only supports Chrome version 142
            Current browser version is 145.0.7632.160 with binary path /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
          # /Users/s/.gem/ruby/3.4.8/gems/selenium-webdriver-4.41.0/lib/selenium/webdriver/remote/response.rb:63:in 'Selenium::WebDriver::Remote::Response#add_cause'

[snip]

          # /Users/s/.gem/ruby/3.4.8/gems/webmock-3.26.1/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
          # ------------------
          # --- Caused by: ---
          # Selenium::WebDriver::Error::WebDriverError:
          #   0   chromedriver                        0x000000010103b3d8 cxxbridge1$str$ptr + 2941356
1   chromedriver                        0x0000000101033094 cxxbridge1$str$ptr + 2907752
2   chromedriver                        0x0000000100b4a2c4 _RNvCsgXDX2mvAJAg_7___rustc35___rust_no_alloc_shim_is_unstable_v2 + 74028
3   chromedriver                        0x0000000100b83158 _RNvCsgXDX2mvAJAg_7___rustc35___rust_no_alloc_shim_is_unstable_v2 + 307136
4   chromedriver                        0x0000000100b822ec _RNvCsgXDX2mvAJAg_7___rustc35___rust_no_alloc_shim_is_unstable_v2 + 303444
5   chromedriver                        0x0000000100b7e54c _RNvCsgXDX2mvAJAg_7___rustc35___rust_no_alloc_shim_is_unstable_v2 + 287668
6   chromedriver                        0x0000000100b7ac40 _RNvCsgXDX2mvAJAg_7___rustc35___rust_no_alloc_shim_is_unstable_v2 + 273064
7   chromedriver                        0x0000000100bbf154 _RNvCsgXDX2mvAJAg_7___rustc35___rust_no_alloc_shim_is_unstable_v2 + 552892
8   chromedriver                        0x0000000100bbeb88 _RNvCsgXDX2mvAJAg_7___rustc35___rust_no_alloc_shim_is_unstable_v2 + 551408
9   chromedriver                        0x0000000100b85f18 _RNvCsgXDX2mvAJAg_7___rustc35___rust_no_alloc_shim_is_unstable_v2 + 318848
10  chromedriver                        0x0000000100ffd81c cxxbridge1$str$ptr + 2688496
11  chromedriver                        0x0000000101001038 cxxbridge1$str$ptr + 2702860
12  chromedriver                        0x0000000100fde634 cxxbridge1$str$ptr + 2561032
13  chromedriver                        0x0000000101001910 cxxbridge1$str$ptr + 2705124
14  chromedriver                        0x0000000100fcfed4 cxxbridge1$str$ptr + 2501800
15  chromedriver                        0x0000000101021a40 cxxbridge1$str$ptr + 2836500
16  chromedriver                        0x0000000101021bc4 cxxbridge1$str$ptr + 2836888
17  chromedriver                        0x0000000101032ce4 cxxbridge1$str$ptr + 2906808
18  libsystem_pthread.dylib             0x0000000187dabc08 _pthread_start + 136
19  libsystem_pthread.dylib             0x0000000187da6ba8 thread_start + 8

```
