### PR TITLE
css-refactor: replace usage of SCSS @extend in footer

### DIFF
--- a/app/assets/stylesheets/2017/components/_footer.scss
+++ b/app/assets/stylesheets/2017/components/_footer.scss
@@ -145,8 +145,7 @@ footer#site-footer {
         margin-bottom: 1rem;
       }
 
-      button {
-        @extend .button;
+      .newsletter-signup-button {
         font-size: 1.5rem;
         float: right;
         background: var(--color-blue);

--- a/app/views/2017/shared/footer/_newsletter.html.erb
+++ b/app/views/2017/shared/footer/_newsletter.html.erb
@@ -24,7 +24,7 @@
           <div class="response" id="mce-success-response"></div>
         </div>
 
-        <%= button_tag t("footer.contact.newsletter.signup_button_text"), name: "subscribe", id: "mc-embedded-subscribe" %>
+        <%= button_tag t("footer.contact.newsletter.signup_button_text"), name: "subscribe", class: "button newsletter-signup-button", id: "mc-embedded-subscribe" %>;
 
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <% left_or_right = html_dir == 'ltr' ? "position: absolute; left: -5000px;" : "position: absolute; right: -5000px;" %>


### PR DESCRIPTION
# What does this pull request do?

* app/assets/stylesheets/2017/components/_footer.scss: replaced SCSS `@extend` syntax with a CSS class.
* app/views/2017/shared/footer/_newsletter.html.erb: added the existing `.button` and a new `.newsletter-signup-button` CSS class to the button.

# How should this be manually tested?
## screenshots

| Before | After |
|--------|--------|
| <img width="2880" height="1920" alt="before" src="https://github.com/user-attachments/assets/694e90eb-6f6e-46e9-ad84-d2851fbd3223" /> | <img width="2880" height="1920" alt="after" src="https://github.com/user-attachments/assets/f1cd738f-286d-4187-ab4d-9ba13c92e5f9" /> | 


# Acceptance Criteria
## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to: https://github.com/crimethinc/website/pull/5212
