### PR TITLE
Enable escape_js_separators_in_json Rails 8.1 default

### DIFF
--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -1,12 +1,6 @@
 Rails.configuration.action_controller.escape_json_responses = false
 
-###
-# Skips escaping LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) in JSON.
-#
-# Historically these characters were not valid inside JavaScript literal strings but that changed in ECMAScript 2019.
-# As such it's no longer a concern in modern browsers: https://caniuse.com/mdn-javascript_builtins_json_json_superset.
-#++
-# Rails.configuration.active_support.escape_js_separators_in_json = false
+Rails.configuration.active_support.escape_js_separators_in_json = false
 
 ###
 # Raises an error when order dependent finder methods (e.g. `#first`, `#second`) are called without `order` values


### PR DESCRIPTION
Stop escaping `U+2028/U+2029` in JSON. These characters have been valid in JavaScript strings since ECMAScript 2019.
