### PR TITLE
fix: Publishable#previous not returning previous articles

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -93,7 +93,7 @@ class ArticlesController < ApplicationController
 
     @live_blog = @article.collection_root?
 
-    @previous_article = Article.previous(@article).first
+    @previous_article = @article.previous
     @next_article     = Article.next(@article).first
     @editable         = @article
 

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -37,6 +37,15 @@ class Article < ApplicationRecord
 
   scope :last_2_weeks, -> { where('published_at BETWEEN ? AND ?', Time.now.utc - 2.weeks, Time.now.utc) }
 
+  def previous
+    canonical_previous
+  end
+
+  def next
+    # TODO: mirror the canonical_previous logic
+    Article.next(self).where(locale: I18n.locale).first
+  end
+
   def path
     if published?
       published_at.strftime("/%Y/%m/%d/#{slug}")
@@ -90,6 +99,39 @@ class Article < ApplicationRecord
   end
 
   private
+
+  def canonical_previous
+    article_select = <<-SQL
+            a1.id,
+            a1.canonical_id,
+            a1.locale,
+            a1.published_at as ts1 ,
+            a2.id,
+            CASE
+              WHEN a1.canonical_id IS NULL THEN a1.published_at
+              ELSE a2.published_at
+            END as canonical_published_at
+    SQL
+    article_self_join = <<-SQL
+   JOIN articles a2 ON COALESCE(a1.canonical_id, a1.id) = a2.id
+    SQL
+
+    query = Article
+              .select(article_select)
+              .from("articles a1")
+              .joins(article_self_join)
+              .where('a1.id < COALESCE(?,?)', self.canonical_id, self.id)
+              .where('a1.published_at <= ?', self.published_at)
+              .where('a1.locale': [I18n.default_locale, I18n.locale].uniq)
+              .where('a1.publication_status = ?', 'published')
+              .reorder('canonical_published_at' => :desc)
+              .limit(1)
+
+    Article.find(query.first&.id)&.preferred_localization
+
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
 
   def find_related_articles
     return {} if categories.blank?

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -34,7 +34,8 @@ module Publishable
 
     scope :previous,
           lambda { |article|
-            root.where(published_at: article.published_at)
+            root.where(published_at: ..article.published_at)
+                .where.not(id: article.id)
                 .live
                 .published
                 .chronological

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -16,6 +16,8 @@ FactoryBot.define do
     end
   end
 
+  trait(:published)      {  publication_status { 'published' } }
+
   trait(:arabic)         { locale { 'ar' } }
   trait(:bengali)        { locale { 'bn' } }
   trait(:czech)          { locale { 'cs' } }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -163,10 +163,25 @@ describe Article do
   end
 
   describe '.previous' do
-    it 'returns the article published on the same date before the given one' do
-      article = create(:article, published_at: 1.day.ago, publication_status: 'published')
+    subject { described_class.previous(current).first&.id }
 
-      expect(described_class.previous(article)).to exist
+    let!(:current)  { create(:article, :published, published_at: current_timestamp) }
+    let!(:previous) { create(:article, :published, published_at: previous_timestamp) }
+    let(:current_timestamp) { Time.current }
+    let(:previous_timestamp) { current_timestamp - 1.day  }
+
+    it { is_expected.to eq previous.id }
+
+    context 'when the previous article has the exact same published_at' do
+      let(:previous_timestamp) { current_timestamp }
+
+      it { is_expected.to eq previous.id }
+    end
+
+    context 'when there is no previous article' do
+      let(:previous_timestamp) { current_timestamp + 1.day }
+
+      it { is_expected.to be nil }
     end
   end
 


### PR DESCRIPTION
What does this pull request do?
===============================

* `app/models/concerns/publishable.rb`: fix a bug where the previous scope was only returning the same article as passed in as an argument.
* `spec/factories/articles.rb`: add a :published trait on the article factory.
* `spec/models/article_spec.rb`: expand test coverage to include regression tests for the fixed bug.

### Further Suggestions

1. turn this scope into a method so it can instead return the `article` or `nil`

There is already a `limit(1)` on the database call. It seems weird to make the caller call `.first` every time the scope is used.

maybe if the scope is still desired, there can also be a method on the model that just calls the scope on itself and unwraps the result :thinking: 

2. ~exclude translations~ handled in latest version of this P

~When an article has many translations, the "previous" article will be those translations. It might make sense to do the same locale-aware filtering that is done on the home page~

## How should this be manually tested?

### base case

- go to any article on .com
- see the previous pagination link doesn't work
- apply patch
- see the previous pagination link works

### old article

- go to https://crimethinc.com/1996/01/01/selling-ourselves-out
- see if you can get to the end of "previous" pagination (without patch you will loop, with patch you will reach the beginning)

### different locale

- set locale to `es`
- try using previous to go through articlea
  - without patch you will get into a loop
  - with patch you will go back in time, loading `es` articles if available, otherwise loading `en`

Is there any background context you want to provide for reviewers?
=============================================================

While working on some pagination changes, I noticed the pagination on an article didn't seem to be working. When you click "previous", you would often end up on the same article you started from.

It looks like in [this MR][0], there was a typo which introduced a bug. In that MR, several instances of

    where('published_at < ?', foo)

were replaced with the alternate syntax of:

    where(published_at: ...foo)

On the `Publishable#previous` the `...` was missed, meaning that the scope would only return articles with the exact same `published_at`. This is why often the only article returned was the article you passed in as an argument.

At a later date, some [specs were added][1] that codefied this bug's behavior as expected.

I also added a `where.not(id:)` call to prevent the same article passed as an argument from also being the "previous" argument.
 
## Acceptance Criteria
### These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

[0]:https://github.com/crimethinc/website/pull/3845 
[1]:https://github.com/crimethinc/website/pull/5196

[^1]: the translations will still cause a loop, as mentioned in the "further suggestions" section of this MR's description
