### PR TITLE
pagination: improve pagination semantics for screen readers

### DIFF
--- a/app/views/2017/articles/show.html.erb
+++ b/app/views/2017/articles/show.html.erb
@@ -40,7 +40,7 @@
       <%= render_themed "articles/categories",               article: @article %>
       <%= render_themed "articles/tags",                     article: @article %>
 
-      <div class="pagination-container">
+      <nav class="pagination-container" aria-label="<%= t('views.pagination.label', default: '') %>">
         <ul class="pagination">
           <% if @previous_article.present? %>
             <li class="page">
@@ -54,7 +54,7 @@
             </li>
           <% end %>
         </ul>
-      </div>
+      </nav>
     </footer>
 
     <%= render_themed "articles/related", article: @article %>

--- a/app/views/2017/home/index.html.erb
+++ b/app/views/2017/home/index.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 </div>
 
-<div class="pagination-container">
+<nav class="pagination-container" aria-label="<%=t('views.pagination.label', default: '')%>">
   <ul class="pagination">
     <li class="page">
       <%= link_to_previous_page @articles, t("views.pagination.previous_page").html_safe %>
@@ -34,4 +34,4 @@
       <%= link_to_next_page @articles, t("views.pagination.next_page").html_safe %>
     </li>
   </ul>
-</div>
+</nav>

--- a/app/views/2025/articles/show.html.erb
+++ b/app/views/2025/articles/show.html.erb
@@ -34,7 +34,7 @@
       <%= render_themed "articles/categories",               article: @article %>
       <%= render_themed "articles/tags",                     article: @article %>
 
-      <div class="pagination-container">
+      <nav class="pagination-container" aria-label="<%= t('views.pagination.label', default: '') %>">
         <ul class="pagination">
           <% if @previous_article.present? %>
             <li class="page">
@@ -48,7 +48,7 @@
             </li>
           <% end %>
         </ul>
-      </div>
+      </nav>
     </footer>
 
     <%= render_themed "articles/related", article: @article %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,5 +6,10 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="next">
-  <%= link_to_unless current_page.last?, t("views.pagination.next").html_safe, url, rel: "next" %>
+    <% unless current_page.last? %>
+      <%= link_to url, rel: "next", class: "page-link" do %>
+        <span aria-hidden="true"><%= t("views.pagination.next").html_safe %></span>
+        <span class="visually-hidden"><%= t("views.pagination.next_screen_reader").html_safe %></span>
+      <% end %>
+  <% end %>
 </li>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -5,8 +5,11 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
     paginator:     the paginator that renders the pagination tags inside -%>
+
+<% container_label = t('views.pagination.label', default: '') %>
+
 <%= paginator.render do -%>
-  <div class="pagination-container">
+  <nav class="pagination-container" aria-label="<%= container_label %>">
     <ul class="pagination">
       <%= prev_page_tag unless current_page.first? %>
       <% each_page do |page| -%>
@@ -20,5 +23,5 @@
         <%= next_page_tag unless current_page.last? %>
       <% end %>
     </ul>
-  </div>
+  </nav>
 <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,5 +6,10 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="prev">
-  <%= link_to_unless current_page.first?, t("views.pagination.previous").html_safe, url, rel: "prev" %>
+  <% unless current_page.first? %>
+    <%= link_to url, rel: "prev", class: "page-link" do %>
+      <span aria-hidden="true"><%= t("views.pagination.previous").html_safe %></span>
+      <span class="visually-hidden"><%= t("views.pagination.previous_screen_reader").html_safe %></span>
+    <% end %>
+  <% end %>
 </li>

--- a/config/locales/en/en.yml
+++ b/config/locales/en/en.yml
@@ -542,6 +542,7 @@ en:
       mobi: Mobi
   views:
     pagination:
+      label: "pagination"
       first: "&laquo;"
       last: "&raquo;"
       previous: "&lsaquo;"


### PR DESCRIPTION
What are the relevant GitHub issues?
=============================================

- related to #5212 

What does this pull request do?
==================================

### first commit | pagination: give pagination semantics for screen readers

* `app/views/2017/articles/show.html.erb`: change pagination container
from a div to nav element. Also add an aria-label.
* `app/views/2017/home/index.html.erb`: change pagination container
from a div to nav element. Also add an aria-label.
* `app/views/2025/articles/show.html.erb`: change pagination container
from a div to nav element. Also add an aria-label.
* `app/views/kaminari/_paginator.html.erb`: change pagination container
from a div to nav element. Also add an aria-label
* `config/locales/en/en.yml`: add english translation of new
aria-label

By changing the `<div>` to a `<nav>` for the pagination container, screen
readers have more of what this is. I also added an optional label.

Rather than let the label fall back to english, I provided a blank
string as the default. This makes the aria-label behave like the
browser default (i.e. it is just skipped), rather than having english
read out when the language is something else.

With a screen reader the change will be read something like:

- "end navigation" when there is no translation for the aria-label
- "end navigation pagination" when there is a translation

### second commit:

pagination: copy aria enhancements from twitter-bootstrap-4 to 2017

* `app/views/kaminari/_next_page.html.erb`: for screen readers, don't
read out the literal icon, rather read out "previous page"
* `app/views/kaminari/_prev_page.html.erb`: for screen readers, don't
read out the literal icon, rather read out "next page"

Prior to this change, screen readers would read out something like
"right facing caret ...". With the change it now reads out something
like "Next ...".

These changes already exist in
`app/views/kaminari/twitter-bootstrap-4/_next_page.html.erb` and
`app/views/kaminari/twitter-bootstrap-4/_prev_page.html.erb`, so I
just copied them up to the view partial being used on the 2017 theme.

How should this be manually tested?
=============================================

- If you don't already have a screenreader set up, you can turn on the screen reader built into most smartphone operating systems
- you can inspect the accessibility tree in the browser dev tools

# Is there any background context you want to provide for reviewers?

### screen recording (includes sound)

| before | after |
|-------------|---------|
| https://github.com/user-attachments/assets/a32046ae-483a-4883-9008-4fc0757edf34 | https://github.com/user-attachments/assets/0e16dc7c-3687-4c68-883f-bca28d701b52 | 

## Acceptance Criteria
### These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema
