### PR TITLE
css refactor: set up `@layers` to resolve specificity issues

### DIFF
--- a/app/assets/stylesheets/2017/base/_elements.scss
+++ b/app/assets/stylesheets/2017/base/_elements.scss
@@ -1,130 +1,132 @@
-* {
-  box-sizing: border-box;
-}
-
-html,
-body {
-  font-size: 62.5%;
-  max-width: $large-desktop;
-  margin: 0 auto;
-}
-
-body {
-  margin-bottom: 0;
-  background: var(--color-white);
-  color: var(--color-black);
-  font: {
-    size: $base-font-size;
-    family: $font-body;
+@layer base {
+  * {
+    box-sizing: border-box;
   }
-}
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-a,
-span {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
-}
-
-b,
-strong {
-  font-weight: 700;
-}
-
-i,
-em {
-  font-style: italic;
-}
-
-input[type="search"] {
-  -webkit-appearance: textfield;
-}
-
-main {
-  clear: both;
-  width: 100%;
-  padding: 0 var(--border-size-medium);
-  margin: 0 auto var(--border-size-xlarge) auto;
-}
-
-a {
-  &:link,
-  &:visited,
-  &:hover,
-  &:active {
-    color: var(--color-true-black);
+  html,
+  body {
+    font-size: 62.5%;
+    max-width: $large-desktop;
+    margin: 0 auto;
   }
-}
 
-#article .e-content li a,
-p a {
-  &:link,
-  &:visited,
-  &:hover,
-  &:active {
-    color: #555;
-    text-decoration: underline;
+  body {
+    margin-bottom: 0;
+    background: var(--color-white);
+    color: var(--color-black);
+    font: {
+      size: $base-font-size;
+      family: $font-body;
+    }
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  a,
+  span {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+
+  b,
+  strong {
     font-weight: 700;
   }
 
-  &:hover,
-  &:active {
-    color: var(--color-true-black);
+  i,
+  em {
+    font-style: italic;
   }
-}
 
-video,
-audio,
-img {
-  max-width: 100%;
-  height: auto;
-}
-
-sup {
-  display: inline-block;
-  font: {
-    size: 0.625em;
-    weight: 500;
+  input[type="search"] {
+    -webkit-appearance: textfield;
   }
-  position: relative;
-  top: -0.625em;
-  left: -0.125em;
 
-  > a {
+  main {
+    clear: both;
+    width: 100%;
+    padding: 0 var(--border-size-medium);
+    margin: 0 auto var(--border-size-xlarge) auto;
+  }
+
+  a {
     &:link,
     &:visited,
     &:hover,
     &:active {
-      display: block;
-      text-decoration: none;
+      color: var(--color-true-black);
     }
   }
-}
 
-audio {
-  display: block;
-  margin: {
-    top: var(--border-size-large);
-    bottom: var(--border-size-xlarge);
+  #article .e-content li a,
+  p a {
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
+      color: #555;
+      text-decoration: underline;
+      font-weight: 700;
+    }
+
+    &:hover,
+    &:active {
+      color: var(--color-true-black);
+    }
   }
-  min-height: var(--border-size-xlarge);
-}
 
-.visually-hidden {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  white-space: nowrap;
-  width: 1px;
+  video,
+  audio,
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  sup {
+    display: inline-block;
+    font: {
+      size: 0.625em;
+      weight: 500;
+    }
+    position: relative;
+    top: -0.625em;
+    left: -0.125em;
+
+    > a {
+      &:link,
+      &:visited,
+      &:hover,
+      &:active {
+        display: block;
+        text-decoration: none;
+      }
+    }
+  }
+
+  audio {
+    display: block;
+    margin: {
+      top: var(--border-size-large);
+      bottom: var(--border-size-xlarge);
+    }
+    min-height: var(--border-size-xlarge);
+  }
+
+  .visually-hidden {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
 }

--- a/app/assets/stylesheets/2017/base/_elements.scss
+++ b/app/assets/stylesheets/2017/base/_elements.scss
@@ -117,16 +117,4 @@
     }
     min-height: var(--border-size-xlarge);
   }
-
-  .visually-hidden {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
 }

--- a/app/assets/stylesheets/2017/lib/_reset.css
+++ b/app/assets/stylesheets/2017/lib/_reset.css
@@ -1,129 +1,131 @@
-/* http://meyerweb.com/eric/tools/css/reset/
+@layer reset {
+  /* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
    License: none (public domain)
-*/
+ */
 
-html,
-body,
-div,
-span,
-applet,
-object,
-iframe,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
-dl,
-dt,
-dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
-table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
-th,
-td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
-}
-/* HTML5 display-role reset for older browsers */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-  display: block;
-}
-body {
-  line-height: 1;
-}
-ol,
-ul {
-  list-style: none;
-}
-blockquote,
-q {
-  quotes: none;
-}
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-  content: "";
-  content: none;
-}
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  blockquote,
+  q {
+    quotes: none;
+  }
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: "";
+    content: none;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
 }

--- a/app/assets/stylesheets/2017/lib/_utilities.css
+++ b/app/assets/stylesheets/2017/lib/_utilities.css
@@ -2,4 +2,17 @@
   .screen-reader-only {
     display: none;
   }
+
+  .sr-only,
+  .visually-hidden {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
 }

--- a/app/assets/stylesheets/2017/lib/_utilities.css
+++ b/app/assets/stylesheets/2017/lib/_utilities.css
@@ -1,3 +1,5 @@
-.screen-reader-only {
-  display: none;
+@layer utilities {
+  .screen-reader-only {
+    display: none;
+  }
 }

--- a/app/assets/stylesheets/2017/views/_page.css
+++ b/app/assets/stylesheets/2017/views/_page.css
@@ -1,156 +1,158 @@
-#page {
-  main {
-    margin: var(--border-size-xlarge) auto;
-    max-width: $large-tablet;
+@layer pages {
+  #page {
+    main {
+      margin: var(--border-size-xlarge) auto;
+      max-width: $large-tablet;
 
-    .crumbtrail {
-      text-transform: uppercase;
-      color: var(--color-gray);
-
-      a {
+      .crumbtrail {
+        text-transform: uppercase;
         color: var(--color-gray);
-      }
-    }
 
-    .intro p {
-      font-size: var(--page-intro-font-size, 2.25rem);
-      line-height: 1.5;
-    }
-
-    .h-entry header,
-    header {
-      margin-bottom: var(--border-size-large);
-
-      h1 {
-        font-weight: bold;
-        font-weight: 800;
-        font-size: var(--page-header-h1, 3rem);
-        line-height: 1.25;
-        text-wrap: balance;
-      }
-
-      h2 {
-        font-weight: normal;
-        font-weight: 300;
-        font-size: var(--page-header-h2, 2rem);
-        line-height: 1.25;
-        text-wrap: balance;
-      }
-    }
-
-    .meta {
-      img {
-        /* TODO refactor away */
-        width: 100% !important;
-        height: auto !important;
-      }
-    }
-
-    .e-content {
-      h1 {
-        font-weight: bold;
-        font-weight: 700;
-        font-size: 4rem;
-        line-height: 1.25em;
-        margin-bottom: var(--border-size-small);
-      }
-
-      h2 {
-        font-weight: normal;
-        font-weight: 500;
-        font-size: 3rem;
-        line-height: 1.25em;
-        margin-bottom: var(--border-size-small);
-      }
-
-      h3 {
-        font-weight: lighter;
-        font-weight: 300;
-        font-size: 2.5rem;
-        line-height: 1.25em;
-        margin-bottom: var(--border-size-medium);
-        border-bottom: var(--border-size-xsmall) solid var(--color-gray-light);
-
-        &:first-child {
-          border: none;
+        a {
+          color: var(--color-gray);
         }
       }
 
-      audio {
-        width: 100%;
+      .intro p {
+        font-size: var(--page-intro-font-size, 2.25rem);
+        line-height: 1.5;
       }
 
-      video {
-        width: 100%;
+      .h-entry header,
+      header {
         margin-bottom: var(--border-size-large);
-      }
 
-      .buttons {
-        margin-bottom: var(--border-size-xlarge);
+        h1 {
+          font-weight: bold;
+          font-weight: 800;
+          font-size: var(--page-header-h1, 3rem);
+          line-height: 1.25;
+          text-wrap: balance;
+        }
 
-        .button {
-          margin: 0 var(--border-size-small) var(--border-size-medium) 0;
+        h2 {
+          font-weight: normal;
+          font-weight: 300;
+          font-size: var(--page-header-h2, 2rem);
+          line-height: 1.25;
+          text-wrap: balance;
         }
       }
 
-      li,
-      p {
-        font-size: 1.75rem;
-        line-height: 1.5em;
-        text-rendering: optimizeLegibility;
+      .meta {
+        img {
+          /* TODO refactor away */
+          width: 100% !important;
+          height: auto !important;
+        }
       }
 
-      p {
-        margin-bottom: var(--border-size-large);
+      .e-content {
+        h1 {
+          font-weight: bold;
+          font-weight: 700;
+          font-size: 4rem;
+          line-height: 1.25em;
+          margin-bottom: var(--border-size-small);
+        }
+
+        h2 {
+          font-weight: normal;
+          font-weight: 500;
+          font-size: 3rem;
+          line-height: 1.25em;
+          margin-bottom: var(--border-size-small);
+        }
+
+        h3 {
+          font-weight: lighter;
+          font-weight: 300;
+          font-size: 2.5rem;
+          line-height: 1.25em;
+          margin-bottom: var(--border-size-medium);
+          border-bottom: var(--border-size-xsmall) solid var(--color-gray-light);
+
+          &:first-child {
+            border: none;
+          }
+        }
+
+        audio {
+          width: 100%;
+        }
+
+        video {
+          width: 100%;
+          margin-bottom: var(--border-size-large);
+        }
+
+        .buttons {
+          margin-bottom: var(--border-size-xlarge);
+
+          .button {
+            margin: 0 var(--border-size-small) var(--border-size-medium) 0;
+          }
+        }
+
+        li,
+        p {
+          font-size: 1.75rem;
+          line-height: 1.5em;
+          text-rendering: optimizeLegibility;
+        }
+
+        p {
+          margin-bottom: var(--border-size-large);
+        }
       }
-    }
 
-    li {
-      text-rendering: optimizeLegibility;
-      margin-bottom: var(--border-size-large);
-    }
-
-    ul:not(.pagination),
-    ol:not(.pagination) {
-      margin-bottom: 1em;
-    }
-
-    li ul,
-    li ol {
-      margin-top: 0.5em;
-    }
-
-    ol {
-      list-style-type: numerals;
-    }
-
-    ul {
-      list-style-type: square;
-    }
-
-    dd,
-    dt,
-    li {
-      line-height: 1em;
-    }
-
-    li {
-      margin: 0 0 0.5em 0;
-    }
-
-    .e-content {
       li {
-        margin: 0 0 0.5em 1em;
+        text-rendering: optimizeLegibility;
+        margin-bottom: var(--border-size-large);
       }
 
-      ol li {
-        margin-left: 1.5em;
+      ul:not(.pagination),
+      ol:not(.pagination) {
+        margin-bottom: 1em;
       }
-    }
 
-    li li {
-      margin: 0 0 0 1.5em;
-      line-height: 1.5em;
+      li ul,
+      li ol {
+        margin-top: 0.5em;
+      }
+
+      ol {
+        list-style-type: numerals;
+      }
+
+      ul {
+        list-style-type: square;
+      }
+
+      dd,
+      dt,
+      li {
+        line-height: 1em;
+      }
+
+      li {
+        margin: 0 0 0.5em 0;
+      }
+
+      .e-content {
+        li {
+          margin: 0 0 0.5em 1em;
+        }
+
+        ol li {
+          margin-left: 1.5em;
+        }
+      }
+
+      li li {
+        margin: 0 0 0 1.5em;
+        line-height: 1.5em;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/2017/views/_podcast.scss
+++ b/app/assets/stylesheets/2017/views/_podcast.scss
@@ -1,17 +1,3 @@
-/* HACK: overly specific override of _page.scss, will go away in 2.0 redesign's CSS */
-#podcast {
-  main {
-    .e-content {
-      h1 {
-        font: {
-          weight: normal;
-          size: 2rem;
-        }
-      }
-    }
-  }
-}
-
 #podcast {
   main {
 
@@ -25,6 +11,13 @@
         }
 
         margin-bottom: var(--border-size-medium);
+      }
+    }
+
+    .other-episodes {
+      h1 {
+        font-weight: normal;
+        font-size: 2rem;
       }
     }
 

--- a/app/assets/stylesheets/2017/views/_read_watch.scss
+++ b/app/assets/stylesheets/2017/views/_read_watch.scss
@@ -1,96 +1,98 @@
-#page {
-  main {
-    p {
-      font-size: 2rem;
-      line-height: 1.25em;
-      margin-bottom: 1em;
-    }
-
-    #years a {
-      font-variant-numeric: tabular-nums;
-    }
-
-    #years a,
-    #categroies a {
-      border-right: 1px solid #ccc;
-      padding-right: 0.75em;
-      margin-right: 0.5em;
-      font-weight: normal;
-    }
-
-    #years a:last-child,
-    #categroies a:last-child {
-      border-right: none;
-    }
-
-    #theme,
-    #years,
-    #samples {
-      margin-top: 3em;
-    }
-
-    .h-entry {
-      margin: 0 0 2em 0;
-      padding: 0 0.65em;
-      h1 {
-        font: {
-          weight: lighter;
-          weight: 300;
-          size: 3rem;
-        }
-        border-bottom: 1px solid var(--color-gray-light);
-        padding-bottom: var(--border-size-small);
+@layer pages {
+  #page {
+    main {
+      p {
+        font-size: 2rem;
+        line-height: 1.25em;
+        margin-bottom: 1em;
       }
 
-      img {
-        margin-top: 1rem;
-
-        @media screen and (min-width: $small-tablet) {
-          width: auto;
-        }
+      #years a {
+        font-variant-numeric: tabular-nums;
       }
 
-      ul {
-        margin-top: 2rem;
+      #years a,
+      #categroies a {
+        border-right: 1px solid #ccc;
+        padding-right: 0.75em;
+        margin-right: 0.5em;
+        font-weight: normal;
       }
 
-      &.section li:first-child {
-        font: {
-          weight: bold;
-          weight: 700;
-          size: 1.5em;
+      #years a:last-child,
+      #categroies a:last-child {
+        border-right: none;
+      }
+
+      #theme,
+      #years,
+      #samples {
+        margin-top: 3em;
+      }
+
+      .h-entry {
+        margin: 0 0 2em 0;
+        padding: 0 0.65em;
+        h1 {
+          font: {
+            weight: lighter;
+            weight: 300;
+            size: 3rem;
+          }
+          border-bottom: 1px solid var(--color-gray-light);
+          padding-bottom: var(--border-size-small);
         }
 
-        line-height: 1.2em;
-        list-style-type: none;
-        margin-left: 0;
-      }
+        img {
+          margin-top: 1rem;
 
-      .video-info {
-        font-style: italic;
-        color: var(--color-gray);
-      }
-    } /* .h-entry */
+          @media screen and (min-width: $small-tablet) {
+            width: auto;
+          }
+        }
 
-    #samples {
-      .column:first-child {
-        padding-left: 0;
-      }
-      .column:last-child {
-        padding-rigth: 0;
-      }
+        ul {
+          margin-top: 2rem;
+        }
 
-      li {
-        margin-left: 1.5em;
-      }
+        &.section li:first-child {
+          font: {
+            weight: bold;
+            weight: 700;
+            size: 1.5em;
+          }
 
-      li:first-child {
-        margin-left: 0;
-      }
-    }
-  } /* main */
-} /* #page */
+          line-height: 1.2em;
+          list-style-type: none;
+          margin-left: 0;
+        }
 
-#library header img {
-  margin-top: 2rem;
+        .video-info {
+          font-style: italic;
+          color: var(--color-gray);
+        }
+      } /* .h-entry */
+
+      #samples {
+        .column:first-child {
+          padding-left: 0;
+        }
+        .column:last-child {
+          padding-rigth: 0;
+        }
+
+        li {
+          margin-left: 1.5em;
+        }
+
+        li:first-child {
+          margin-left: 0;
+        }
+      }
+    } /* main */
+  } /* #page */
+
+  #library header img {
+    margin-top: 2rem;
+  }
 }

--- a/app/assets/stylesheets/2017/views/support.css
+++ b/app/assets/stylesheets/2017/views/support.css
@@ -246,18 +246,6 @@ label[for=amount_slider]  {
   color: #444;
 }
 
-.visually-hidden,
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0,0,0,0);
-  border: 0;
-}
-
 /* Generated using: http://danielstern.ca/range.css */
 #amount_slider {
   -webkit-appearance: none;

--- a/app/assets/stylesheets/sass-to-css-transition.css
+++ b/app/assets/stylesheets/sass-to-css-transition.css
@@ -1,5 +1,6 @@
 /* TODO: In-line the CSS in this file to the relevant files once the
    SASS preprocessor is removed. */
+@layer reset, base, pages, components, utilities;
 
 :root {
   /*

--- a/app/views/2017/shared/head/_stylesheets.html.erb
+++ b/app/views/2017/shared/head/_stylesheets.html.erb
@@ -1,4 +1,5 @@
 <!-- CSS -->
+<%= stylesheet_link_tag "sass-to-css-transition", media: :all %>
 <%= stylesheet_link_tag Current.theme, media: "all" unless lite_mode? %>
 
 <style>

--- a/app/views/layouts/2017/_application.html.erb
+++ b/app/views/layouts/2017/_application.html.erb
@@ -8,7 +8,7 @@
     <%= render_themed "shared/head" %>
 
     <%= yield :head %>
-    <%= stylesheet_link_tag "sass-to-css-transition", media: :all %>
+
     <% if content_for(:javascript).present? %>
       <%= javascript_importmap_tags %>
       <%= yield :javascript %>


### PR DESCRIPTION
# What does this pull request do?

* `app/assets/stylesheets/sass-to-css-transition.css`: Set up several `@layers` which will be used to organize the CSS into.
* `app/views/2017/shared/head/_stylesheets.html.erb`: Move the loading of sass-to-css-transition to be before all other CSS.
* `app/views/layouts/2017/_application.html.erb`: Move the loading of sass-to-css-transition to `_stylesheets.html.erb`.
* `app/assets/stylesheets/2017/base/_elements.scss`: move `_elements.scss` to the `@layer base`
* `app/assets/stylesheets/2017/views/_page.css`: move `_page.css` to the `@layer pages`
* `app/assets/stylesheets/2017/views/_read_watch.scss`: move `_read_watch.css` to the `@layer pages`
* `app/assets/stylesheets/2017/lib/_utilities.css`: move `_utilities.css` to the `@layer utilities`
* `app/assets/stylesheets/2017/lib/_reset.css`: move `_reset.css` to the `@layer reset`
* `app/assets/stylesheets/2017/base/_elements.scss`: move the `.visually-hidden` class to `utilities.css`
* `app/assets/stylesheets/2017/views/support.css`: move the `.visually-hidden` class to `utilities.css`
* `app/assets/stylesheets/2017/views/_podcast.scss`: Removed the HACK code and moved it to a `.other-episodes` class

# How should this be manually tested?

* The podcast episodes page is a good before/after to check (e.g. https://crimethinc.com/podcasts/the-ex-worker)

# Is there any background context you want to provide for reviewers?

`@layer` rules are widely supported[^1] and will allow us to set precedence for the CSS rules[^2].

The main issue I want to solve is that throughout the 2017 theme there
are many `#id` selector rules in use. The especially tricky one is the
`#page` selector, since that is loaded on multiple pages and wraps the
whole page. This means rules defined in `_page.css` will always take
precedence.

Putting the `#page {...}` rules in a lower layer let's other style's,
such as `_podcasts`, manage their own styles without having to rely on
overly specific rules to set the styles[^3].

[^1]: 94.82% on caniuse https://caniuse.com/mdn-css_at-rules_layer
[^2]: MDN docs https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@layer
[^3]: There is a change in this PR to the podcast styles that demonstrates this.

In this PR I just set up some typical layers, and then wrap a few of the existing files in those layers. As a demo of the effect, I replaced a podcast style with a class style.

### re: the diff on github

you're going to want to make sure "ignore whitespace" is on for seeing what is going on in the diff:

| diff no whitespace |
|--------|
|  <img width="2880" height="1920" alt="diff-no-whitespace" src="https://github.com/user-attachments/assets/1ff2ab90-c8b6-4a59-8205-a86a48fc9106" /> | 

# Acceptance Criteria
## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to: #5349 