### PR TITLE
fix: database query for Article.previous scope

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -93,8 +93,8 @@ class ArticlesController < ApplicationController
 
     @live_blog = @article.collection_root?
 
-    @previous_article = Article.previous(@article).first
-    @next_article     = Article.next(@article).first
+    @previous_article = @article.previous
+    @next_article     = @article.next
     @editable         = @article
 
     # TODO: extract to an async background job

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -38,6 +38,18 @@ class Article < ApplicationRecord
 
   scope :last_2_weeks, -> { where('published_at BETWEEN ? AND ?', Time.now.utc - 2.weeks, Time.now.utc) }
 
+  def previous
+    return nil if draft?
+
+    Article.previous(self).first
+  end
+
+  def next
+    return nil if draft?
+
+    Article.next(self).first
+  end
+
   def path
     if published?
       published_at.strftime("/%Y/%m/%d/#{slug}")

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -22,26 +22,27 @@ module Publishable
             where('published_at BETWEEN ? AND ?', date.try(:beginning_of_day), date.try(:end_of_day))
           }
 
-    scope :next,
-          lambda { |article|
-            unscoped.root
-                    .where('published_at > ?', article.published_at)
-                    .where.not(id: article.id)
-                    .live
-                    .published
-                    .order(published_at: :asc)
-                    .limit(1)
-          }
+    scope :next, lambda { |article|
+      root.where('published_at > ?', article.published_at).or(
+        self.where('published_at = ?', article.published_at).and(
+          self.where('id > ?', article.id)))
+        .where.not(id: article.id)
+        .live
+        .published
+        .reorder(published_at: :asc, id: :asc)
+        .limit(1)
+    }
 
-    scope :previous,
-          lambda { |article|
-            root.where(published_at: ..article.published_at)
-                .where.not(id: article.id)
-                .live
-                .published
-                .chronological
-                .limit(1)
-          }
+    scope :previous, lambda { |article|
+      root.where('published_at < ?', article.published_at).or(
+        self.where('published_at = ?', article.published_at).and(
+          self.where('id < ?', article.id)))
+        .where.not(id: article.id)
+        .live
+        .published
+        .chronological
+        .limit(1)
+   }
   end
 
   def dated?

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -24,25 +24,29 @@ module Publishable
 
     scope :next, lambda { |article|
       root.where('published_at > ?', article.published_at).or(
-        self.where('published_at = ?', article.published_at).and(
-          self.where('id > ?', article.id)))
-        .where.not(id: article.id)
-        .live
-        .published
-        .reorder(published_at: :asc, id: :asc)
-        .limit(1)
+        where(published_at: article.published_at).and(
+          where('id > ?', article.id)
+        )
+      )
+          .where.not(id: article.id)
+          .live
+          .published
+          .reorder(published_at: :asc, id: :asc)
+          .limit(1)
     }
 
     scope :previous, lambda { |article|
-      root.where('published_at < ?', article.published_at).or(
-        self.where('published_at = ?', article.published_at).and(
-          self.where('id < ?', article.id)))
-        .where.not(id: article.id)
-        .live
-        .published
-        .chronological
-        .limit(1)
-   }
+      root.where(published_at: ...article.published_at).or(
+        where(published_at: article.published_at).and(
+          where(id: ...article.id)
+        )
+      )
+          .where.not(id: article.id)
+          .live
+          .published
+          .chronological
+          .limit(1)
+    }
   end
 
   def dated?

--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -12,7 +12,7 @@ module Publishable
 
     scope :for_admin, -> { unscoped.order(published_at: :desc) }
 
-    scope :chronological, -> { order(published_at: :desc) }
+    scope :chronological, -> { order(published_at: :desc, id: :desc) }
     scope :root,          -> { where(collection_id: nil) }
     scope :live,          -> { where(published_at: ...Time.now.utc) }
     scope :recent,        -> { where('published_at BETWEEN ? AND ?', Time.now.utc - 2.days, Time.now.utc) }
