### PR TITLE
css-refactor: replace SCSS font syntax with CSS in _form.scss

### DIFF
--- a/app/assets/stylesheets/2017/components/_forms.scss
+++ b/app/assets/stylesheets/2017/components/_forms.scss
@@ -1,11 +1,8 @@
 .simple-field {
   border-radius: 0;
-  font: {
-    weight: normal;
-    weight: 100;
-    size: 1.5rem;
-  }
-
+  font-weight: normal;
+  font-weight: 100;
+  font-size: 1.5rem;
   padding: var(--border-size-medium);
   width: 66%;
   text-transform: uppercase;


### PR DESCRIPTION
## What are the relevant GitHub issues?

resolves #5212 

## What does this pull request do?

* `app/assets/stylesheets/2017/components/_forms.scss`: renamed `_form.scss` to `_form.css`. Also replace the SCSS font syntax with CSS syntax.


## Acceptance Criteria
### These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema
