### PR TITLE
css refactor: decouple _pagination.scss from other css

### DIFF
--- a/app/assets/stylesheets/2017/views/_home.scss
+++ b/app/assets/stylesheets/2017/views/_home.scss
@@ -35,7 +35,7 @@
     }
   }
 
-  .pagination {
+  .pagination-container {
     margin: 0 0 var(--border-size-xlarge) 0;
   }
 

--- a/app/assets/stylesheets/2017/views/_page.scss
+++ b/app/assets/stylesheets/2017/views/_page.scss
@@ -116,8 +116,8 @@
       margin-bottom: var(--border-size-large);
     }
 
-    ul,
-    ol {
+    ul:not(.pagination),
+    ol:not(.pagination) {
       margin-bottom: 1em;
     }
 

--- a/app/views/2017/articles/show.html.erb
+++ b/app/views/2017/articles/show.html.erb
@@ -40,7 +40,7 @@
       <%= render_themed "articles/categories",               article: @article %>
       <%= render_themed "articles/tags",                     article: @article %>
 
-      <div>
+      <div class="pagination-container">
         <ul class="pagination">
           <% if @previous_article.present? %>
             <li class="page">

--- a/app/views/2025/articles/show.html.erb
+++ b/app/views/2025/articles/show.html.erb
@@ -34,7 +34,7 @@
       <%= render_themed "articles/categories",               article: @article %>
       <%= render_themed "articles/tags",                     article: @article %>
 
-      <div>
+      <div class="pagination-container">
         <ul class="pagination">
           <% if @previous_article.present? %>
             <li class="page">


### PR DESCRIPTION
What are the relevant GitHub issues?
=============================================

- related to https://github.com/crimethinc/website/pull/5212

What does this pull request do?
================================

* `app/assets/stylesheets/2017/views/_home.scss`: the home page was reaching into the pagination component to set a margin that could instead be set on the container div.
* `app/assets/stylesheets/2017/views/_page.scss`: the _page css style's stuff like the categories index, but its css had a specificity that was reaching into pagination.
* `app/views/2017/articles/show.html.erb`: give the surrounding div the pagination-container class to make it consistent with the rest of the site's pagination
* `app/views/2025/articles/show.html.erb`: give the surrounding div the pagination-container class to make it consistent with the rest of the site's pagination


Is there any background context you want to provide for reviewers?
========================================================================

While working on pagination CSS changes related to the work to drop the sass preprocessor dependency[^1], I ran into issue's where certain unrelated css was getting applied to the pagination component with an overriding specificity, making `.../components/_pagination.scss` no longer able to fully style the pagination component itself.

I have included [screenshots](https://github.com/crimethinc/website/pull/5296#user-content-pr-screenshots) on the PR to try to better explain.

* the 2017/2025 view changes
  - only the 2017 change has any real effect as the article show endpoint doesn't yet use 2025 ([`src`][0]).
* the `_page.scss` change
  - ideally the `page` css should not even need to know there is a `.pagination` class to avoid, however until `sass` is completely dropped this would be more of a headache than it is worth[^2]

<span id="pr-screenshots">Screenshots</span>
=====================================

### `_pages.scss`

If you add the following css to `_pages.scss`

```diff
diff --git a/app/assets/stylesheets/2017/views/_page.scss b/app/assets/stylesheets/2017/views/_page.scss
index 7926346f..c395e406 100644
--- a/app/assets/stylesheets/2017/views/_page.scss
+++ b/app/assets/stylesheets/2017/views/_page.scss
@@ -116,8 +116,10 @@
       margin-bottom: var(--border-size-large);
     }
 
     ul,
     ol {
+      background-color: red;
+      font-size: 55px;
       margin-bottom: 1em;
     }
 
```

you will see the following on a page such as http://localhost:3000/categories/analysis

<img width="400" height="auto" alt="pages-before-2017" style="max-width: 70ch; height: auto; aspect-ratio: 16 / 9;" src="https://github.com/user-attachments/assets/8e555fc8-240a-47bb-8a0f-22f0fe0fc3dd" />

The pagination component is picking up the list styling from `_page.scss`, which we do not want. With the patched code we do not pick up the styling in the pagination component:

```diff
diff --git a/app/assets/stylesheets/2017/views/_page.scss b/app/assets/stylesheets/2017/views/_page.scss
index 7926346f..c395e406 100644
--- a/app/assets/stylesheets/2017/views/_page.scss
+++ b/app/assets/stylesheets/2017/views/_page.scss
@@ -116,8 +116,10 @@
       margin-bottom: var(--border-size-large);
     }
 
+    ul:not(.pagination),
+    ol:not(.pagination) {
-    ul,
-    ol {
       background-color: red;
       font-size: 55px;
       margin-bottom: 1em;
     }
 
```

<img width="400" height="auto" alt="pages-after-2017" src="https://github.com/user-attachments/assets/a32c7d60-baed-4ee1-a429-9888de4182e7" />

### `_home.scss`

if you make the following changes to the `_pagination` component, the effect of the `_home.scss` change is easier to see:

```diff
diff --git a/app/assets/stylesheets/2017/components/_pagination.scss b/app/assets/stylesheets/2017/components/_pagination.scss
index fb8cc8df..d7e99aea 100644
--- a/app/assets/stylesheets/2017/components/_pagination.scss
+++ b/app/assets/stylesheets/2017/components/_pagination.scss
@@ -1,4 +1,6 @@
 ul.pagination {
+  background-color: red;
+  border: 2px solid black;
   display: inline-block;
   padding: 0;
   margin: 0;
@@ -27,4 +29,6 @@ ul.pagination {
 
 .pagination-container {
   text-align: center;
+  background-color: pink;
+  border: 2px dashed black;
 }
```

with those changes, you can see the home page css is reaching into the `.pagination` class to add an internal margin:

<img width="400" height="auto" alt="home-before-2017" src="https://github.com/user-attachments/assets/2642ccdb-42b3-4e92-b811-a2dfaf324c6e" />

with the patch:

```diff
diff --git a/app/assets/stylesheets/2017/views/_home.scss b/app/assets/stylesheets/2017/views/_home.scss
index 7be2f1e5..9c72b4cc 100644
--- a/app/assets/stylesheets/2017/views/_home.scss
+++ b/app/assets/stylesheets/2017/views/_home.scss
@@ -35,7 +35,7 @@
     }
   }
 
-  .pagination {
+  .pagination-container{
     margin: 0 0 var(--border-size-xlarge) 0;
   }
```

the home page no longer needs to reach into `_pagination.scss`, and the resulting layout is the same:

<img width="400" height="auto" alt="home-after-2017" src="https://github.com/user-attachments/assets/a11c3ee2-8381-4333-9305-54523c0ede57" />


### `articles/show.html.erb`

there are no visual changes with adding the container class to articles pagination, but I will be making use of it in a subsequent PR

 | theme | before | after |
|------|---------|-----------|
| **2017** | <img width="2880" height="1920" alt="article-before-2017" src="https://github.com/user-attachments/assets/d10da10f-c488-4eb0-92e5-5726a1c478eb" />  |  <img width="2880" height="1920" alt="article-after-2017" src="https://github.com/user-attachments/assets/b2791314-42a5-4a0a-b86d-fa9623a9d175" /> |
| **2025** | <img width="2880" height="1920" alt="article-before-2025" src="https://github.com/user-attachments/assets/30cbe1f9-c624-4952-b94d-82ddd2ef8683" />  | <img width="2880" height="1920" alt="article-after-2025" src="https://github.com/user-attachments/assets/117c9fcc-16f6-498e-b414-c701a1827322" />  |


## Acceptance Criteria
### These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

--------

[^1]:https://github.com/crimethinc/website/pull/5212 
[^2]: SASS and CSS handle nesting differently, even though the syntax overlaps enough for them to be somewhat compatible. The biggest difference is with what the `&` means and how it affects specificity

[0]:https://github.com/crimethinc/website/blob/215414e718e57f15371afeb5b6c33423ff839281/app/controllers/articles_controller.rb#L60-L77