### PR TITLE
[#5318] Lock /manifest.json and /opensearch.xml to their response formats

### DIFF
--- a/app/controllers/misc_controller.rb
+++ b/app/controllers/misc_controller.rb
@@ -1,2 +1,9 @@
 class MiscController < ApplicationController
+  def manifest_json
+    render formats: :json
+  end
+
+  def opensearch_xml
+    render formats: :xml
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -211,8 +211,8 @@ Rails.application.routes.draw do
   get 'signout',  to: 'sessions#destroy', as: :signout
 
   # Misc plumbing infrastructure
-  get 'manifest.json',  to: 'misc#manifest_json'
-  get 'opensearch.xml', to: 'misc#opensearch_xml'
+  get 'manifest.json',  to: 'misc#manifest_json',  defaults: { format: :json }
+  get 'opensearch.xml', to: 'misc#opensearch_xml', defaults: { format: :xml }
 
   # Pages
   get 'about',                 to: 'pages#about',   as: :about,   via: :all

--- a/spec/controllers/misc_controller_spec.rb
+++ b/spec/controllers/misc_controller_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe MiscController do
 
       expect(response).to be_successful
     end
+
+    it 'responds successfully when the client only accepts text/html' do
+      request.headers['Accept'] = 'text/html, text/plain'
+      get :manifest_json
+
+      expect(response).to be_successful
+      expect(response.content_type).to start_with 'application/json'
+    end
   end
 
   describe 'GET #opensearch_xml' do
@@ -16,6 +24,14 @@ RSpec.describe MiscController do
       get :opensearch_xml
 
       expect(response).to be_successful
+    end
+
+    it 'responds successfully when the client only accepts text/html' do
+      request.headers['Accept'] = 'text/html, text/plain'
+      get :opensearch_xml
+
+      expect(response).to be_successful
+      expect(response.content_type).to start_with 'application/xml'
     end
   end
 end


### PR DESCRIPTION
# #5318

https://app.bugsnag.com/crimethinc/rails/errors/69f00ddf7aaa488f2cc144d3

## Summary

- `MiscController#manifest_json` and `#opensearch_xml` were 500'ing in production when clients sent `Accept: text/html, text/plain` (no `*/*` fallback). Rails picked the first acceptable format from the header, found no matching template (only `.json.jbuilder` / `.xml.builder` exist), and raised `ActionController::UnknownFormat`.
- Fix: explicit `render formats: :json` / `render formats: :xml` in the controller forces the correct template regardless of the client's Accept header. Belt-and-suspenders, also added `defaults: { format: :json }` / `{ format: :xml }` on the routes so `request.format` is consistent for any inspecting code.

## Note about /opensearch.xml

`Rack::CleanPath` middleware (`app/middlewares/rack/clean_path.rb`) currently strips `.xml` from any URL path via the `'.xml' => ''` substitution. So in production, `/opensearch.xml` 301s to `/opensearch`, which has no route → 404. That's a separate, deeper issue from #5318 (which was about the format error). The controller-level fix in this PR is correct independently; the routing problem deserves its own ticket.

## Test plan

- [ ] In staging, `curl -H 'Accept: text/html, text/plain' https://staging…/manifest.json` should return JSON, not 500