### PR TITLE
[#5306] Clamp page param to avoid PG bigint overflow

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,6 +5,8 @@ class ArticlesController < ApplicationController
   before_action :redirect_malformed_pagination, only: :index
   before_action :force_2025_theme_for_feeds,    only: :index
 
+  PAGE_NUMBER_LIMIT = 1_000_000
+
   def index
     # TEMP: copied from home#index because the route /page/:page changed
     #       from home#index in 2017 theme
@@ -20,7 +22,7 @@ class ArticlesController < ApplicationController
       @latest_article = articles_for_current_page.first if params[:page].blank?
 
       # Feed artciles
-      @articles = articles_for_current_page.page(params[:page]).per(6)
+      @articles = articles_for_current_page.page(@page_number).per(6)
 
       render "#{Current.theme}/home/index"
     end
@@ -140,6 +142,7 @@ class ArticlesController < ApplicationController
     return if params[:page].blank?
 
     @page_number = params[:page].gsub(/\D/, '')
+    @page_number = PAGE_NUMBER_LIMIT.to_s if @page_number.to_i > PAGE_NUMBER_LIMIT
   end
 
   def redirect_malformed_pagination

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe ArticlesController do
+  describe 'GET #index' do
+    context 'when params[:page] is a number larger than Postgres can store as bigint' do
+      let(:huge_page) { '569480344293394003561863877600713420' }
+
+      it 'does not raise a database range error' do
+        expect { get :index, params: { page: huge_page } }.not_to raise_error
+      end
+
+      it 'redirects to a clamped, sane page number' do
+        get :index, params: { page: huge_page }
+
+        expect(response).to be_redirect
+        expect(response.location).not_to include huge_page
+      end
+    end
+  end
+end


### PR DESCRIPTION
# #5306

https://app.bugsnag.com/crimethinc/rails/errors/69e408067aaa488f2c64cd60

## Summary

- `ArticlesController#index` was passing `params[:page]` to Kaminari without bounds. The existing `set_page_number` filter strips non-digits via `gsub(/\D/, '')` but does not clamp the magnitude.
- A SQLi-probing bot was sending paths like `/page/-9491339 UNION ALL SELECT CONCAT(0x7155656a6d726a,0x31,…)`. After `gsub`, the digits embedded in the SQL keywords and hex literals concatenate into a number with 36 digits — far larger than Postgres bigint can hold, so `Kaminari`'s `OFFSET = (page - 1) * per_page` overflowed and raised `PG::NumericValueOutOfRange` mid-render.
- Fix: extend `set_page_number` to clamp the cleaned page number to `PAGE_NUMBER_LIMIT = 1_000_000` (well within int4 bounds even after multiplying by `per_page`). When a clamp happens, `redirect_malformed_pagination` already redirects users to the corrected URL.
- Also switched the 2017 theme branch to use `@page_number` instead of `params[:page]` so json/atom feed requests (which skip `redirect_malformed_pagination`) get the same protection.

## Note

This will eventually be moot once #5303's bot/scraper Rack middleware lands and drops these probes before they reach Rails. Until then, controller-level clamping is cheap defense in depth.

## Test plan

- [ ] In staging, normal pagination still works on `/`, `/page/2`, etc.
- [ ] Visit `/page/569480344293394003561863877600713420` — should redirect to `/page/1000000` (or a similarly clamped value), not 500