### PR TITLE
2025 layout: handle admin header for non-localizable models

### DIFF
--- a/app/views/layouts/2025/_admin_header.html.erb
+++ b/app/views/layouts/2025/_admin_header.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <div>
-      <% if @editable.present? %>
+      <% if @editable.present? && @editable.respond_to?(:localizations) %>
         <p class="mb-0 d-lg-inline font-weight-bold mr-1">Translate <%= @editable.class %> to</p>
 
         <% Locale.all.each do |locale| %>


### PR DESCRIPTION
What are the relevant GitHub issues?
=======================

n/a

What does this pull request do?
====================

* `app/views/layouts/2025/_admin_header.html.erb`: skip rendering the localization links in the admin header if the active record model doesn't define `.localizations`

# How should this be manually tested?

1. **without patch**
  - be logged in as a publisher
  - set theme to 2025
  - go to http://localhost:3000/categories
  - see error
2. **with patch applied**
  - be logged in as a publisher
  - set theme to 2025
  - go to http://localhost:3000/categories
  - see page render, admin banner should have no localization options

# Is there any background context you want to provide for reviewers?

While working on pagination CSS changes related to the work to drop the sass preprocessor dependency[^1], I ran into a `500` when trying to view the categories index.

In this scenario, the `@editable` is set to a `Category` model, which does not (currently) `include Translatable`.

Acceptance Criteria
=======================

### These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

[^1]:https://github.com/crimethinc/website/pull/5212
