### PR TITLE
[#5308] Redirect to podcasts index when slug not found

### DIFF
--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -10,9 +10,11 @@ class PodcastsController < ApplicationController
   end
 
   def show
+    @podcast = Podcast.find_by slug: params[:slug]
+    return redirect_to(podcasts_path) if @podcast.blank?
+
     @html_id  = 'page'
     @body_id  = 'podcast'
-    @podcast  = Podcast.find_by! slug: params[:slug]
     @episodes = @podcast.episodes.live.published
     @title    = PageTitle.new [title_for(:podcasts), @podcast.name]
 

--- a/spec/controllers/podcasts_controller_spec.rb
+++ b/spec/controllers/podcasts_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe PodcastsController do
+  describe 'GET #show' do
+    context 'when the podcast exists' do
+      let(:podcast) { create(:podcast) }
+
+      it 'renders successfully' do
+        get :show, params: { slug: podcast.slug }
+
+        expect(response).to be_successful
+      end
+    end
+
+    context 'when the slug does not match any podcast' do
+      it 'redirects to the podcasts index instead of raising' do
+        get :show, params: { slug: 'no-such-podcast' }
+
+        expect(response).to redirect_to(podcasts_path)
+      end
+    end
+  end
+end

--- a/spec/factories/podcasts.rb
+++ b/spec/factories/podcasts.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :podcast do
     sequence(:title) { |n| "anarchy #{n}" }
+    sequence(:slug)  { |n| "anarchy-#{n}" }
   end
 end


### PR DESCRIPTION
# #5308

https://app.bugsnag.com/crimethinc/rails/errors/69c68e036bb8e831667ea24d

## Summary

- `PodcastsController#show` was using `Podcast.find_by!`, which raised `ActiveRecord::RecordNotFound` when a slug had no matching podcast. Bugsnag captured this as a recurring `info`-level error.
- Switched to `Podcast.find_by` + early redirect to the podcasts index when the slug is unknown. Mirrors the existing pattern in `BooksController#set_book`.
- Updated the podcast factory to set a `slug` (the model validates `presence: true`, so the factory was previously incapable of producing a valid record).
- Added `spec/controllers/podcasts_controller_spec.rb` covering both the happy path and the unknown-slug redirect.

## Test plan

- [ ] In staging, visit `/podcasts/no-such-podcast` — should redirect to `/podcasts` instead of returning 500