### PR TITLE
css refactor: replace header/footer SCSS icon with CSS

### DIFF
--- a/app/assets/stylesheets/2017/base/_mixins.scss
+++ b/app/assets/stylesheets/2017/base/_mixins.scss
@@ -21,11 +21,9 @@
 }
 
 @mixin image-replacement-graphic($url, $retina-url, $width, $height) {
-  background: {
-    position: center center;
-    repeat: no-repeat;
-    size: contain;
-  }
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: contain;
 
   @include size($width, $height);
   @include image-replacement();

--- a/app/assets/stylesheets/2017/base/_mixins.scss
+++ b/app/assets/stylesheets/2017/base/_mixins.scss
@@ -21,6 +21,7 @@
 }
 
 @mixin image-replacement-graphic($url, $retina-url, $width, $height) {
+  background-image: asset-data-url($url);
   background-position: center center;
   background-repeat: no-repeat;
   background-size: contain;
@@ -29,13 +30,6 @@
   height: $height;
 
   @include image-replacement();
-
-  @media screen and #{$standard-def} {
-    background-image: asset-data-url($url);
-  }
-  @media screen and #{$retina} {
-    background-image: asset-data-url($retina-url);
-  }
 }
 
 @mixin social-icon($domain) {

--- a/app/assets/stylesheets/2017/base/_mixins.scss
+++ b/app/assets/stylesheets/2017/base/_mixins.scss
@@ -34,15 +34,6 @@
   white-space: nowrap;
 }
 
