### PR TITLE
css refactor: (_header.scss) replace SCSS with CSS

### DIFF
--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -20,6 +20,12 @@
       padding: 0.5em;
     }
   }
+
+  /* nav */
+  .primary-navigation {
+    margin: 1rem 0 0 0;
+    display: inline-block;
+  }
 }
 
 .header-logo a {
@@ -37,11 +43,6 @@
   }
 }
 
-/* nav */
-.primary-navigation {
-  margin: 1rem 0 0 0;
-  display: inline-block;
-}
 
 .nav-link {
   display: inline-block;

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -7,6 +7,21 @@
     padding: var(--border-size-medium);
   }
 
+  .header-logo a {
+    background: var(--crimethinc-icon-svg);
+    width: 15rem;
+    height: 3rem;
+    overflow: hidden;
+    text-indent: -10000%;
+    white-space: nowrap;
+    display: inline-block;
+
+    @media screen and (max-width: $small-tablet) {
+      width: 10rem;
+      height: 2rem;
+    }
+  }
+
   .button {
     position: absolute;
     inset-block-start: var(--border-size-large);
@@ -50,20 +65,6 @@
   }
 }
 
-.header-logo a {
-  background: var(--crimethinc-icon-svg);
-  width: 15rem;
-  height: 3rem;
-  overflow: hidden;
-  text-indent: -10000%;
-  white-space: nowrap;
-  display: inline-block;
-
-  @media screen and (max-width: $small-tablet) {
-    width: 10rem;
-    height: 2rem;
-  }
-}
 
 
 
@@ -75,7 +76,5 @@
 
 /* larger than $large-phone viewport */
 @media screen and (min-width: $small-tablet) {
-  .site-header .nav-link {
-    font-size: 1.7rem;
-  }
+  .site-header .nav-link { font-size: 1.7rem; }
 }

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -21,10 +21,32 @@
     }
   }
 
-  /* nav */
-  .primary-navigation {
+  /* nav, language link */
+  .primary-navigation, .primary-navigation + ul {
     margin: 1rem 0 0 0;
     display: inline-block;
+
+    .nav-link {
+      display: inline-block;
+      font-size: 1.6rem;
+      letter-spacing: 0.05em;
+      margin-bottom: 1rem;
+      margin-right: 1rem;
+
+      a {
+        text-decoration: none;
+
+        &:link,
+        &:visited {
+          color: var(--color-white);
+        }
+
+        &:hover,
+        &:active {
+          border-bottom: 1px solid var(--color-white);
+        }
+      }
+    }
   }
 }
 
@@ -44,27 +66,6 @@
 }
 
 