@@ -26,6 +26,7 @@ module Publishable
           lambda { |article|
             unscoped.root
                     .where('published_at > ?', article.published_at)
+                    .where.not(id: article.id)
                     .live
                     .published
                     .order(published_at: :asc)
@@ -34,7 +35,8 @@ module Publishable
 
     scope :previous,
           lambda { |article|
-            root.where(published_at: article.published_at)
+            root.where(published_at: ..article.published_at)
+                .where.not(id: article.id)
                 .live
                 .published
                 .chronological

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -140,20 +140,82 @@ describe Article do
     end
   end
 
-  describe '.next' do
-    it 'returns the article published after the given one' do
-      older = create(:article, published_at: 2.days.ago, publication_status: 'published')
-      newer = create(:article, published_at: 1.day.ago, publication_status: 'published')
+  shared_context "timeline of articles" do
+    include ActiveSupport::Testing::TimeHelpers
 
-      expect(described_class.next(older).first).to eq newer
+    let(:unpublished_article) { create(:article, publication_status: "draft") }
+    let(:article) { Article.find_by(title: article_under_test) }
+
+    before(:context) do
+      travel_to(1.day.ago) do
+        # t0     | represents an article published "now" (the chronologically last published_at date)
+        # t1...n | represents articles with a published at of "t0 - n.days"
+        now = Time.now.utc
+        [
+          {title: 't0', published_at: now.end_of_day, locale: :en, canonical_id: nil },
+          {title: 't1', published_at: now.end_of_day, locale: :en, canonical_id: nil },
+          {title: 't2', published_at: now.end_of_day, locale: :en, canonical_id: nil },
+          {title: 't3', published_at: now.beginning_of_day, locale: :en, canonical_id: nil },
+          {title: 't4', published_at: (now - 1.day).end_of_day, locale: :en, canonical_id: nil },
+          {title: 't5', published_at: (now - 1.day).beginning_of_day, locale: :en, canonical_id: nil },
+          {title: 't6', published_at: (now - 2.days).end_of_day, locale: :en, canonical_id: nil },
+          {title: 't7', published_at: (now - 2.days).beginning_of_day, locale: :en, canonical_id: nil }
+        ].reverse.map! { | params| (create :article, **params) }
+      end
+    end
+
+    after(:context) { Article.destroy_all }
+  end
+
+  describe '#next' do
+    subject { article.next&.title }
+
+    include_context "timeline of articles"
+
+    context 'when the article is the most recently published article' do
+      let(:article_under_test) { "t0" }
+      it { is_expected.to be nil }
+    end
+
+    context 'when the article is the oldest published article' do
+      let(:article_under_test) { "t7" }
+      it { is_expected.to eq "t6" }
+    end
+
+    context 'when the article is on a date boundary' do
+      let(:article_under_test) { "t4" }
+      it { is_expected.to eq "t3" }
+    end
+
+    context 'when the article is unpublished' do
+      let(:article) { unpublished_article }
+      it { is_expected.to be nil }
     end
   end
 
-  describe '.previous' do
-    it 'returns the article published on the same date before the given one' do
-      article = create(:article, published_at: 1.day.ago, publication_status: 'published')
+  describe '#previous' do
+    subject { article.previous&.title }
 
-      expect(described_class.previous(article)).to exist
+    include_context "timeline of articles"
+
+    context 'when the article is the most recently published article' do
+      let(:article_under_test) { "t0" }
+      it { is_expected.to eq "t1" }
+    end
+
+    context 'when the article is the oldest published article' do
+      let(:article_under_test) { "t7" }
+      it { is_expected.to be nil }
+    end
+
+    context 'when the article is on a date boundary' do
+      let(:article_under_test) { "t5" }
+      it { is_expected.to eq "t6" }
+    end
+
+    context 'when the article is unpublished' do
+      let(:article) { unpublished_article }
+      it { is_expected.to be nil }
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -168,53 +168,43 @@ describe Article do
   end
 
   describe '#next' do
-    subject { article.next&.title }
+    subject(:actual_order) do
+      publication_timeline.map { |t| Article.find_by(title: t)&.next&.title }
+    end
 
     include_context "timeline of articles"
+    
+    let(:publication_timeline) { %w[t7 t6 t5 t4 t3 t2 t1 t0] }
+    let(:expected_order) { publication_timeline.tap(&:shift).then{ it.push nil } }
 
-    context 'when the article is the most recently published article' do
-      let(:article_under_test) { "t0" }
-      it { is_expected.to be nil }
+    it "traverses the publication timeline" do
+      expect(actual_order).to eq expected_order
     end
-
-    context 'when the article is the oldest published article' do
-      let(:article_under_test) { "t7" }
-      it { is_expected.to eq "t6" }
-    end
-
-    context 'when the article is on a date boundary' do
-      let(:article_under_test) { "t4" }
-      it { is_expected.to eq "t3" }
-    end
-
+    
     context 'when the article is unpublished' do
-      let(:article) { unpublished_article }
+      subject{ unpublished_article.next }
+
       it { is_expected.to be nil }
     end
   end
 
   describe '#previous' do
-    subject { article.previous&.title }
+    subject(:actual_order) do
+      publication_timeline.reverse.map { |t| Article.find_by(title: t).previous&.title }
+    end
 
     include_context "timeline of articles"
 
-    context 'when the article is the most recently published article' do
-      let(:article_under_test) { "t0" }
-      it { is_expected.to eq "t1" }
-    end
+    let(:publication_timeline) { %w[t7 t6 t5 t4 t3 t2 t1 t0] }
+    let(:expected_order) { publication_timeline.reverse.tap(&:shift).then{ it.push nil } }
 
-    context 'when the article is the oldest published article' do
-      let(:article_under_test) { "t7" }
-      it { is_expected.to be nil }
+    it "traverses the publication timeline" do
+      expect(actual_order).to eq expected_order
     end
-
-    context 'when the article is on a date boundary' do
-      let(:article_under_test) { "t5" }
-      it { is_expected.to eq "t6" }
-    end
-
+    
     context 'when the article is unpublished' do
-      let(:article) { unpublished_article }
+      subject{ unpublished_article.next }
+
       it { is_expected.to be nil }
     end
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -140,72 +140,60 @@ describe Article do
     end
   end
 
-  shared_context "timeline of articles" do
+  shared_examples 'it can traverse the publication timeline' do |direction|
     include ActiveSupport::Testing::TimeHelpers
 
-    let(:unpublished_article) { create(:article, publication_status: "draft") }
-    let(:article) { Article.find_by(title: article_under_test) }
+    subject(:actual_order) do
+      articles_to_traverse.map do |t|
+        described_class.find_by(title: t)&.send(method_under_test)&.title
+      end
+    end
 
-    before(:context) do
+    let(:method_under_test) { direction.to_sym }
+
+    let(:publication_timeline) { %w[t7 t6 t5 t4 t3 t2 t1 t0] }
+    let(:unpublished_article) { create(:article, publication_status: 'draft') }
+
+    before do
       travel_to(1.day.ago) do
         # t0     | represents an article published "now" (the chronologically last published_at date)
         # t1...n | represents articles with a published at of "t0 - n.days"
         now = Time.now.utc
         [
-          {title: 't0', published_at: now.end_of_day, locale: :en, canonical_id: nil },
-          {title: 't1', published_at: now.end_of_day, locale: :en, canonical_id: nil },
-          {title: 't2', published_at: now.end_of_day, locale: :en, canonical_id: nil },
-          {title: 't3', published_at: now.beginning_of_day, locale: :en, canonical_id: nil },
-          {title: 't4', published_at: (now - 1.day).end_of_day, locale: :en, canonical_id: nil },
-          {title: 't5', published_at: (now - 1.day).beginning_of_day, locale: :en, canonical_id: nil },
-          {title: 't6', published_at: (now - 2.days).end_of_day, locale: :en, canonical_id: nil },
-          {title: 't7', published_at: (now - 2.days).beginning_of_day, locale: :en, canonical_id: nil }
-        ].reverse.map! { | params| (create :article, **params) }
+          { title: 't0', published_at: now.end_of_day, locale: :en, canonical_id: nil },
+          { title: 't1', published_at: now.end_of_day, locale: :en, canonical_id: nil },
+          { title: 't2', published_at: now.end_of_day, locale: :en, canonical_id: nil },
+          { title: 't3', published_at: now.beginning_of_day, locale: :en, canonical_id: nil },
+          { title: 't4', published_at: (now - 1.day).end_of_day, locale: :en, canonical_id: nil },
+          { title: 't5', published_at: (now - 1.day).beginning_of_day, locale: :en, canonical_id: nil },
+          { title: 't6', published_at: (now - 2.days).end_of_day, locale: :en, canonical_id: nil },
+          { title: 't7', published_at: (now - 2.days).beginning_of_day, locale: :en, canonical_id: nil }
+        ].reverse.map! { |params| create(:article, **params) }
       end
     end
 
-    after(:context) { Article.destroy_all }
+    it 'traverses the publication timeline' do
+      expect(actual_order).to eq expected_order
+    end
+
+    context 'when the article is unpublished' do
+      subject { unpublished_article.next }
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe '#next' do
-    subject(:actual_order) do
-      publication_timeline.map { |t| Article.find_by(title: t)&.next&.title }
-    end
-
-    include_context "timeline of articles"
-    
-    let(:publication_timeline) { %w[t7 t6 t5 t4 t3 t2 t1 t0] }
-    let(:expected_order) { publication_timeline.tap(&:shift).then{ it.push nil } }
-
-    it "traverses the publication timeline" do
-      expect(actual_order).to eq expected_order
-    end
-    
-    context 'when the article is unpublished' do
-      subject{ unpublished_article.next }
-
-      it { is_expected.to be nil }
+    it_behaves_like 'it can traverse the publication timeline', :next do
+      let(:articles_to_traverse) { publication_timeline }
+      let(:expected_order) { publication_timeline.tap(&:shift).then { it.push nil } }
     end
   end
 
   describe '#previous' do
-    subject(:actual_order) do
-      publication_timeline.reverse.map { |t| Article.find_by(title: t).previous&.title }
-    end
-
-    include_context "timeline of articles"
-
-    let(:publication_timeline) { %w[t7 t6 t5 t4 t3 t2 t1 t0] }
-    let(:expected_order) { publication_timeline.reverse.tap(&:shift).then{ it.push nil } }
-
-    it "traverses the publication timeline" do
-      expect(actual_order).to eq expected_order
-    end
-    
-    context 'when the article is unpublished' do
-      subject{ unpublished_article.next }
-
-      it { is_expected.to be nil }
+    it_behaves_like 'it can traverse the publication timeline', :previous do
+      let(:articles_to_traverse) { publication_timeline.reverse }
+      let(:expected_order) { publication_timeline.reverse.tap(&:shift).then { it.push nil } }
     end
   end
 


### PR DESCRIPTION
# What does this pull request do?

* `app/models/article.rb`: add instance methods to wrap the Article.{previous, next} class methods.
* `app/controllers/articles_controller.rb`: replace usage of class method with new instance methods.
* `spec/models/article_spec.rb`: Add regression tests
* `app/models/concerns/publishable.rb`: update the previous scope to exclude the given articles id, use id column as a sort tie-breaker, and change the range query to "<="


# How should this be manually tested?

- run the new specs without the fix to the application code, they will fail
- apply the fix, re-run the specs. they will pass

# Is there any background context you want to provide for reviewers?

In PR #5299 I started patching a bug in the `Article.previous` scope.

The short version of the bug is that in a previous MR several instances of:

    where('published_at < ?', foo)

were replaced with the alternate syntax of:

    where(published_at: ...foo)

However on the `Publishable#previous` the `...` was missed, meaning that the scope would only return articles with the exact same `published_at`.

## Database query example

<details>
<summary>

### `.next`

</summary>

### SQL Before

``` sql
SELECT
  "articles".*
FROM
  "articles"
WHERE
  "articles"."collection_id" IS NULL
  AND (published_at > "2026-05-02 00:00:00")                    -- article.published_at
  AND "articles"."published_at" < "2026-05-05 19:13:43.334302"  -- .live
  AND "articles"."publication_status" = "published"
ORDER BY
  "articles"."published_at" ASC
LIMIT
  1
```

### SQL After
``` sql
SELECT
  "articles".*
FROM
  "articles"
WHERE
  (
    "articles"."collection_id" IS NULL
    AND (published_at > "2026-05-04 23:59:59.999999")              -- article.published_at
    OR (published_at = "2026-05-04 23:59:59.999999")               -- article.published_at
    AND (id > 3613)                                                -- article.id
  )
  AND "articles"."id" != 3613                                      -- article.id
  AND "articles"."published_at" < "2026-05-05 18:46:58.017702"     -- .live
  AND "articles"."publication_status" = "published"
ORDER BY
  "articles"."published_at" ASC,
  "articles"."id" ASC
LIMIT
  1
```

</details>

<details>
<summary>

### `.previous`

</summary>

### SQL Before
``` sql
SELECT
  "articles".*
FROM
  "articles"
WHERE
  "articles"."collection_id" IS NULL
  AND "articles"."published_at" = "2026-05-04 23:59:59.999999"     -- article.published_at
  AND "articles"."published_at" < "2026-05-05 19:19:15.177659"     -- .live
  AND "articles"."publication_status" = "published"
ORDER BY
  "articles"."published_at" DESC
LIMIT
  1
```

### SQL After

``` sql
SELECT
  "articles".*,
FROM
  "articles"
WHERE
  (
    "articles"."collection_id" IS NULL
    AND (published_at < "2026-05-02 00:00:00")                  -- article.published_at
    OR (published_at = "2026-05-02 00:00:00")                   -- article.published_at
    AND (id < 3623)                                             -- article.id
  )
  AND "articles"."id" != 3623                                   -- article.id
  AND "articles"."published_at" < "2026-05-05 19:00:05.935992"  -- .live
  AND "articles"."publication_status" = "published"
ORDER BY
  "articles"."published_at" DESC,
  "articles"."id" DESC
LIMIT
  1
```

</details>

TODO
====================

I mentioned on PR #5299 that this scope could be improved further to handle translations and the canonical article better.

However, that will require much more substantial code changes to the query, which will take some time.

In the meantime this fixes the bug and puts some regression tests in place.



# Acceptance Criteria
## Questions for the pull request author (delete any that don't apply)

- [X] Does the code you updated have tests? If not, could you add some please?

## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to: https://github.com/crimethinc/website/pull/5299
related-to: https://github.com/crimethinc/website/pull/3845
related-to: https://github.com/crimethinc/website/pull/5196
