### PR TITLE
[#5304] Fall back to default locale when localized markdown is missing

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,8 +1,9 @@
 module MarkdownHelper
   def render_markdown_for page:
-    content = File.read [Rails.root, "config/locales/pages/#{I18n.locale}", "#{page}.markdown"].join('/')
+    path = Rails.root.join "config/locales/pages/#{I18n.locale}/#{page}.markdown"
+    path = Rails.root.join "config/locales/pages/#{I18n.default_locale}/#{page}.markdown" unless path.exist?
 
-    render_markdown content
+    render_markdown File.read(path)
   end
 
   def render_markdown text, remove_wrapper_p_tag: false

--- a/app/views/2017/home/index.html.erb
+++ b/app/views/2017/home/index.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 </div>
 
-<nav class="pagination-container" aria-label="<%=t('views.pagination.label', default: '')%>">
+<nav class="pagination-container" aria-label="<%= t('views.pagination.label', default: '') %>">
   <ul class="pagination">
     <li class="page">
       <%= link_to_previous_page @articles, t("views.pagination.previous_page").html_safe %>

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -16,4 +16,33 @@ RSpec.describe MarkdownHelper do
 
     it { is_expected.to eq('<p>text</p>') }
   end
+
+  describe '#render_markdown_for' do
+    around do |example|
+      I18n.with_locale(locale) { example.run }
+    end
+
+    before do
+      without_partial_double_verification do
+        allow(helper).to receive(:media_mode?).and_return(false)
+      end
+    end
+
+    context 'when the current locale has the markdown file' do
+      let(:locale) { :en }
+
+      it 'renders the markdown from that locale' do
+        expect(helper.render_markdown_for(page: :litkit_main)).to include('<p>')
+      end
+    end
+
+    context 'when the current locale lacks the markdown file' do
+      let(:locale) { :ca }
+
+      it 'falls back to the default locale instead of raising' do
+        expect { helper.render_markdown_for(page: :litkit_main) }.not_to raise_error
+        expect(helper.render_markdown_for(page: :litkit_main)).to include('<p>')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `MarkdownHelper#render_markdown_for` was reading `config/locales/pages/{I18n.locale}/{page}.markdown` directly with `File.read`, no fallback. Locales without a localized markdown file (e.g. `:ca`, `:el`, `:hy`, `:mt`) 500'd on `books#lit_kit` and any other page using this helper.
- Rails `config.i18n.fallbacks` only applies to `I18n.t` lookups, not raw filesystem reads.
- Fix: check for the localized file's existence; fall back to `I18n.default_locale` if missing.

Refs #5304 (Bugsnag bs#681063 — 5992× occurrences).

## Test plan

- [ ] `bundle exec rspec spec/helpers/markdown_helper_spec.rb`
- [ ] Visit `/ca/books/lit-kit` in staging — should render English content instead of 500
- [ ] Visit `/en/books/lit-kit` — unchanged