-.nav-link {
-  display: inline-block;
-  font-size: 1.6rem;
-  letter-spacing: 0.05em;
-  margin-bottom: 1rem;
-  margin-right: 1rem;
-
-  a {
-    text-decoration: none;
-
-    &:link,
-    &:visited {
-      color: var(--color-white);
-    }
-
-    &:hover,
-    &:active {
-      border-bottom: 1px solid var(--color-white);
-    }
-  }
-}
 
 @media screen and (max-width: $small-tablet) {
   .site-header nav {

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -16,16 +16,16 @@
   padding: var(--_site-header-padding, var(--border-size-large));
 
   .header-logo a {
-    background: var(--crimethinc-icon-svg);
+    display: inline-block;
     width: var(--_site-header-logo-w, 15rem);
     height: var(--_site-header-logo-h, 3rem);
+    background: var(--crimethinc-icon-svg);
     overflow: hidden;
     text-indent: -10000%;
     white-space: nowrap;
-    display: inline-block;
   }
 
-  // support us button
+  /* support us button */
   .button {
        position: absolute;
        inset-block-start: var(--_site-header-support-button-inset, var(--border-size-large));
@@ -39,16 +39,15 @@
 
   /* nav, language link */
   .primary-navigation, .primary-navigation + ul {
-    margin: 1rem 0 0 0;
     display: inline-block;
+    margin: 1rem 0 0 0;
     color: var(--color-white);
 
     .nav-link {
       display: inline-block;
+      margin: 0 1rem 1rem 0;
       font-size: var(--_site-header-nav-font-size, 1.7rem);
       letter-spacing: 0.05em;
-      margin-bottom: 1rem;
-      margin-right: 1rem;
 
       a {
         text-decoration: none;

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -1,53 +1,51 @@
 .site-header {
+  @media screen and (max-width: 800px) {
+    --_site-header-padding: var(--border-size-medium);
+    --_site-header-logo-w: 10rem;
+    --_site-header-logo-h: 2rem;
+    --_site-header-nav-margin: 0.4em 0 0 0;
+    --_site-header-nav-font-size: 1.6rem;
+
+    --_site-header-support-button-font-size: 12px;
+    --_site-header-support-button-padding: 0.5em;
+    --_site-header-support-button-inset: var(--border-size-medium);
+  }
+
   position: relative;
   background-color: var(--color-true-black);
-  padding: var(--border-size-large);
-
-  @media screen and (max-width: $small-tablet) {
-    padding: var(--border-size-medium);
-  }
+  padding: var(--_site-header-padding, var(--border-size-large));
 
   .header-logo a {
     background: var(--crimethinc-icon-svg);
-    width: 15rem;
-    height: 3rem;
+    width: var(--_site-header-logo-w, 15rem);
+    height: var(--_site-header-logo-h, 3rem);
     overflow: hidden;
     text-indent: -10000%;
     white-space: nowrap;
     display: inline-block;
-
-    @media screen and (max-width: $small-tablet) {
-      width: 10rem;
-      height: 2rem;
-    }
   }
 
+  // support us button
   .button {
        position: absolute;
-       inset-block-start: var(--border-size-large);
-       inset-inline-end: var(--border-size-large);
+       inset-block-start: var(--_site-header-support-button-inset, var(--border-size-large));
+       inset-inline-end: var(--_site-header-support-button-inset, var(--border-size-large));
        background: var(--color-blue);
-
-       @media screen and (max-width: $small-tablet) {
-         inset-block-start: var(--border-size-medium);
-         inset-inline-end: var(--border-size-medium);
-         font-size: 12px;
-         padding: 0.5em;
-       }
+       font-size: var(--_site-header-support-button-font-size, inherit);
+       padding: var(--_site-header-support-button-padding, 1rem);
   }
+  
+  nav { margin: var(--_site-header-nav-margin, 0); }
 
   /* nav, language link */
-  @media screen and (max-width: $small-tablet) {
-    nav { margin-top: 0.4em; }
-  }
-
   .primary-navigation, .primary-navigation + ul {
     margin: 1rem 0 0 0;
     display: inline-block;
+    color: var(--color-white);
 
     .nav-link {
       display: inline-block;
-      font-size: 1.6rem;
+      font-size: var(--_site-header-nav-font-size, 1.7rem);
       letter-spacing: 0.05em;
       margin-bottom: 1rem;
       margin-right: 1rem;
@@ -55,19 +53,8 @@
       a {
         text-decoration: none;
 
-        &:link,
-        &:visited {
-          color: var(--color-white);
-        }
-
-        &:hover,
-        &:active {
-          border-bottom: 1px solid var(--color-white);
-        }
-      }
-      /* larger than $large-phone viewport */
-      @media screen and (min-width: $small-tablet) {
-        font-size: 1.7rem;
+        &:link, &:visited { color: currentColor; }
+        &:hover, &:active { border-bottom: 1px solid currentColor; }
       }
     }
   }

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -23,20 +23,24 @@
   }
 
   .button {
-    position: absolute;
-    inset-block-start: var(--border-size-large);
-    inset-inline-end: var(--border-size-large);
-    background: var(--color-blue);
+       position: absolute;
+       inset-block-start: var(--border-size-large);
+       inset-inline-end: var(--border-size-large);
+       background: var(--color-blue);
 
-    @media screen and (max-width: $small-tablet) {
-      inset-block-start: var(--border-size-medium);
-      inset-inline-end: var(--border-size-medium);
-      font-size: 12px;
-      padding: 0.5em;
-    }
+       @media screen and (max-width: $small-tablet) {
+         inset-block-start: var(--border-size-medium);
+         inset-inline-end: var(--border-size-medium);
+         font-size: 12px;
+         padding: 0.5em;
+       }
   }
 
   /* nav, language link */
+  @media screen and (max-width: $small-tablet) {
+    nav { margin-top: 0.4em; }
+  }
+
   .primary-navigation, .primary-navigation + ul {
     margin: 1rem 0 0 0;
     display: inline-block;
@@ -61,20 +65,10 @@
           border-bottom: 1px solid var(--color-white);
         }
       }
+      /* larger than $large-phone viewport */
+      @media screen and (min-width: $small-tablet) {
+        font-size: 1.7rem;
+      }
     }
   }
-}
-
-
-
-
-@media screen and (max-width: $small-tablet) {
-  .site-header nav {
-    margin-top: 0.4em;
-  }
-}
-
-/* larger than $large-phone viewport */
-@media screen and (min-width: $small-tablet) {
-  .site-header .nav-link { font-size: 1.7rem; }
 }

--- a/app/assets/stylesheets/2017/components/_header.scss
+++ b/app/assets/stylesheets/2017/components/_header.scss
@@ -20,9 +20,6 @@
     width: var(--_site-header-logo-w, 15rem);
     height: var(--_site-header-logo-h, 3rem);
     background: var(--crimethinc-icon-svg);
-    overflow: hidden;
-    text-indent: -10000%;
-    white-space: nowrap;
   }
 
   /* support us button */

--- a/app/views/2017/shared/_header.html.erb
+++ b/app/views/2017/shared/_header.html.erb
@@ -1,9 +1,11 @@
 <header class="site-header" id="header">
+  <% logo_class = lite_mode? ? '' : 'visually-hidden' %>
+
   <% if lite_mode? %>
     <p><%= link_to(t("header.site_mode"), url_for_current_path_with_subdomain) %></p>
   <% end %>
 
-  <span class="header-logo"><%= link_to t("site_name"), [:root] %></span>
+  <span class="header-logo"><%= link_to([:root]) { tag.span(class: logo_class) { t("site_name") } } %></span>
 
   <nav>
     <ul class="primary-navigation">


### PR DESCRIPTION
# What does this pull request do?

* app/assets/stylesheets/2017/components/_header.scss: Move the `.primary-navigation` class up to be nested under the `.site-header` class.
* app/assets/stylesheets/2017/components/_header.scss: Move the `.nav-links` class under `.primary-navigation` class.
* app/assets/stylesheets/2017/components/_header.scss: moved the header logo to be nested withing the `.site-header` section.
* app/assets/stylesheets/2017/components/_header.scss: moved the media queries to be nested in their relevant sections.
* app/assets/stylesheets/2017/components/_header.scss: consolidate all of the media queries under a single media query.
* app/assets/stylesheets/2017/components/_header.scss: made the ordering of some properties consistent, replaced some properties with shorthand versions
* app/assets/stylesheets/2017/components/_header.scss (.site-header .header-logo a): removed properties hiding the text as they will be replaced with the .visually-hidden class.
* app/views/2017/shared/_header.html.erb: If the site is in lite mode, render the text in the logo. If not, mark the logo text as .visually-hidden


# How should this be manually tested?

- browsing the site at > 800px
- browsing the site at < 800px
- browsing the site in lite mode
- browsing the site in a locale other than `:en`

# Is there any background context you want to provide for reviewers?
## re commit: `css refactor:(_header.scss) nest .nav-links in .primary-navigation`
 
I also had to add the `.primary-navigation + ul` as part of the
selection so that the link styles will be applied to the
[language link][0] that shows up if you are in a locale other than :en.

[0]:https://github.com/crimethinc/website/blob/e597b7bfea0cfe86548fdf0d751f2bdc8be2deb8/app/views/2017/shared/_header.html.erb#L20-L24

## re commit: `css refactor:(_header.scss) consolidate media queries`

The header only has one breakpoint at 800px. I consolidated the media
queries under a single query. This helps to clarify what is changing,
which is mostly font sizes and paddings.

Followup work can be done to completely eliminate the font and padding
differences by using responsive fonts and paddings (i.e. using
`clamp()`)


# Acceptance Criteria
## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to: #5349 