### PR TITLE
css refactor: (_elements.scss) replace SCSS with CSS

### DIFF
--- a/app/assets/stylesheets/2017/base/_elements.scss
+++ b/app/assets/stylesheets/2017/base/_elements.scss
@@ -13,7 +13,7 @@
   html,
   body {
     font-size: 62.5%;
-    max-width: $large-desktop;
+    max-width: var(--large-desktop);
     margin: 0 auto;
   }
 
@@ -21,10 +21,8 @@
     margin-bottom: 0;
     background: var(--color-white);
     color: var(--color-black);
-    font: {
-      size: $base-font-size;
-      family: $font-body;
-    }
+    font-size: var(--font-base-size);
+    font-family: var(--font-body);
   }
 
   h1,
@@ -99,10 +97,8 @@
 
   sup {
     display: inline-block;
-    font: {
-      size: 0.625em;
-      weight: 500;
-    }
+    font-size: 0.625em;
+    font-weight: 500;
     position: relative;
     top: -0.625em;
     left: -0.125em;
@@ -120,10 +116,8 @@
 
   audio {
     display: block;
-    margin: {
-      top: var(--border-size-large);
-      bottom: var(--border-size-xlarge);
-    }
+    margin-top: var(--border-size-large);
+    margin-bottom: var(--border-size-xlarge);
     min-height: var(--border-size-xlarge);
   }
 }

--- a/app/assets/stylesheets/2017/base/variables/_typography.scss
+++ b/app/assets/stylesheets/2017/base/variables/_typography.scss
@@ -1,12 +1,18 @@
-:root {
-  --crimethinc-icon-svg: url("crimethinc-logo-type-white.svg")
-                         center center / contain no-repeat
-                         scroll border-box padding-box transparent;
-}
-
 $base-font-size: 1.6rem;
 
 $family-system: system, -apple-system, BlinkMacSystemFont, ‘Segoe UI’, Roboto, Oxygen, Ubuntu, Cantarell, ‘Open Sans’, ‘Helvetica Neue’, sans-serif;
 
 $font-headings: $family-system;
 $font-body:     $family-system;
+
+:root {
+  --crimethinc-icon-svg: url("crimethinc-logo-type-white.svg")
+                         center center / contain no-repeat
+                         scroll border-box padding-box transparent;
+
+  --font-base-size: 1.6rem;
+  --font-family-system: system, -apple-system, BlinkMacSystemFont, ‘Segoe UI’, Roboto, Oxygen, Ubuntu, Cantarell, ‘Open Sans’, ‘Helvetica Neue’, sans-serif;
+  
+  --font-headings: var(--font-family-system);
+  --font-body:     var(--font-family-system);
+}

--- a/app/assets/stylesheets/2017/base/variables/_viewports.scss
+++ b/app/assets/stylesheets/2017/base/variables/_viewports.scss
@@ -11,3 +11,16 @@ $large-desktop:  1920px;
 
 $standard-def : "(-webkit-max-device-pixel-ratio: 1.49), (max-resolution: 143.9dpi), (max-resolution: 1.5dppx)";
 $retina :       "(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi), (min-resolution: 1.49dppx)";
+
+:root {
+  --small-phone:     480px;
+  --large-phone:     640px;
+  --small-tablet:    800px;
+  --large-tablet:    960px;
+  --small-laptop:   1120px;
+  --medium-laptop:  1280px;
+  --large-laptop:   1440px;
+  --small-desktop:  1000px;
+  --medium-desktop: 1760px;
+  --large-desktop:  1920px;
+}


### PR DESCRIPTION
# What does this pull request do?

* `app/assets/stylesheets/2017/base/_elements.scss`: replace somoe SCSS syntax with CSS versions.
* `app/assets/stylesheets/2017/base/variables/_typography.scss`: create CSS versions of the typography variables.
* `app/assets/stylesheets/2017/base/variables/_viewports.scss`: create CSS versions of the viewport variables.


# How should this be manually tested?

To test the typography changes I used a color font. I applied this patch:

```diff
diff --git a/app/assets/stylesheets/2017/base/_elements.scss b/app/assets/stylesheets/2017/base/_elements.scss
index 98f6373a..7e0d64db 100644
--- a/app/assets/stylesheets/2017/base/_elements.scss
+++ b/app/assets/stylesheets/2017/base/_elements.scss
@@ -25,0 +26 @@
+    font-palette: --myPalette;
diff --git a/app/assets/stylesheets/2017/base/variables/_typography.scss b/app/assets/stylesheets/2017/base/variables/_typography.scss
index b24423fa..fec665e3 100644
--- a/app/assets/stylesheets/2017/base/variables/_typography.scss
+++ b/app/assets/stylesheets/2017/base/variables/_typography.scss
@@ -14 +14 @@ $font-body:     $family-system;
-  --font-family-system: system, -apple-system, BlinkMacSystemFont, ‘Segoe UI’, Roboto, Oxygen, Ubuntu, Cantarell, ‘Open Sans’, ‘Helvetica Neue’, sans-serif;
+  --font-family-system: Nabla, system, -apple-system, BlinkMacSystemFont, ‘Segoe UI’, Roboto, Oxygen, Ubuntu, Cantarell, ‘Open Sans’, ‘Helvetica Neue’, sans-serif;
diff --git a/app/assets/stylesheets/sass-to-css-transition.css b/app/assets/stylesheets/sass-to-css-transition.css
index eba45988..3e2ca283 100644
--- a/app/assets/stylesheets/sass-to-css-transition.css
+++ b/app/assets/stylesheets/sass-to-css-transition.css
@@ -0,0 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Nabla&display=swap');
+@font-palette-values --myPalette {
+  font-family: "Nabla";
+  base-palette: 1;
+}
+
```

and then browsed the site:

| homepage example | article example |
|--------|--------|
| <img width="2880" height="1920" alt="homepage-example" src="https://github.com/user-attachments/assets/50d514a4-8152-489c-85a2-5b52a0e3fefc" /> | <img width="2880" height="1920" alt="article-example" src="https://github.com/user-attachments/assets/f0f9fdf2-f4e3-4328-8212-3a094ac767b8" /> | 

## followup work

I noticed there are some form elements not using the site's font-system (see screenshot on PR). As a followup, we could also style those form elements if so desired.

in the below screenshot you can see the useragent fonts are being used in

- the search boxes
- the dropdown select
- the email address input

| example of unstyled form elements |
|--------|
| <img width="2880" height="1920" alt="form-elements-font" src="https://github.com/user-attachments/assets/c65b7bbf-e78e-4c5e-9adf-24cf0f065505" /> | 
 

# Is there any background context you want to provide for reviewers?

The remaining SCSS in `_elements.scss` was pretty minimal. There were a couple of `margin {...}` or `font {...}` blocks that had to be unrolled.

The other major thing was creating CSS variable versions of the SCSS typography and viewport variables. The SCSS variable versions will eventually go away, but until all the 2017 theme is converted I left them in place.


# Acceptance Criteria
## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

- related-to: https://github.com/crimethinc/website/issues/5349
- related-to: https://github.com/crimethinc/website/pull/5362
