### PR TITLE
css-refactor: replace remaining component SCSS with CSS

### DIFF
--- a/app/assets/stylesheets/2017/components/_classifications.scss
+++ b/app/assets/stylesheets/2017/components/_classifications.scss
@@ -22,7 +22,7 @@
   .categories {
     display: none;
 
-    @media screen and (min-width: $small-tablet) {
+    @media screen and (min-width: 800px) {
       display: block;
       margin-bottom: 0.5em;
     }

--- a/app/assets/stylesheets/2017/components/_embeds.scss
+++ b/app/assets/stylesheets/2017/components/_embeds.scss
@@ -12,20 +12,20 @@ figure {
   video {
     height: 56.25vw;
     margin: 1em auto 0;
-    max-height: $large-phone;
-    max-width: $small-laptop;
+    max-height: var(--large-phone);
+    max-width: var(--small-laptop);
     width: 100%;
 
-    @media screen and (min-width: $small-tablet) {
+    @media screen and (min-width: 800px) {
       height: calc(56.25vw - 50pt);
     }
 
-    @media screen and (min-width: $small-laptop) {
+    @media screen and (min-width: 1120px) {
       height: 56.25vw;
     }
 
     .column-half & {
-      @media screen and (min-width: $large-phone) {
+      @media screen and (min-width: 640px) {
         height: calc((56.25vw / 2) - 2rem);
         max-height: 26rem;
       }
@@ -34,7 +34,7 @@ figure {
 
   audio {
     margin: 0 auto;
-    max-width: $large-phone;
+    max-width: var(--large-phone);
     width: 100%;
   }
 }
@@ -44,13 +44,13 @@ figcaption {
   font-weight: 300;
   font-size: 1rem;
   margin: 0.5em auto 1em auto;
-  max-width: $small-laptop;
+  max-width: var(--small-laptop);
 
   &.video-caption-giphy {
     margin-top: 3rem;
   }
 
-  @media screen and (min-width: $small-tablet) {
+  @media screen and (min-width: 800px) {
     font-size: 1.6rem;
   }
 }

--- a/app/assets/stylesheets/2017/components/_grid.scss
+++ b/app/assets/stylesheets/2017/components/_grid.scss
@@ -1,4 +1,4 @@
-@media screen and (min-width: $large-phone) {
+@media screen and (min-width: 640px) {
   .row {
     display: flex;
   }

--- a/app/assets/stylesheets/2017/components/_story_cards.scss
+++ b/app/assets/stylesheets/2017/components/_story_cards.scss
@@ -32,7 +32,7 @@
   text-align: right;
   line-height: 1.25em;
 
-  @media screen and (min-width: $small-tablet) {
+  @media screen and (min-width: 800px) {
     display: inline-block;
   }
 


### PR DESCRIPTION
# What does this pull request do?

* app/assets/stylesheets/2017/components/_classifications.scss: inline media query breakpoint.
* app/assets/stylesheets/2017/components/_embeds.scss: inline media query breakpoints and use CSS variables.
* app/assets/stylesheets/2017/components/_grid.scss: inline media query breakpoint.
* app/assets/stylesheets/2017/components/_story_cards.scss: inline media query breakpoint.


# Is there any background context you want to provide for reviewers?

These are the last remaining files in `stylesheets/2017/components/` that contain SCSS. After getting these renamed in a followup, I will continue on to converting the `stylesheets/2017/views/` directory.

---

- related-to: https://github.com/crimethinc/website/issues/5349
