### PR TITLE
Replace remaining SCSS in `_footer.scss` with CSS

### DIFF
--- a/app/assets/stylesheets/2017/components/_footer.scss
+++ b/app/assets/stylesheets/2017/components/_footer.scss
@@ -8,18 +8,14 @@ footer#site-footer {
     align-items: top;
   }
 
-  @media screen and (min-width: $small-tablet) {
+  @media screen and (min-width: 800px) {
     .footer-section {
       width: 33.33333333%;
     }
   }
 
   .footer-section-container {
-    padding: var(--border-size-large);
-
-    @media screen and (min-width: $small-tablet) {
-      padding: var(--border-size-xlarge);
-    }
+    padding: var(--footer-section-padding);
   }
 
   .footer-section-about .footer-section-container {
@@ -71,11 +67,9 @@ footer#site-footer {
       font-weight: bold;
 
       b {
-        font: {
-          weight: normal;
-          weight: 300;
-          size: 0.6em;
-        }
+        font-weight: normal;
+        font-weight: 300;
+        font-size: 0.6em;
       }
     }
 
@@ -109,7 +103,6 @@ footer#site-footer {
 
     .first-time-link a,
     .about-us-link a {
-      @extend .button;
       background: var(--color-white);
       color: var(--color-true-black) !important;
       text-decoration: none;

--- a/app/assets/stylesheets/sass-to-css-transition.css
+++ b/app/assets/stylesheets/sass-to-css-transition.css
@@ -1,13 +1,20 @@
 /* TODO: In-line the CSS in this file to the relevant files once the
    SASS preprocessor is removed. */
 
-/*
-╭────────────────────────────────────────────────────╮
-│    app/assets/stylesheets/2017/views/_page.scss    │
-╰────────────────────────────────────────────────────╯
-*/
 :root {
+  /*
+╭────────────────────────────────────────────────────╮
+│    app/assets/stylesheets/2017/views/_page.css     │
+╰────────────────────────────────────────────────────╯
+ */
   --page-header-h1: clamp(3rem, 2.1vw + 1rem, 8rem);
   --page-header-h2: clamp(2rem, 1.4vw + 1rem, 6rem);
   --page-intro-font-size: clamp(1rem, 1vw + 1.25rem, 5rem);
+
+  /*
+╭───────────────────────────────────────────────────────────╮
+│    app/assets/stylesheets/2017/components/_footer.scss    │
+╰───────────────────────────────────────────────────────────╯
+ */
+  --footer-section-padding: clamp(var(--border-size-large), 3.5vw, var(--border-size-xlarge));
 }

--- a/app/views/2017/shared/footer/_about.html.erb
+++ b/app/views/2017/shared/footer/_about.html.erb
@@ -9,7 +9,7 @@
       </div>
 
       <p class="about-us-link">
-        <%= link_to t("footer.about.more_link"), "/about" %>
+        <%= link_to t("footer.about.more_link"), "/about", class: "button" %>
       </p>
     </div>
 
@@ -19,7 +19,7 @@
       </div>
 
       <p class="first-time-link">
-        <%= link_to t("footer.about.first_time_link"), "/start" %>
+        <%= link_to t("footer.about.first_time_link"), "/start", class: "button" %>
       </p>
     </div>
 

--- a/app/views/2017/shared/footer/_newsletter.html.erb
+++ b/app/views/2017/shared/footer/_newsletter.html.erb
@@ -24,7 +24,7 @@
           <div class="response" id="mce-success-response"></div>
         </div>
 
-        <%= button_tag t("footer.contact.newsletter.signup_button_text"), name: "subscribe", class: "button newsletter-signup-button", id: "mc-embedded-subscribe" %>;
+        <%= button_tag t("footer.contact.newsletter.signup_button_text"), name: "subscribe", class: "button newsletter-signup-button", id: "mc-embedded-subscribe" %>
 
         <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
         <% left_or_right = html_dir == 'ltr' ? "position: absolute; left: -5000px;" : "position: absolute; right: -5000px;" %>


### PR DESCRIPTION
# What does this pull request do?

* `app/assets/stylesheets/2017/components/_footer.scss (.footer-sections)`: in-lined 800px to replace that SCSS
`$small-tablet` variable and replaced other media query with a `clamp()`.
`(.footer-section-nav dt)`: replaced the SCSS `font {...}` syntax with CSS.
`(.first-time-link a, .about-us-link a)`: Removed use of SCSS `@extend`.
* `app/assets/stylesheets/sass-to-css-transition.css (:root)`: added `--footer-section-padding` to replace a media query in `_footer.scss`.
* app/views/2017/shared/footer/_about.html.erb: added the `.button` css class to the link to make up for removing the `@extend` in `_footer.scss`.
* `app/views/2017/shared/footer/_newsletter.html.erb`: removed an errant ";" I added in a previous commit.

# Acceptance Criteria
## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to:  https://github.com/crimethinc/website/issues/5349
