### PR TITLE
css refactor: replace scss comments with css comments

### DIFF
--- a/app/assets/stylesheets/2017/articles_custom_css.scss
+++ b/app/assets/stylesheets/2017/articles_custom_css.scss
@@ -1,10 +1,10 @@
-// for text centering in 2017 theme, which does not include Bootstrap
+/* for text centering in 2017 theme, which does not include Bootstrap */
 .text-center {
   text-align: center !important;
 }
 
-// for article:
-// https://crimethinc.com/2017/02/12/high-voltage-lessons-from-four-summers-of-protests-in-armenia
+/* for article: */
+/* https://crimethinc.com/2017/02/12/high-voltage-lessons-from-four-summers-of-protests-in-armenia */
 #article--high-voltage-lessons-from-four-summers-of-protests-in-armenia td {
   width: 33.3333%;
 }

--- a/app/assets/stylesheets/2017/base/_mixins.scss
+++ b/app/assets/stylesheets/2017/base/_mixins.scss
@@ -1,5 +1,5 @@
 @mixin out() {
-  // for development and debugging only
+  /* for development and debugging only */
   outline: 1px solid red;
 }
 

--- a/app/assets/stylesheets/2017/components/_articles_list.scss
+++ b/app/assets/stylesheets/2017/components/_articles_list.scss
@@ -42,13 +42,13 @@
       h2 {
         font-size: 2.5rem;
       }
-    } // .h-entry
-  } //.articles-list
-} // .h-feed
+    } /* .h-entry */
+  } /* .articles-list */
+} /* .h-feed */
 
-// articles lists (/tags, /categories)...
+/* articles lists (/tags, /categories)... */
 .categories,
 .categories ul {
   margin: 0 !important;
 }
-// ...articles lists (/tags, /categories)
+/* ...articles lists (/tags, /categories) */

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -1,4 +1,4 @@
-// Move SUPPORT US button to left or right based on language direction
+/* Move SUPPORT US button to left or right based on language direction */
 html[dir="ltr"] .site-header .button {
   right: var(--border-size-large);
 }
@@ -63,7 +63,7 @@ html[dir="rtl"] .site-header .button {
   color: white !important;
 }
 
-// nav
+/* nav */
 .primary-navigation {
   margin: 1rem 0 0 0;
   display: inline-block;
@@ -98,7 +98,7 @@ html[dir="rtl"] .site-header .button {
   }
 }
 
-// larger than $large-phone viewport
+/* larger than $large-phone viewport */
 @media screen and (min-width: $small-tablet) {
   .site-header .nav-link {
     font-size: 1.7rem;

--- a/app/assets/stylesheets/2017/components/_social.scss
+++ b/app/assets/stylesheets/2017/components/_social.scss
@@ -16,7 +16,7 @@
       margin: 0 var(--border-size-small) var(--border-size-small) 0;
     }
 
-    // The Mastodon account is on a domain called todon.eu
+    /* The Mastodon account is on a domain called todon.eu */
     .link-domain-todon,
     .link-domain-mastodon  { @include social-icon("mastodon");  }
     .link-domain-email     { @include social-icon("email");     }
@@ -29,11 +29,11 @@
     .link-domain-tumblr    { @include social-icon("tumblr");    }
     .link-domain-twitter   { @include social-icon("twitter");   }
     .link-domain-youtube   { @include social-icon("youtube");   }
-    .link-domain-kolektiva, // the peertube instance domain is kolektiva.media
+    .link-domain-kolektiva, /* the peertube instance domain is kolektiva.media */
     .link-domain-peertube  { @include social-icon("peertube");  }
     .link-domain-bandcamp  { @include social-icon("bandcamp");  }
     .link-domain-reddit    { @include social-icon("reddit");  }
-    .link-domain-bsky, // the bluesky domain is bsky for now, but it may change or have more in the future
+    .link-domain-bsky, /* the bluesky domain is bsky for now, but it may change or have more in the future */
     .link-domain-bluesky    { @include social-icon("bluesky");  }
   }
 }

--- a/app/assets/stylesheets/2017/views/_article.scss
+++ b/app/assets/stylesheets/2017/views/_article.scss
@@ -352,14 +352,14 @@
     }
 
     caption {
-      // TODO
+      /* TODO */
       font-weight: bold;
       font-weight: 700;
       padding: .5em;
     }
 
     th {
-      // TODO
+      /* TODO */
       font: {
         weight: bold;
         weight: 700;
@@ -370,7 +370,7 @@
     }
 
     th, td {
-      // TODO
+      /* TODO */
       padding: .5em;
     }
 
@@ -439,7 +439,7 @@
     }
 
     /* for groups of images */
