### PR TITLE
css-refactor: remove unused CSS in the header

### DIFF
--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -37,11 +37,6 @@
   }
 }
 
-.language-switcher a,
-.language-switcher {
-  color: white !important;
-}
-
 /* nav */
 .primary-navigation {
   margin: 1rem 0 0 0;
@@ -72,7 +67,6 @@
 
 @media screen and (max-width: $small-tablet) {
   .site-header nav {
-    display: block;
     margin-top: 0.4em;
   }
 }


### PR DESCRIPTION
# What does this pull request do?

* app/assets/stylesheets/2017/components/_header.scss: remove unused .language-switcher class

# Is there any background context you want to provide for reviewers?

I don't see any erb views assigning a class of language-switcher anywhere.

Pretty sure its functionality was replaced by [`.subdomain-switcher`][0].

history
---------

- added: https://github.com/crimethinc/website/pull/955/changes#diff-4af0cf93e4b6738bc3d50da17268952e8490783b3cf37c62f1ebb8ac98f3a1aeR55
- usage removed: https://github.com/crimethinc/website/pull/4225/changes#diff-1ae134fe0faff698ed0d994c91c2cd1ebf47ceb35ec7eeefe2b2b5abefde62cbL30

[0]:https://github.com/crimethinc/website/blob/bdcc6885427e2b0f9f5f2089ffc176acb567c17d/app/assets/stylesheets/2017/views/_languages.css#L2


# Acceptance Criteria
## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to: https://github.com/crimethinc/website/issues/5349
