### PR TITLE
css refactor: (_elements.scss) move common link styling to `@layer base`

### DIFF
--- a/app/assets/stylesheets/2017/base/_elements.scss
+++ b/app/assets/stylesheets/2017/base/_elements.scss
@@ -1,4 +1,11 @@
 @layer base {
+  :root {
+    --link-underline-thickness: var(--_link-underline-thickness, .15ch);
+    --link-underline-offset: var(--_link-underline-offset, 0.1em);
+    --link-color: var(--_link-color, currentColor);
+    --link-hover-color: oklch(from currentColor calc(l - 50) c h);
+  }
+
   * {
     box-sizing: border-box;
   }
@@ -55,30 +62,32 @@
     margin: 0 auto var(--border-size-xlarge) auto;
   }
 
-  a {
-    &:link,
-    &:visited,
-    &:hover,
-    &:active {
-      color: var(--color-true-black);
+
+  a, a:link, a:visited, a:hover, a:active {
+    color: var(--link-color);
+
+    &:has(h1,h2) { text-decoration: none;  }
+  }
+
+  nav a {
+    color: var(--link-color);
+
+    &:link, &:visited { text-decoration: none; }
+    &:hover, &:active {
+      text-decoration: underline solid currentColor var(--link-underline-thickness);
+      text-underline-offset: var(--link-underline-offset);
     }
   }
 
-  #article .e-content li a,
   p a {
-    &:link,
-    &:visited,
-    &:hover,
-    &:active {
-      color: #555;
-      text-decoration: underline;
+    color: var(--link-color);
+
+    &:link, &:visited, &:hover, &:active {
+      text-decoration: underline solid currentColor var(--link-underline-thickness);
+      text-underline-offset: var(--link-underline-offset);
       font-weight: 700;
     }
-
-    &:hover,
-    &:active {
-      color: var(--color-true-black);
-    }
+    &:hover, &:active { color: var(--link-hover-color); }
   }
 
   video,

--- a/app/assets/stylesheets/2017/components/_buttons.css
+++ b/app/assets/stylesheets/2017/components/_buttons.css
@@ -4,7 +4,7 @@
   padding: 1rem;
   text-decoration: none;
   text-transform: uppercase;
-  color: var(--color-white) !important;
+  color: var(--color-white);
   border: var(--border-size-xsmall) solid var(--color-true-black);
   border-radius: 2px;
 }

--- a/app/assets/stylesheets/2017/components/_footer.css
+++ b/app/assets/stylesheets/2017/components/_footer.css
@@ -50,13 +50,7 @@ footer#site-footer {
   .footer-section.footer-section-nav {
     a {
       color: var(--color-true-black);
-      text-decoration: none;
       line-height: 1.5em;
-
-      &:hover,
-      &:active {
-        border-bottom: var(--border-size-xsmall) solid var(--color-true-black);
-      }
     }
 
     dl {
@@ -104,8 +98,7 @@ footer#site-footer {
     .first-time-link a,
     .about-us-link a {
       background: var(--color-white);
-      color: var(--color-true-black) !important;
-      text-decoration: none;
+      color: var(--color-true-black);
       text-align: right;
       display: block;
     }

--- a/app/assets/stylesheets/2017/components/_header.css
+++ b/app/assets/stylesheets/2017/components/_header.css
@@ -45,13 +45,6 @@
       margin: 0 1rem 1rem 0;
       font-size: var(--_site-header-nav-font-size, 1.7rem);
       letter-spacing: 0.05em;
-
-      a {
-        text-decoration: none;
-
-        &:link, &:visited { color: currentColor; }
-        &:hover, &:active { border-bottom: 1px solid currentColor; }
-      }
     }
   }
 }

--- a/app/assets/stylesheets/2017/views/_page.css
+++ b/app/assets/stylesheets/2017/views/_page.css
@@ -8,9 +8,7 @@
         text-transform: uppercase;
         color: var(--color-gray);
 
-        a {
-          color: var(--color-gray);
-        }
+        a { text-decoration: none; }
       }
 
       .intro p {


### PR DESCRIPTION
# What does this pull request do?

* app/assets/stylesheets/2017/base/_elements.scss: moved common link styling into this layer.
* app/assets/stylesheets/2017/components/_buttons.css: remove a now uneeded `!important`
* app/assets/stylesheets/2017/components/_footer.css: remove a now uneeded `!important` and common link styles.
* app/assets/stylesheets/2017/components/_header.css: remove common link styles.
* app/assets/stylesheets/2017/components/_pagination.css: make pagination links black.
* app/assets/stylesheets/2017/views/_page.css: make breadcrumb link have no underline.

# How should this be manually tested?

??

# Is there any background context you want to provide for reviewers?

This also let me remove a couple of `!important` usages.

The common link styling is set so:

1. links in a `nav` element (e.g. site header and footer)
  - have no underline by default
  - get an underline when hovered
2. links that wrap an `h1` or `h2` (e.g. the articles category index)
  - have no underline by default
  - do no get an underline when hovered
3. links in a `p` or an `li` (e.g. article text)
  - have underline by default
  - get slightly darker when hovered



# Acceptance Criteria
## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

related-to: https://github.com/crimethinc/website/issues/5349
