### PR TITLE
home: redirect to feed when request with atom, xml or json format

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -49,7 +49,13 @@ class HomeController < ApplicationController
       @ex_workers_collection = Article.featured
     end
 
-    render "#{Current.theme}/home/index"
+    respond_to do |format|
+      format.html { render "#{Current.theme}/home/index" }
+      format.atom { redirect_to feed_path }
+      format.xml { redirect_to feed_path }
+      format.json { redirect_to json_feed_path }
+      format.any { head :not_found }
+    end
   end
 
   private

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe HomeController do
+  describe 'GET #index' do
+    it 'responds successfully' do
+      get 'index'
+
+      expect(response).to be_successful
+    end
+
+    it 'redirect to atom feed when request with atom format' do
+      get 'index', format: :atom
+
+      expect(response).to redirect_to(feed_path)
+      expect(response.content_type).to start_with 'application/atom'
+    end
+
+    it 'redirect to atom feed when request with xml format' do
+      get 'index', format: :xml
+
+      expect(response).to redirect_to(feed_path)
+      expect(response.content_type).to start_with 'application/xml'
+    end
+
+    it 'redirect to json feed when request with json format' do
+      get 'index', format: :json
+
+      expect(response).to redirect_to(json_feed_path)
+      expect(response.content_type).to start_with 'application/json'
+    end
+
+    it 'returns 404 for invalid format' do
+      get 'index', format: :zip
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
When someone request the home page with a usual rss feed format, we redirect them to the feed, otherwise we return a 404.

HTML: render the html
atom: render the atom feed
xml: render the atom feed
json: render the json feed
otherwise: return 404

Part of #5303