### PR TITLE
Extract system test helpers into support files

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,9 +5,9 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 
 require 'spec_helper'
 require 'rspec/rails'
-require 'capybara/rspec'
-require 'capybara/cuprite'
+require 'support/capybara'
 require 'support/factory_bot'
+require 'support/login_helper'
 require 'webmock/rspec'
 
 WebMock.disable_net_connect!(allow_localhost: true)
@@ -20,5 +20,3 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 end
-
-Capybara.javascript_driver = :cuprite

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,6 @@ require 'simplecov'
 SimpleCov.start 'rails'
 
 RSpec.configure do |config|
-  config.before(:each, type: :system) do
-    driven_by :rack_test
-  end
-
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
@@ -17,16 +13,4 @@ RSpec.configure do |config|
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
   config.example_status_persistence_file_path = 'tmp/rspec-failures.txt'
-end
-
-def login_user _user
-  visit '/signin'
-
-  within('main') do
-    fill_in 'username', with: 'user1'
-    fill_in 'password', with: 'c' * 31
-  end
-
-  click_link_or_button 'Sign In'
-  expect(page).to have_content 'Logged in!'
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,14 @@
+require 'capybara/rspec'
+require 'capybara/cuprite'
+
+Capybara.javascript_driver = :cuprite
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    if self.class.metadata[:js]
+      driven_by :cuprite
+    else
+      driven_by :rack_test
+    end
+  end
+end

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -1,0 +1,17 @@
+module LoginHelper
+  def login_user
+    visit '/signin'
+
+    within('main') do
+      fill_in 'username', with: 'user1'
+      fill_in 'password', with: 'c' * 31
+    end
+
+    click_link_or_button 'Sign In'
+    expect(page).to have_content 'Logged in!'
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginHelper, type: :system
+end

--- a/spec/system/admin_live_blog_spec.rb
+++ b/spec/system/admin_live_blog_spec.rb
@@ -5,17 +5,15 @@ describe 'Creating sub articles for a live blog' do
 
   before do
     Current.theme = '2017'
-  end
-
-  let(:admin) do
     create(:user, username: 'user1', password: 'c' * 31, role: 'publisher')
   end
+
   let(:blog_update_title) { 'live blog update 1' }
 
   it 'can add sub articles to an existing article' do
     article = create(:article, published_at: Time.zone.parse('2018-12-24 11:59:00 UTC'))
 
-    login_user(admin)
+    login_user
     visit '/admin/articles'
 
     click_link_or_button article.title

--- a/spec/system/article_datetime_settings_spec.rb
+++ b/spec/system/article_datetime_settings_spec.rb
@@ -5,14 +5,11 @@ describe 'Setting and changing an articles published_at date', :js do
 
   before do
     Current.theme = '2017'
-  end
-
-  let(:admin) do
     create(:user, username: 'user1', password: 'c' * 31, role: 'publisher')
   end
 
   it 'creates a new article' do
-    login_user(admin)
+    login_user
     visit '/admin/articles'
 
     click_link_or_button 'NEW'
@@ -37,7 +34,7 @@ describe 'Setting and changing an articles published_at date', :js do
     expect(article.published_at.utc).to eq('2018-12-24 11:59:00 UTC')
     expect(article.published_at_tz).to eq('Pacific Time (US & Canada)')
 
-    login_user(admin)
+    login_user
     visit '/admin/articles'
 
     click_link_or_button 'EDIT'
@@ -62,7 +59,7 @@ describe 'Setting and changing an articles published_at date', :js do
   end
 
   it 'saves an article without entering publication date info', skip: 'TODO: fix or change flaky system tests' do
-    login_user(admin)
+    login_user
     visit '/admin/articles'
 
     click_link_or_button 'NEW'
@@ -78,7 +75,7 @@ describe 'Setting and changing an articles published_at date', :js do
 
   it 'uses ‘PUBLISH NOW’ feature' do
     freeze_time do
-      login_user(admin)
+      login_user
       visit '/admin/articles'
 
       click_link_or_button 'NEW'
@@ -97,7 +94,7 @@ describe 'Setting and changing an articles published_at date', :js do
   it 'Sets the publication date/time if article is `published` and fields are blank',
      skip: 'TODO: fix or change flaky system tests' do
     freeze_time do
-      login_user(admin)
+      login_user
       visit '/admin/articles'
 
       click_link_or_button 'NEW'


### PR DESCRIPTION
Follow up to https://github.com/crimethinc/website/pull/5186 and https://github.com/crimethinc/website/pull/5187

Move login helper and Capybara driver config out of `spec_helper.rb` into dedicated files under `spec/support/`. Simplify `login_user` by dropping the unused argument.
