### PR TITLE
github: update default PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,11 +1,3 @@
-# How does this pull request make you feel (in animated GIF format)?
-
-![alt text](giphy link)
-
-# What are the relevant GitHub issues?
-
-resolves `[link to github issue]`
-
 # What does this pull request do?
 
 ??
@@ -18,12 +10,19 @@ resolves `[link to github issue]`
 
 ??
 
-# Questions for the pull request author (delete any that don't apply):
+# Acceptance Criteria
+## Questions for the pull request author (delete any that don't apply)
+
 - [ ] Are any needed README/wiki/documentation updates needed for this pull request?
 - [ ] Does the code you updated have tests? If not, could you add some please?
 - [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.
 
-# Acceptance Criteria
-## These should be checked by the reviewers
+## Questions for the reviewer
 
 - [ ] This pull request does not cause the database export script to become out of sync with the db schema
+
+---
+
+<!-- links to related issues/commits/PRs -->
+<!-- related-to: [link to github issue/commit/PR] -->
+<!-- resolves: [link to github issue] -->


### PR DESCRIPTION
What does this pull request do?
==========================================================================


* `.github/PULL_REQUEST_TEMPLATE.MD`: remove the gif block and move trailers to the end of the commit message

Update the PR template to make it a little bit easier to use via

    git commit --template=.github/PULL_REQUEST_TEMPLATE.MD


Is there any background context you want to provide for reviewers? 
==========================================================================

I think it makes sense to move references to the end of the commit message to be compatible with [git trailers][0], which can make git spelunking a bit easier.

[0]:https://git-scm.com/docs/git-interpret-trailers

# Acceptance Criteria

## These should be checked by the reviewers

- [ ] This pull request does not cause the database export script to become out of sync with the db schema