-    // TODO
+    /* TODO */
     .images,
     .images-group {
       text-align: center;
@@ -454,13 +454,13 @@
       @media screen and (min-width: $small-tablet) {
         figure + figure,
         img + img {
-          // TODO
+          /* TODO */
           margin-left: 1em;
         }
       }
 
       figure {
-        // TODO
+        /* TODO */
         display: inline-block;
         margin: 0;
         max-width: 50%;
@@ -474,13 +474,13 @@
     }
 
     table {
-      // TODO
+      /* TODO */
       text-align: center;
       margin: 1em auto;
     }
 
     th {
-      // TODO
+      /* TODO */
       text-align: left;
       padding-right: .25em;
       font-weight: normal;
@@ -488,7 +488,7 @@
     }
 
     td {
-      // TODO
+      /* TODO */
       text-align: left;
       font-weight: lighter;
       font-weight: 300;
@@ -528,18 +528,18 @@
       .categories { display: none !important; }
       .localizations { display: none !important; }
 
-      // only safari supports currently
+      /* only safari supports currently */
       div:has(> ul.pagination) { display: none; }
       ul.pagination { display: none; }
 
-      // hide videos as they render as a large blank space in print
+      /* hide videos as they render as a large blank space in print */
       .video-container { display: none; }
 
-      // make title and subtitle a lil bit bigger in print
+      /* make title and subtitle a lil bit bigger in print */
       .p-name .p-x-title { font-size: 5rem; }
       .p-name .p-x-subtitle { font-size: 3rem; }
 
-      // Prevent images and blockquotes from spanning a page break
+      /* Prevent images and blockquotes from spanning a page break */
       blockquote, figure, img {
           break-inside: avoid;
           max-height: 90vh;

--- a/app/assets/stylesheets/2017/views/_article_archives.scss
+++ b/app/assets/stylesheets/2017/views/_article_archives.scss
@@ -16,6 +16,6 @@
         color: var(--color-true-black);
       }
 
-    } // .h-feed
-  } // main
-} // #article-archives
+    } /* .h-feed */
+  } /* main */
+} /* #article-archives */

--- a/app/assets/stylesheets/2017/views/_home.scss
+++ b/app/assets/stylesheets/2017/views/_home.scss
@@ -9,7 +9,7 @@
     padding: 0;
     list-style: none;
 
-    // most recent entry only
+    /* most recent entry only */
     > .h-entry {
       height: 300pt;
 
@@ -39,7 +39,7 @@
     margin: 0 0 var(--border-size-xlarge) 0;
   }
 
-  // all entries in the feed (including most recent)
+  /* all entries in the feed (including most recent) */
   .h-entry {
     background-color:    var(--color-true-black);
     background-position: center;
@@ -138,7 +138,7 @@
     }
   } /* .h-entry */
 
-  // all entries in the feed except most recent
+  /* all entries in the feed except most recent */
   .row {
     @media screen and (min-width: $small-tablet) {
       display: flex;
@@ -165,9 +165,9 @@
       }
     }
   }
-} // #home
+} /* #home */
 
-// hide 'Tags:' and 'Categories:' on home page story card and article#show header
+/* hide 'Tags:' and 'Categories:' on home page story card and article#show header */
 #article,
 #home {
   .badge {

--- a/app/assets/stylesheets/2017/views/_page.scss
+++ b/app/assets/stylesheets/2017/views/_page.scss
@@ -37,7 +37,7 @@
 
     .meta {
       img {
-        // TODO refactor away
+        /* TODO refactor away */
         width: 100% !important;
         height: auto !important;
       }

--- a/app/assets/stylesheets/2017/views/_podcast.scss
+++ b/app/assets/stylesheets/2017/views/_podcast.scss
@@ -1,4 +1,4 @@
-// HACK: overly specific override of _page.scss, will go away in 2.0 redesign's CSS
+/* HACK: overly specific override of _page.scss, will go away in 2.0 redesign's CSS */
 #podcast {
   main {
     .e-content {
@@ -83,7 +83,7 @@
         display: inline-block;
         margin: 0 0 var(--border-size-small) var(--border-size-small);
 
-        // TODO WHY is this necessary? :(
+        /* TODO WHY is this necessary? :( */
         text-indent: 9999em !important;
 
         &:first-child {
@@ -142,7 +142,7 @@
 
         a {
           margin: 0 0 var(--border-size-small) var(--border-size-small);
-          // WHY is this necessary? :(
+          /* WHY is this necessary? :( */
           text-indent: 9999em !important;
         }
       }

--- a/app/assets/stylesheets/2017/views/_read_watch.scss
+++ b/app/assets/stylesheets/2017/views/_read_watch.scss
@@ -70,7 +70,7 @@
         font-style: italic;
         color: var(--color-gray);
       }
-    } // .h-entry
+    } /* .h-entry */
 
     #samples {
       .column:first-child {
@@ -88,8 +88,8 @@
         margin-left: 0;
       }
     }
