### PR TITLE
[Rail 8.2 prep] Enable new default: raise_on_missing_required_finder_order_columns

### DIFF
--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -2,15 +2,7 @@ Rails.configuration.action_controller.escape_json_responses = false
 
 Rails.configuration.active_support.escape_js_separators_in_json = false
 
-###
-# Raises an error when order dependent finder methods (e.g. `#first`, `#second`) are called without `order` values
-# on the relation, and the model does not have any order columns (`implicit_order_column`, `query_constraints`, or
-# `primary_key`) to fall back on.
-#
-# The current behavior of not raising an error has been deprecated, and this configuration option will be removed in
-# Rails 8.2.
-#++
-# Rails.configuration.active_record.raise_on_missing_required_finder_order_columns = true
+Rails.configuration.active_record.raise_on_missing_required_finder_order_columns = true
 
 Rails.configuration.action_controller.action_on_path_relative_redirect = :raise
 


### PR DESCRIPTION


Last Rails 8.1 framework default. Raises when order-dependent finders like `.first`/`.last` are called on unordered relations. This will become mandatory in Rails 8.2.
