### PR TITLE
[#5309] MusicController: redirect to Bandcamp, stop inheriting Tool flow

### DIFF
--- a/app/controllers/music_controller.rb
+++ b/app/controllers/music_controller.rb
@@ -1,4 +1,5 @@
-class MusicController < ToolsController
-  # Redirects to Bandcamp
-  def index; end
+class MusicController < ApplicationController
+  def index
+    redirect_to 'https://crimethinc.bandcamp.com', allow_other_host: true
+  end
 end

--- a/spec/controllers/music_controller_spec.rb
+++ b/spec/controllers/music_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe MusicController do
+  describe 'GET #index' do
+    it 'redirects to the CrimethInc. Bandcamp page without raising' do
+      expect { get :index }.not_to raise_error
+
+      expect(response).to redirect_to('https://crimethinc.bandcamp.com')
+    end
+  end
+end


### PR DESCRIPTION
# #5309

https://app.bugsnag.com/crimethinc/rails/errors/69e89678ba7b406400c4ca2c

## Summary

- `MusicController` was extending `ToolsController`, which runs `set_tool` / `set_tools` before_actions on every action. Both call `tool_class`, which returns `nil` when `controller_path` isn't in `ALL_TOOLS = %w[tools books zines journals posters stickers videos]`. `music` is not in that list (and there is no `Music` model to constantize), so `tool_class.live` raised `NoMethodError`.
- The original controller's comment was `# Redirects to Bandcamp` but the action was an empty `def index; end` — there was no view, no model, and no actual redirect. Music isn't a tool in the app's data model; it's a pointer to an external Bandcamp page.
- Fix: change `MusicController` to extend `ApplicationController` directly and actually redirect to https://crimethinc.bandcamp.com (which is what the site's footer / about copy already references for music).

## Test plan

- [ ] In staging, `/music` 302s to https://crimethinc.bandcamp.com