### PR TITLE
css-refactor: replace SASS syntax with CSS in _page.scss

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -11,6 +11,7 @@
 //= link to_change_everything.css
 
 // Legacy theme (2017)
+//= link sass-to-css-transition.css
 //= link 2017.css
 
 // 2025 theme

--- a/app/assets/stylesheets/2017/views/_page.scss
+++ b/app/assets/stylesheets/2017/views/_page.scss
@@ -12,26 +12,29 @@
       }
     }
 
+    .intro p {
+      font-size: var(--page-intro-font-size, 2.25rem);
+      line-height: 1.5;
+    }
+
     .h-entry header,
     header {
       margin-bottom: var(--border-size-large);
 
       h1 {
-        font: {
-          weight: bold;
-          weight: 800;
-          size: 3rem;
-        }
-        line-height: 1.25em;
+        font-weight: bold;
+        font-weight: 800;
+        font-size: var(--page-header-h1, 3rem);
+        line-height: 1.25;
+        text-wrap: balance;
       }
 
       h2 {
-        font: {
-          weight: normal;
-          weight: 300;
-          size: 2rem;
-        }
-        line-height: 1.25em;
+        font-weight: normal;
+        font-weight: 300;
+        font-size: var(--page-header-h2, 2rem);
+        line-height: 1.25;
+        text-wrap: balance;
       }
     }
 
@@ -45,34 +48,25 @@
 
     .e-content {
       h1 {
-        font: {
-          weight: bold;
-          weight: 700;
-          size: 4rem;
-        }
-
+        font-weight: bold;
+        font-weight: 700;
+        font-size: 4rem;
         line-height: 1.25em;
         margin-bottom: var(--border-size-small);
       }
 
       h2 {
-        font: {
-          weight: normal;
-          weight: 500;
-          size: 3rem;
-        }
-
+        font-weight: normal;
+        font-weight: 500;
+        font-size: 3rem;
         line-height: 1.25em;
         margin-bottom: var(--border-size-small);
       }
 
       h3 {
-        font: {
-          weight: lighter;
-          weight: 300;
-          size: 2.5rem;
-        }
-
+        font-weight: lighter;
+        font-weight: 300;
+        font-size: 2.5rem;
         line-height: 1.25em;
         margin-bottom: var(--border-size-medium);
         border-bottom: var(--border-size-xsmall) solid var(--color-gray-light);
@@ -157,23 +151,6 @@
     li li {
       margin: 0 0 0 1.5em;
       line-height: 1.5em;
-    }
-
-    @media screen and (min-width: $small-tablet) {
-      .intro p {
-        font-size: 2.25rem;
-        line-height: 1.5em;
-      }
-
-      header {
-        h1 {
-          font-size: 4rem;
-        }
-
-        h2 {
-          font-size: 3rem;
-        }
-      }
     }
   }
 }

--- a/app/assets/stylesheets/sass-to-css-transition.css
+++ b/app/assets/stylesheets/sass-to-css-transition.css
@@ -1,0 +1,13 @@
+/* TODO: In-line the CSS in this file to the relevant files once the
+   SASS preprocessor is removed. */
+
+/*
+╭────────────────────────────────────────────────────╮
+│    app/assets/stylesheets/2017/views/_page.scss    │
+╰────────────────────────────────────────────────────╯
+*/
+:root {
+  --page-header-h1: clamp(3rem, 2.1vw + 1rem, 8rem);
+  --page-header-h2: clamp(2rem, 1.4vw + 1rem, 6rem);
+  --page-intro-font-size: clamp(1rem, 1vw + 1.25rem, 5rem);
+}

--- a/app/views/layouts/2017/_application.html.erb
+++ b/app/views/layouts/2017/_application.html.erb
@@ -8,7 +8,7 @@
     <%= render_themed "shared/head" %>
 
     <%= yield :head %>
-
+    <%= stylesheet_link_tag "sass-to-css-transition", media: :all %>
     <% if content_for(:javascript).present? %>
       <%= javascript_importmap_tags %>
       <%= yield :javascript %>


### PR DESCRIPTION
What are the relevant GitHub issues?
=========================================

related to: https://github.com/crimethinc/website/pull/5212

What does this pull request do?
=========================================

* `app/assets/stylesheets/2017/views/_page.scss`: replaced SASS font syntax with CSS. Also used clamp to replace the media query.
* `app/assets/stylesheets/sass-to-css-transition.css`: introduced a new file to hold CSS code that cannot go through the SASS preprocessor.
* `app/assets/config/manifest.js`: Added the new `sass-to-css-transition.css` to the sprockets manifest.
* `app/views/layouts/2017/_application.html.erb`: included the new `sass-to-css-transition.css` file in the 2017 layout.

--- 

There were two types of SASS syntax that need to be converted to CSS. The first is straightforward: unrolling the `font: {...}` syntax into standard CSS attributes.

The second was the use of variable in the media query. This isn't something you can do with CSS.

I considered a couple approaches:

1. Just replace the variable with a `800px`.
2. avoid the media query entirely by clamping the font size.

Just inlining the 800px value is the simplest and would guarantee the layout remains exactly the same.

However, at least in this case, we could probably avoid the media query entirely with `clamp()`. The one complication with using `clamp` is that SASS implements its own `clamp` method, and the SASS version doesn't allow for mixed units (same with the SASS versions of min, max, etc.)

As a workaround, I introduced a CSS file that does not go through SASS to use as a temporary workaround until the view/component CSS files are no longer being preprocessed.

How should this be manually tested?
==============================================

- visually inspect the pages (library, tools, etc.) at different viewport sizes and zoom amounts

Is there any background context you want to provide for reviewers?
============================================================================

To better explain my intent with the clamp change:

The existing styles would adjust the `header.h1` and `header.h2` font size with a breakpoint a t `800px`:

```
when viewport width < 800px
  h1: 3rem
  h2: 2rem
```

```
when viewport width >= 800px
  h1: 4rem
  h2: 3rem
```

I replaced the breakpoint with a [`clamp`][0] usage.

From MDN:

> Note that using clamp() for font sizes, as in these examples, allows you to set a font-size that grows with the size of the viewport, but doesn't go below a minimum font-size or above a maximum font-size. It has the same effect as the code in Fluid Typography but in one line, and without the use of media queries.


To determine the min, max, and target font sizes I did the following:

* for min I used the `width < 800px` values
* for max I set the dev tools simulator to 4k TV and picking something that looked decent at such a large viewport
* for the target I took the `width >= 800px` values as the starting point and converted that to `wv` units (minus 1rem, to be added in later). This makes the font automatically responsive to viewport size, but makes the font no longer adjust to page zooming. By mixing the `vw` unit with the `1 rem`, the font will once again adjust with page zooming

[0]:https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/clamp

## Acceptance Criteria
### These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema
