### PR TITLE
[#5307] Guard nil host in ApexRedirect

### DIFF
--- a/app/middlewares/rack/apex_redirect.rb
+++ b/app/middlewares/rack/apex_redirect.rb
@@ -7,7 +7,7 @@ module Rack
     def call env
       @request = Rack::Request.new env
 
-      return redirect location if @request.host.start_with? 'www.'
+      return redirect location if @request.host&.start_with? 'www.'
 
       @app.call env
     end

--- a/spec/middlewares/rack/apex_redirect_spec.rb
+++ b/spec/middlewares/rack/apex_redirect_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Rack::ApexRedirect do
+  let(:inner_app) { ->(_env) { [200, {}, ['ok']] } }
+  let(:middleware) { described_class.new(inner_app) }
+
+  context 'when the request host has a www. subdomain' do
+    let(:env) { Rack::MockRequest.env_for('http://www.crimethinc.com/about') }
+
+    it 'redirects to the apex domain' do
+      status, headers, _body = middleware.call(env)
+
+      expect(status).to eq 301
+      expect(headers['Location']).to eq 'http://crimethinc.com/about'
+    end
+  end
+
+  context 'when the request host is the apex domain' do
+    let(:env) { Rack::MockRequest.env_for('http://crimethinc.com/about') }
+
+    it 'passes through to the inner app' do
+      status, _headers, body = middleware.call(env)
+
+      expect(status).to eq 200
+      expect(body).to eq ['ok']
+    end
+  end
+
+  context 'when the request host is missing' do
+    let(:env) { Rack::MockRequest.env_for('http://example.com/').merge('HTTP_HOST' => nil, 'SERVER_NAME' => nil) }
+
+    it 'passes through without raising' do
+      expect { middleware.call(env) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
# #5307

https://app.bugsnag.com/crimethinc/rails/errors/69d635e91ff884595f13c378

## Summary

- `Rack::ApexRedirect#call` was calling `@request.host.start_with? 'www.'` directly. When a request arrives with no `Host` header (or a misconfigured proxy strips it), `@request.host` is `nil` and the line raises `NoMethodError: undefined method 'start_with?' for nil`.
- Fix: safe navigation — `@request.host&.start_with? 'www.'`. A request with no host can't be a `www.` subdomain, so the redirect simply doesn't fire and the request passes through.
- Added `spec/middlewares/rack/apex_redirect_spec.rb` with three cases (www. subdomain redirects, apex passes through, missing host passes through without raising). This is a new spec file under a new `spec/middlewares/rack/` directory.

## Test plan

- [ ] In staging, normal traffic continues to redirect www. → apex