### PR TITLE
Update header's "support us" button to replace some SCSS

### DIFF
--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -3,26 +3,21 @@
   background-color: var(--color-true-black);
   padding: var(--border-size-large);
 
-  /* Move SUPPORT US button to left or right based on language direction */
-  .button {
-      inset-inline-end: var(--border-size-large);
-
-      @media screen and (max-width: $small-tablet) { inset-inline-end: var(--border-size-medium); }
-  }
-
   @media screen and (max-width: $small-tablet) {
     padding: var(--border-size-medium);
   }
 
   .button {
-    background: var(--color-blue);
     position: absolute;
-    top: var(--border-size-large);
+    inset-block-start: var(--border-size-large);
+    inset-inline-end: var(--border-size-large);
+    background: var(--color-blue);
 
     @media screen and (max-width: $small-tablet) {
+      inset-block-start: var(--border-size-medium);
+      inset-inline-end: var(--border-size-medium);
       font-size: 12px;
       padding: 0.5em;
-      top: var(--border-size-medium);
     }
   }
 }

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -1,24 +1,14 @@
-/* Move SUPPORT US button to left or right based on language direction */
-html[dir="ltr"] .site-header .button {
-  right: var(--border-size-large);
-}
-html[dir="rtl"] .site-header .button {
-  left: var(--border-size-large);
-}
-
-@media screen and (max-width: $small-tablet) {
-  html[dir="ltr"] .site-header .button {
-    right: var(--border-size-medium);
-  }
-  html[dir="rtl"] .site-header .button {
-    left: var(--border-size-medium);
-  }
-}
-
 .site-header {
   position: relative;
   background-color: var(--color-true-black);
   padding: var(--border-size-large);
+
+  /* Move SUPPORT US button to left or right based on language direction */
+  .button {
+      inset-inline-end: var(--border-size-large);
+
+      @media screen and (max-width: $small-tablet) { inset-inline-end: var(--border-size-medium); }
+  }
 
   @media screen and (max-width: $small-tablet) {
     padding: var(--border-size-medium);


### PR DESCRIPTION
# What does this pull request do?

* `app/assets/stylesheets/2017/components/_header.scss (.site-header .button)`: Use inset-inline-start CSS property rather than left/right.
* `app/assets/stylesheets/2017/components/_header.scss (.site-header)`: nest the inset-inline-end style with the rest of the support button.

# How should this be manually tested?

- view the site header in both rtl and ltr languages

# Is there any background context you want to provide for reviewers?

The logical property, [`inset-inline-end`][0], will adjust to the
writing mode automatically. Logical properties are [supported][1] in
every major browser.

Now that we are using the logical properties, we can nest the
`inset-inline-end` styles with the rest of the support button styles.

I also replaced `top` with its corresponding logical property.

[0]:https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/inset-inline-end
[1]:https://caniuse.com/css-logical-props

# Acceptance Criteria
## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to: https://github.com/crimethinc/website/issues/5349