### PR TITLE
Remove unused heroku-api-postgres and platform-api gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,10 +137,6 @@ gem 'tzinfo-data', platforms: %i[windows jruby]
 # i18n
 gem 'rack-contrib'
 
-# Heroku API SDKs
-gem 'heroku-api-postgres' # Extension for Platform API for Heroku Postgres
-gem 'platform-api'        # Heroku API SDK, rake task: data:copy_production_to_staging
-
 group :production do
   # webserver
   gem 'rack-timeout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,9 +163,6 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
-    erubis (2.7.0)
-    excon (1.4.2)
-      logger
     execjs (2.10.1)
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
@@ -204,15 +201,6 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.2.1)
-    heroics (0.1.3)
-      base64
-      erubis (~> 2.0)
-      excon
-      moneta
-      multi_json (>= 1.9.2)
-      webrick
-    heroku-api-postgres (0.14.0)
-      platform-api
     http (6.0.2)
       http-cookie (~> 1.0)
       llhttp (~> 0.6.1)
@@ -295,8 +283,6 @@ GEM
     minitest (6.0.4)
       drb (~> 2.0)
       prism (~> 1.5)
-    moneta (1.0.0)
-    multi_json (1.20.1)
     nenv (0.3.0)
     net-imap (0.6.3)
       date
@@ -327,10 +313,6 @@ GEM
       racc
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-linux)
-    platform-api (3.9.0)
-      heroics (~> 0.1.1)
-      moneta (~> 1.0.0)
-      rate_throttle_client (~> 0.1.0)
     popper_js (2.11.8)
     pp (0.6.3)
       prettyprint
@@ -404,7 +386,6 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rate_throttle_client (0.1.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
@@ -601,7 +582,6 @@ DEPENDENCIES
   fasterer
   flamegraph
   guard-rspec
-  heroku-api-postgres
   http
   i18n-debug
   image_processing
@@ -620,7 +600,6 @@ DEPENDENCIES
   overcommit
   pandoc-ruby
   pg
-  platform-api
   pry-byebug
   puma
   rack-attack
@@ -710,8 +689,6 @@ CHECKSUMS
   erb (6.0.3) sha256=e43685a8a0a0ea6a924871b2162e8953ef73147ce46b75b36d1f6774fd286e91
   erb_lint (0.9.0) sha256=dfb5e40ad839e8d1f0d56ca85ec9a7ac4c9cd966ec281138282f35b323ca7c31
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
-  erubis (2.7.0) sha256=63653f5174a7997f6f1d6f465fbe1494dcc4bdab1fb8e635f6216989fb1148ba
-  excon (1.4.2) sha256=32d8d8eda619717d9b8043b4675e096fb5c2139b080e2ad3b267f88c545aaa35
   execjs (2.10.1) sha256=abe0ae028467eb8e30c10814eb934d07876a691aae7e803d813b7ce5a75e73f1
   factory_bot (6.5.6) sha256=12beb373214dccc086a7a63763d6718c49769d5606f0501e0a4442676917e077
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
@@ -727,8 +704,6 @@ CHECKSUMS
   guard-compat (1.2.1) sha256=3ad21ab0070107f92edfd82610b5cdc2fb8e368851e72362ada9703443d646fe
   guard-rspec (4.7.3) sha256=a47ba03cbd1e3c71e6ae8645cea97e203098a248aede507461a43e906e2f75ca
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  heroics (0.1.3) sha256=31d792e8706ecc6f78299f52d0b0f8ab55489a13b5f4f76c3050b07912563562
-  heroku-api-postgres (0.14.0) sha256=e86cc16666051745f0db92216e05be6ceab09f38b96c92569dbb1581d824ebd2
   http (6.0.2) sha256=be337816fb45cee712eeb0829a16d9300c9d2b87b38b771d177d7a59f77e8b83
   http-cookie (1.1.4) sha256=8dd8011dedcae5f91af2671b7ba878c4a9e89f0f6384790c1f4cdd176f5e3ada
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
@@ -765,8 +740,6 @@ CHECKSUMS
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.4) sha256=df1304664589d40f46089247fdc451f866b0ce0d7cae1457a15fc1eb7d48dca1
-  moneta (1.0.0) sha256=2224e5a68156e8eceb525fb0582c8c4e0f29f67cae86507cdcfb406abbb1fc5d
-  multi_json (1.20.1) sha256=2f3934e805cc45ef91b551a1f89d0e9191abd06a5e04a2ef09a6a036c452ca6d
   nenv (0.3.0) sha256=d9de6d8fb7072228463bf61843159419c969edb34b3cef51832b516ae7972765
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
@@ -783,7 +756,6 @@ CHECKSUMS
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
   pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
-  platform-api (3.9.0) sha256=be3b919955c52649fd931a9f62d571bd6f06613de630970dc7255fc95eb7d962
   popper_js (2.11.8) sha256=f4b0be717fc0d50bdb3dbbc55788525a9e0e8f640b76c9971fc34ee609eadbd2
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
@@ -809,7 +781,6 @@ CHECKSUMS
   railties (8.1.3) sha256=913eb0e0cb520aac687ffd74916bd726d48fa21f47833c6292576ef6a286de22
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rate_throttle_client (0.1.2) sha256=f9de968b892fea9272154f6182b4f5cfb74292585e66763fb8a8510181ec83ee
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rbs (4.0.2) sha256=af75671e66cd03434cc546622741ebf83f6197ec4328375805306330bf78ef25


### PR DESCRIPTION
## Summary

Removes two unused Heroku API SDK gems:

- `heroku-api-postgres` — extension for the Platform API for Heroku Postgres
- `platform-api` — Heroku Platform API SDK (was slated for a `rake data:copy_production_to_staging` task that never got finished)

Neither is referenced anywhere in the app beyond the `Gemfile`.

## Why

Dropping them kills the `MultiJson.decode is deprecated` warning that prints on every `rails db:migrate` (and every `rspec` run). That warning was coming from `heroics (0.1.3)`, a transitive dep of `platform-api`, which still calls the deprecated `MultiJson.decode` at `heroics/configuration.rb:43`. Both `platform-api` and `heroics` are at their latest published versions, so there's no gem-update path — the cleanest fix is to drop the unused gem.

## Test plan

- [ ] `bundle install` succeeds cleanly
- [ ] `bundle exec rspec` passes without the `MultiJson.decode` warning
- [ ] `bundle exec rails db:migrate` runs without the deprecation warning