-@mixin social-icon($domain) {
-  @include image-replacement-graphic(
-    "social-icons/#{$domain}.svg",
-    "social-icons/#{$domain}.svg",
-    40px,
-    40px
-  );
-}
-
 @mixin podcast-subscribe-button($domain) {
   @include image-replacement-graphic(
     "podcast-subscribe-buttons/#{$domain}.png",

--- a/app/assets/stylesheets/2017/base/_mixins.scss
+++ b/app/assets/stylesheets/2017/base/_mixins.scss
@@ -25,7 +25,9 @@
   background-repeat: no-repeat;
   background-size: contain;
 
-  @include size($width, $height);
+  width: $width;
+  height: $height;
+
   @include image-replacement();
 
   @media screen and #{$standard-def} {

--- a/app/assets/stylesheets/2017/base/_mixins.scss
+++ b/app/assets/stylesheets/2017/base/_mixins.scss
@@ -21,17 +21,30 @@
 }
 
 @mixin image-replacement-graphic($url, $retina-url, $width, $height) {
-  background-image: asset-data-url($url);
-  background-position: center center;
-  background-repeat: no-repeat;
-  background-size: contain;
+  background: {
+    position: center center;
+    repeat: no-repeat;
+    size: contain;
+  }
 
-  width: $width;
-  height: $height;
+  @include size($width, $height);
+  @include image-replacement();
 
-  overflow: hidden;
-  text-indent: -10000%;
-  white-space: nowrap;
+  @media screen and #{$standard-def} {
+    background-image: asset-data-url($url);
+  }
+  @media screen and #{$retina} {
+    background-image: asset-data-url($retina-url);
+  }
+}
+
+@mixin social-icon($domain) {
+  @include image-replacement-graphic(
+    "social-icons/#{$domain}.svg",
+    "social-icons/#{$domain}.svg",
+    40px,
+    40px
+  );
 }
 
 @mixin podcast-subscribe-button($domain) {

--- a/app/assets/stylesheets/2017/base/_mixins.scss
+++ b/app/assets/stylesheets/2017/base/_mixins.scss
@@ -29,7 +29,9 @@
   width: $width;
   height: $height;
 
-  @include image-replacement();
+  overflow: hidden;
+  text-indent: -10000%;
+  white-space: nowrap;
 }
 
 @mixin social-icon($domain) {

--- a/app/assets/stylesheets/2017/base/variables/_typography.scss
+++ b/app/assets/stylesheets/2017/base/variables/_typography.scss
@@ -1,3 +1,9 @@
+:root {
+  --crimethinc-icon-svg: url("crimethinc-logo-type-white.svg")
+                         center center / contain no-repeat
+                         scroll border-box padding-box transparent;
+}
+
 $base-font-size: 1.6rem;
 
 $family-system: system, -apple-system, BlinkMacSystemFont, ‘Segoe UI’, Roboto, Oxygen, Ubuntu, Cantarell, ‘Open Sans’, ‘Helvetica Neue’, sans-serif;

--- a/app/assets/stylesheets/2017/components/_footer.scss
+++ b/app/assets/stylesheets/2017/components/_footer.scss
@@ -99,10 +99,10 @@ footer#site-footer {
 
   .footer-section.footer-section-about {
     .about-us-heading {
-      background-image: url("crimethinc-logo-type-white.svg");
-      background-position: center center;
-      background-repeat: no-repeat;
-      background-size: contain;
+      background:
+        url("crimethinc-logo-type-white.svg")
+        center center / contain no-repeat
+        scroll border-box padding-box transparent;
       width: 16rem;
       height: 3.2rem;
       overflow: hidden;

--- a/app/assets/stylesheets/2017/components/_footer.scss
+++ b/app/assets/stylesheets/2017/components/_footer.scss
@@ -99,10 +99,7 @@ footer#site-footer {
 
   .footer-section.footer-section-about {
     .about-us-heading {
-      background:
-        url("crimethinc-logo-type-white.svg")
-        center center / contain no-repeat
-        scroll border-box padding-box transparent;
+      background: var(--crimethinc-icon-svg);
       width: 16rem;
       height: 3.2rem;
       overflow: hidden;

--- a/app/assets/stylesheets/2017/components/_footer.scss
+++ b/app/assets/stylesheets/2017/components/_footer.scss
@@ -99,12 +99,15 @@ footer#site-footer {
 
   .footer-section.footer-section-about {
     .about-us-heading {
-      @include image-replacement-graphic(
-        "crimethinc-logo-type-white.svg",
-        "crimethinc-logo-type-white.svg",
-        16rem,
-        3.2rem
-      );
+      background-image: url("crimethinc-logo-type-white.svg");
+      background-position: center center;
+      background-repeat: no-repeat;
+      background-size: contain;
+      width: 16rem;
+      height: 3.2rem;
+      overflow: hidden;
+      text-indent: -10000%;
+      white-space: nowrap;
     }
 
     .first-time-link a,

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -38,10 +38,10 @@ html[dir="rtl"] .site-header .button {
 }
 
 .header-logo a {
-  background-image: url("crimethinc-logo-type-white.svg");
-  background-position: center center;
-  background-repeat: no-repeat;
-  background-size: contain;
+  background:
+    url("crimethinc-logo-type-white.svg")
+    center center / contain no-repeat
+    scroll border-box padding-box transparent;
   width: 15rem;
   height: 3rem;
   overflow: hidden;

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -38,23 +38,20 @@ html[dir="rtl"] .site-header .button {
 }
 
 .header-logo a {
-  @include image-replacement-graphic(
-    "crimethinc-logo-type-white.svg",
-    "crimethinc-logo-type-white.svg",
-    15rem,
-    3rem
-  );
-  @include size(15rem, 3rem);
+  background-image: url("crimethinc-logo-type-white.svg");
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  width: 15rem;
+  height: 3rem;
+  overflow: hidden;
+  text-indent: -10000%;
+  white-space: nowrap;
   display: inline-block;
 
   @media screen and (max-width: $small-tablet) {
-    @include image-replacement-graphic(
-      "crimethinc-logo-type-white.svg",
-      "crimethinc-logo-type-white.svg",
-      10rem,
-      2rem
-    );
-    @include size(10rem, 2rem);
+    width: 10rem;
+    height: 2rem;
   }
 }
 

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -38,10 +38,7 @@ html[dir="rtl"] .site-header .button {
 }
 
 .header-logo a {
-  background:
-    url("crimethinc-logo-type-white.svg")
-    center center / contain no-repeat
-    scroll border-box padding-box transparent;
+  background: var(--crimethinc-icon-svg);
   width: 15rem;
   height: 3rem;
   overflow: hidden;


### PR DESCRIPTION
# What does this pull request do?

* `app/assets/stylesheets/2017/base/variables/_typography.scss`: added the logo SVG attributes to a `:root` variable.
* `app/assets/stylesheets/2017/components/_footer.scss`: in-lined the `image-replacement-graphic` mixin, making use of the new variable.
* `app/assets/stylesheets/2017/components/_header.scss`: in-lined the `image-replacement-graphic` mixin, making use of the new variable.

# How should this be manually tested?

- visually inspect the header and footer logos

## screenshots

|  | header before | header after | footer before | footer after |
|--------|--------|--------|--------|--------|
| **phone** | <img width="1449" height="2961" alt="header-phone-before" src="https://github.com/user-attachments/assets/b255ac0d-9d23-4979-9536-129071043275" /> | <img width="1449" height="2961" alt="header-phone-after" src="https://github.com/user-attachments/assets/647ce1a9-f98e-41af-bd30-a4c424a6539a" /> | <img width="1449" height="2961" alt="footer-phone-before" src="https://github.com/user-attachments/assets/2e177501-7206-453b-8b33-6b3530bebb45" /> | <img width="1449" height="2961" alt="footer-phone-after" src="https://github.com/user-attachments/assets/11265c68-0269-490b-92cc-9937a506ff19" /> |
| **desktop** | <img width="2880" height="1800" alt="header-laptop-before" src="https://github.com/user-attachments/assets/aa4bbb79-3a76-465d-9903-3223467d977e" /> | <img width="2880" height="1800" alt="header-laptop-after" src="https://github.com/user-attachments/assets/25e9d5f8-3ae6-4233-b76d-1e6b7ef70fa0" /> | <img width="2880" height="1800" alt="footer-laptop-before" src="https://github.com/user-attachments/assets/a449fb18-6374-4553-beba-a0ff08d2a56c" /> | <img width="2880" height="1800" alt="footer-laptop-after" src="https://github.com/user-attachments/assets/f889bc79-f441-4ab7-aee8-11217340eaa9" /> | 

# Is there any background context you want to provide for reviewers?

We will need to eventually get rid of the entire `_mixin.scss` file since mixins are a SCSS specific concept (at least [for now][2]).

The `image-replacement-graphic` mixin seems like it isn't actually needed anymore.

A brief overview:

* introduced in [5f8930b][0] as a way to handle different image files for retina screens
* later we started using SVGs (e.g. [4395903][1]), which work regardless of screen size
* so now the mixin just creates redundant CSS

[0]:https://github.com/crimethinc/website/commit/5f8930bbd7f3fad92c4f4200bdb682afa513c627
[1]:https://github.com/crimethinc/website/commit/43959035a55b4dd341cc2336bcf4957b5522990b
[2]:https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Custom_functions_and_mixins

# Acceptance Criteria
## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to: https://github.com/crimethinc/website/pull/5212