-  } // main
-} // #page
+  } /* main */
+} /* #page */
 
 #library header img {
   margin-top: 2rem;

--- a/app/assets/stylesheets/2017/views/_tools.scss
+++ b/app/assets/stylesheets/2017/views/_tools.scss
@@ -1,4 +1,4 @@
-// Contradictionary definitions
+/* Contradictionary definitions */
 .h-entry.definition {
   #intro a {
     font-weight: normal;
@@ -85,19 +85,19 @@
         }
       }
 
-      // Contradictionary rounded corners
-      // books#index
+      /* Contradictionary rounded corners */
+      /* books#index */
       #contradictionary .tool-front img {
         border-radius: 0 10px 10px 0;
       }
-      // books#show
+      /* books#show */
       .tool-front.contradictionary-cover img {
         border-radius: 0 20px 20px 0;
       }
 
-      // Cover image sizes on /books
+      /* Cover image sizes on /books */
       .book {
-        // Custom size
+        /* Custom size */
         &#recipes-for-disaster .tool-front img {
           width: 100%;
         }
@@ -112,7 +112,7 @@
           }
         }
 
-        // Default size
+        /* Default size */
         & .tool-front img {
           width: 68%;
         }
@@ -334,7 +334,7 @@
         }
       }
 
-      // extras
+      /* extras */
       h1 + .row {
         margin-top: 2rem;
       }

--- a/app/assets/stylesheets/2017/views/support.scss
+++ b/app/assets/stylesheets/2017/views/support.scss
@@ -232,7 +232,7 @@
   width: 75%;
 }
 
-// removes little up and down arrows in number field
+/* removes little up and down arrows in number field */
 #amount::-webkit-inner-spin-button,
 #amount::-webkit-outer-spin-button {
   -webkit-appearance: none;
@@ -258,7 +258,7 @@ label[for=amount_slider]  {
   border: 0;
 }
 
-// Generated using: http://danielstern.ca/range.css
+/* Generated using: http://danielstern.ca/range.css */
 #amount_slider {
   -webkit-appearance: none;
   width: 100%;

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -19,13 +19,13 @@ label {
   font-weight: normal;
 }
 
-// Border on this article (2017-08-23) indicates when the view counter started.
-// Everything below it was published pre-counter.
+/* Border on this article (2017-08-23) indicates when the view counter started. */
+/* Everything below it was published pre-counter. */
 .article-counter-genesis {
   border-bottom: 10px solid #666;
 }
 
-// helpers, extract to file when it makes sense
+/* helpers, extract to file when it makes sense */
 .rotated {
   transform: rotate(-2deg);
 }

--- a/app/assets/stylesheets/to_change_everything/_ภาษาไทย.scss
+++ b/app/assets/stylesheets/to_change_everything/_ภาษาไทย.scss
@@ -15,7 +15,7 @@
     position: absolute;
   }
 
