### PR TITLE
rack(clean_path): do not remove `.xml` extension from `opensearch.xml`

### DIFF
--- a/app/middlewares/rack/clean_path.rb
+++ b/app/middlewares/rack/clean_path.rb
@@ -79,7 +79,10 @@ module Rack
     end
 
     def exit_early?
-      @req.path == '/' || @req.path.starts_with?('/assets') || @req.path.include?('sitemap')
+      @req.path == '/' ||
+        @req.path.starts_with?('/assets') ||
+        @req.path.include?('sitemap') ||
+        @req.path.include?('opensearch')
     end
 
     # get path before Unicode character got smooshed into it

--- a/spec/requests/clean_paths_spec.rb
+++ b/spec/requests/clean_paths_spec.rb
@@ -22,4 +22,12 @@ RSpec.describe 'Rack::CleanPath' do
     expect(response.header['Location']).to be_nil
     expect(response.body).not_to be_empty
   end
+
+  it 'does not strip .xml extension from opensearch.xml.gz' do
+    get 'http://example.com/opensearch.xml.gz'
+
+    expect(response).to have_http_status(:ok)
+    expect(response.header['Location']).to be_nil
+    expect(response.body).not_to be_empty
+  end
 end


### PR DESCRIPTION
We're striping the `.xml` extension of the request path if it exists, but we have a function (`exit_early?`) that check for a couple of file for which we do not want to remove the `.xml` extension. This commit add
 a new exception for `openserach.xml`.

Fix #5320