### PR TITLE
Remove deprecated to_time_preserves_timezone config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -107,12 +107,6 @@ module Crimethinc
     # config.eager_load_paths << Rails.root.join("extras")
 
     # TODO: rails81
-    # DEPRECATION WARNING:
-    # `to_time` will always preserve the full timezone rather than offset of the receiver in Rails 8.1.
-    # is deprecated and will be removed in Rails 8.2
-    # To opt in to the new behavior, set `config.active_support.to_time_preserves_timezone = :zone`.
-    config.active_support.to_time_preserves_timezone = :zone
-
     # Load service-specific config files into Rails' custom config namespace: x
     # Example: Rails.application.config.x.stripe.secret_key
     config.x.app         = config_for 'services/app'


### PR DESCRIPTION
The `:zone` behavior is the default in Rails 8.2, so the explicit setting is no longer needed.