-  // the video image/link
+  /* the video image/link */
   .cte-video {
     img {
       @media (min-width: 104.4375rem) {

--- a/app/assets/stylesheets/to_change_everything/_한국어.scss
+++ b/app/assets/stylesheets/to_change_everything/_한국어.scss
@@ -19,9 +19,9 @@
       padding-top: 5rem;
     }
 
-    // the title
+    /* the title */
     h1 {
-      // make sure subtitle clears any descenders
+      /* make sure subtitle clears any descenders */
       padding-bottom: 1.5rem;
       @media (min-width: 37.5625rem) and (max-width: 63.9375rem) {
         padding-bottom: 5rem;

--- a/app/assets/stylesheets/to_change_everything/common/_title_section.scss
+++ b/app/assets/stylesheets/to_change_everything/common/_title_section.scss
@@ -1,4 +1,4 @@
-// Overall Layout Spacing
+/* Overall Layout Spacing */
 .title-container {
   display: flex;
   flex-flow: column nowrap;
@@ -6,7 +6,7 @@
   align-content: center;
   align-items: center;
 
-  // make sure overall container is the right shape on all devices
+  /* make sure overall container is the right shape on all devices */
   min-height: 17rem;
   min-height: 40vh;
   @media (min-width: 75.0625rem) {
@@ -16,24 +16,24 @@
     min-height: 50vh;
   }
 
-  // clear the nav bar
+  /* clear the nav bar */
   padding-top: 3rem;
   @media (min-width: 75.0625rem) {
     padding-top: 5rem;
   }
 
-  // the title
+  /* the title */
   h1 {
     text-align: center;
 
-    // make sure subtitle clears any descenders
+    /* make sure subtitle clears any descenders */
     padding-bottom: 1rem;
     @media (min-width: 64rem) {
       padding-bottom: 3rem;
     }
   }
 
-  // the subtitle
+  /* the subtitle */
   h4 {
     text-align: center;
     padding-bottom: 1rem;
@@ -42,8 +42,8 @@
     }
   }
 
-  // the "call to action" is the section containg the buttons to watch
-  // the TCE video or download the TCE PDF
+  /* the "call to action" is the section containg the buttons to watch */
+  /* the TCE video or download the TCE PDF */
   .call-to-action {
     display: flex;
     flex-flow: row nowrap;
@@ -51,14 +51,14 @@
     justify-content: center;
     width: 100%;
 
-    // gap between subtitle and cte container
+    /* gap between subtitle and cte container */
     padding: 1rem 0;
 
     @media (min-width: 104.4375rem) {
       padding: 3rem 0;
     }
 
-    // gap between bottom of cte container and start of text intro
+    /* gap between bottom of cte container and start of text intro */
     @media (max-width: 104.375rem) {
       margin-bottom: 3rem;
     }
@@ -68,7 +68,7 @@
     }
   }
 
-  // the video image/link
+  /* the video image/link */
   .cte-video {
     display: flex;
     flex-flow: column nowrap;
@@ -87,14 +87,14 @@
     }
   }
 
-  // put a gap between pdf/video that will grow to be proportional based
-  // on container width
+  /* put a gap between pdf/video that will grow to be proportional based */
+  /* on container width */
   .cte-spacer {
     min-width: 3rem;
     flex-grow: 0.15;
   }
 
-  // the pdf image and link
+  /* the pdf image and link */
   .cte-pdf {
     display: flex;
     flex-flow: row nowrap;
@@ -112,7 +112,7 @@
   }
 }
 
-// The background image of the title section
+/* The background image of the title section */
 .title-container {
   background-color: grey;
   background-image: url("https://cdn.crimethinc.com/tce/images/cover-phone.jpg");
@@ -135,7 +135,7 @@
     background-image: url("https://cdn.crimethinc.com/assets/tce/images/cover-large.gif");
   }
 
-  // Retina backgrounds
+  /* Retina backgrounds */
   @media (-webkit-min-device-pixel-ratio: 2) and (min-width: 200px),
     (min-resolution: 192dpi) and (min-width: 200px) {
     background-image: url("https://cdn.crimethinc.com/assets/tce/images/cover-phonesmall@2x.jpg");
@@ -162,7 +162,7 @@
   }
 }
 
-// ie11 needs a height with flexbox (rather than a min-height)
+/* ie11 needs a height with flexbox (rather than a min-height) */
 @media all and (-ms-high-contrast: none) {
   .title-container {
     display: -ms-flexbox;

--- a/app/assets/stylesheets/to_change_everything/korean/_font_overrides.scss
+++ b/app/assets/stylesheets/to_change_everything/korean/_font_overrides.scss
@@ -12,7 +12,7 @@
   text-indent: 0 !important;
 }
 
-// flip a character for a visual wordplay
+/* flip a character for a visual wordplay */
 .title-container {
   h1 {
     span.drop-word-1 {


### PR DESCRIPTION
# What are the relevant GitHub issues?

related to this PR: https://github.com/crimethinc/website/pull/5212

# What does this pull request do?

All of this is find/replace of SCSS comment syntax (`// comment`) with CSS comment syntax (`/* comment */`)

# How should this be manually tested?

- Just being able to load the site without a sass error is a good sign

# Is there any background context you want to provide for reviewers?

This is one PR in what will be an extended series of commits to eventually drop the css and js pre-processor gem dependencies as discussed in https://github.com/crimethinc/website/pull/5212

As referenced in the color variable PR ([#5223](https://github.com/crimethinc/website/pull/5223#issuecomment-4134312948)), this should be the last PR in this series that touches many files at once. The next step is to convert each SCSS file to CSS files either file by file or in small groups where it make sense.

# Questions for the pull request author (delete any that don't apply):
- [ ] Are any needed README/wiki/documentation updates needed for this pull request?
- [ ] Does the code you updated have tests? If not, could you add some please?
- [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.

# Acceptance Criteria
## These should be checked by the reviewers

- [x] This pull request does not cause the database export script to become out of sync with the db schema
