### PR TITLE
[#5305] Skip image link in tool partial when front_image is nil

### DIFF
--- a/app/views/2017/tools/_tool.html.erb
+++ b/app/views/2017/tools/_tool.html.erb
@@ -5,7 +5,9 @@
 
   <div class="e-content row">
     <div class="tool-front column column-one-quarter">
-      <%= link_to image_tag(tool.front_image, alt: tool.front_image_description, class: "u-image"), tool.path %>
+      <% if tool.front_image.present? %>
+        <%= link_to image_tag(tool.front_image, alt: tool.front_image_description, class: "u-image"), tool.path %>
+      <% end %>
 
       <% if tool.published_at.present? %>
         <time datetime="<%= tool.published_at.iso8601 %>"><%= tool.published_at.year %></time>

--- a/spec/controllers/posters_controller_spec.rb
+++ b/spec/controllers/posters_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe PostersController do
+  render_views
+
+  describe 'GET #index' do
+    context 'when a published poster has no images attached' do
+      it 'renders without raising "Nil location provided"' do
+        create(
+          :poster,
+          slug:               'no-image-poster',
+          publication_status: 'published',
+          published_at:       1.day.ago,
+          locale:             'en'
+        )
+
+        expect { get :index }.not_to raise_error
+        expect(response).to be_successful
+      end
+    end
+  end
+end


### PR DESCRIPTION
# #5305

https://app.bugsnag.com/crimethinc/rails/errors/69a42b73ac4797e40c624395

## Summary

- `Poster#front_image` returns `nil` when no images are attached to the record (existing, intentional behavior — see `spec/models/poster_spec.rb#front_image`).
- `app/views/2017/tools/_tool.html.erb` was unconditionally calling `image_tag(tool.front_image, ...)`. `image_tag(nil)` invokes `resolve_asset_source` → `polymorphic_url(nil)` → `ArgumentError: Nil location provided. Can't build URI.`
- This was being hit by Amazonbot (a legitimate well-behaved crawler) iterating posters that lack image attachments — 75 occurrences in production.
- Fix: guard the `link_to image_tag(...)` block on `tool.front_image.present?`. The titled link in the inner header (line 17 of the partial) keeps the listing entry navigable when the image is absent.
- Added `spec/controllers/posters_controller_spec.rb` with `render_views` exercising the regression.

## Test plan

- [ ] In staging, `/posters` renders normally with image-bearing posters
- [ ] In staging, posters with no attachments render in the listing without a broken `<a><img></a>` block (just the title link)