### PR TITLE
css-refactor: remove unused padding from header nav links

### DIFF
--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -81,9 +81,5 @@
 @media screen and (min-width: $small-tablet) {
   .site-header .nav-link {
     font-size: 1.7rem;
-
-    a {
-      padding: 1rem 0;
-    }
   }
 }


### PR DESCRIPTION
# What does this pull request do?

* app/assets/stylesheets/2017/components/_header.scss (@media screen and (max-width: $small-tablet) .site-header nav): removing padding styles.


# Is there any background context you want to provide for reviewers?

As far as I can tell, this padding has no effect. It might be leftover from a previous design

I tried setting the padding to a large number, and changed locales, but didn't see any effects on the layout:

| Screenshot |
|--------|
| <img width="2880" height="1920" alt="with-large-padding" src="https://github.com/user-attachments/assets/e6891760-38d0-4cf4-8fda-69d7d6c1bdd3" /> | 

# Acceptance Criteria

## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to: https://github.com/crimethinc/website/issues/5349
