### PR TITLE
specs: Refactor tools_index_pages_spec

### DIFF
--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,4 +1,3 @@
 FactoryBot.define do
-  factory :book, parent: :tool, class: Book do
-  end
+  factory :book, parent: :tool, class: 'Book'
 end

--- a/spec/factories/issues.rb
+++ b/spec/factories/issues.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :issue, parent: :tool, class: Issue do
+  factory :issue, parent: :tool, class: 'Issue' do
     journal
     title { 'Issue 1' }
     slug { 'issue-1' }

--- a/spec/factories/journals.rb
+++ b/spec/factories/journals.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :journal, parent: :tool, class: Journal do
+  factory :journal, parent: :tool, class: 'Journal' do
     title { 'Rolling Thunder' }
     slug { 'rolling-thunder' }
   end

--- a/spec/factories/logos.rb
+++ b/spec/factories/logos.rb
@@ -1,4 +1,3 @@
 FactoryBot.define do
-  factory :logo, parent: :tool, class: Logo do
-  end
+  factory :logo, parent: :tool, class: 'Logo'
 end

--- a/spec/factories/posters.rb
+++ b/spec/factories/posters.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :poster, parent: :tool, class: Poster do
+  factory :poster, parent: :tool, class: 'Poster' do
     trait :sticker do
       sticker { true }
     end

--- a/spec/factories/stickers.rb
+++ b/spec/factories/stickers.rb
@@ -1,4 +1,3 @@
 FactoryBot.define do
-  factory :sticker, parent: :tool, class: Sticker do
-  end
+  factory :sticker, parent: :tool, class: 'Sticker'
 end

--- a/spec/factories/tools.rb
+++ b/spec/factories/tools.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :tool do
-    sequence(:title) { "tool title #{_1}" }
-    sequence(:subtitle) { "tool title #{_1}" }
+    sequence(:title) { "tool title #{it}" }
+    sequence(:subtitle) { "tool title #{it}" }
 
     transient do
       uploads { [] }

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -1,4 +1,3 @@
 FactoryBot.define do
-  factory :video, parent: :tool, class: Video do
-  end
+  factory :video, parent: :tool, class: 'Video'
 end

--- a/spec/factories/zines.rb
+++ b/spec/factories/zines.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :zine, parent: :tool, class: Zine do
+  factory :zine, parent: :tool, class: 'Zine' do
     locale { 'en' }
 
     after(:build) do |tool|

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -5,9 +5,10 @@ describe 'Tools pages' do
     Current.theme = '2017'
   end
 
-  it 'renders published logos calling /logos' do
-    test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
+  def test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
+  def test_pdf   = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')
 
+  it 'renders published logos calling /logos' do
     logo = create(:logo,
                   title:              'published',
                   published_at:       1.day.ago,
@@ -32,10 +33,6 @@ describe 'Tools pages' do
   end
 
   it 'renders published stickers calling /stickers' do
-    first_test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
-    second_test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
-    third_test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
-
     first_sticker = create(:sticker,
                            title:              'published',
                            published_at:       1.day.ago,
@@ -50,9 +47,9 @@ describe 'Tools pages' do
                            title:              'draft',
                            publication_status: 'draft')
 
-    first_sticker.image_front_color_image.attach first_test_image
-    second_sticker.image_front_color_image.attach second_test_image
-    third_sticker.image_front_color_image.attach third_test_image
+    first_sticker.image_front_color_image.attach test_image
+    second_sticker.image_front_color_image.attach test_image
+    third_sticker.image_front_color_image.attach test_image
 
     visit :stickers
 
@@ -84,13 +81,6 @@ describe 'Tools pages' do
   end
 
   it 'renders published posters calling /posters' do
-    first_test_pdf    = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')
-    first_test_image  = fixture_file_upload('spec/fixtures/files/test_image.jpg', 'image/jpg')
-    second_test_pdf   = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')
-    second_test_image = fixture_file_upload('spec/fixtures/files/test_image.jpg', 'image/jpg')
-    third_test_pdf    = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')
-    third_test_image  = fixture_file_upload('spec/fixtures/files/test_image.jpg', 'image/jpg')
-
     first_poster = create(:poster,
                           title:              'published',
                           published_at:       1.day.ago,
@@ -105,12 +95,12 @@ describe 'Tools pages' do
                           title:              'draft',
                           publication_status: 'draft')
 
-    first_poster.image_front_color_download.attach first_test_pdf
-    first_poster.image_front_color_image.attach first_test_image
-    second_poster.image_front_color_download.attach second_test_pdf
-    second_poster.image_front_color_image.attach second_test_image
-    third_poster.image_front_color_download.attach third_test_pdf
-    third_poster.image_front_color_image.attach third_test_image
+    first_poster.image_front_color_download.attach test_pdf
+    first_poster.image_front_color_image.attach test_image
+    second_poster.image_front_color_download.attach test_pdf
+    second_poster.image_front_color_image.attach test_image
+    third_poster.image_front_color_download.attach test_pdf
+    third_poster.image_front_color_image.attach test_image
 
     visit :posters
 

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -19,63 +19,65 @@ describe 'Tools pages' do
   end
 
   describe '/logos' do
-    before do
-      logo = create(:logo, :live, title: 'published')
-      logo.image_jpg.attach test_image
+    let(:uploads) { [[:image_jpg, test_image]] }
 
-      create(:logo, :published, :not_live, title: 'not live')
-      create(:logo, :draft, title: 'draft')
+    before do
+      create(:logo, :live, title: 'published', uploads: uploads)
+      create(:logo, :published, :not_live, title: 'not live', uploads: uploads)
+      create(:logo, :draft, title: 'draft', uploads: uploads)
     end
 
     it_behaves_like "renders published tool type for the path", :logos
   end
 
   describe '/stickers' do
-    before do
-      first_sticker = create(:sticker, :live, title: 'published')
-      second_sticker = create(:sticker, :not_live, title: 'not live')
-      third_sticker = create(:sticker, :draft, title: 'draft')
+    let(:uploads) { [[:image_front_color_image, test_image]] }
 
-      first_sticker.image_front_color_image.attach test_image
-      second_sticker.image_front_color_image.attach test_image
-      third_sticker.image_front_color_image.attach test_image
+    before do
+      create(:sticker, :live, title: 'published', uploads: uploads)
+      create(:sticker, :not_live, title: 'not live', uploads: uploads)
+      create(:sticker, :draft, title: 'draft', uploads: uploads)
     end
 
     it_behaves_like "renders published tool type for the path", :stickers
   end
 
   describe '/zines' do
+    let(:uploads) { [] }
+
     before do
-      create(:zine, :live, title: 'published')
-      create(:zine, :not_live, title: 'not live')
-      create(:zine, :draft, title: 'draft')
+      create(:zine, :live, title: 'published', uploads: uploads)
+      create(:zine, :not_live, title: 'not live', uploads: uploads)
+      create(:zine, :draft, title: 'draft', uploads: uploads)
     end
 
     it_behaves_like "renders published tool type for the path", :zines
   end
 
   describe '/posters' do
-    before do
-      first_poster = create(:poster, :live, title: 'published')
-      second_poster = create(:poster, :not_live, title: 'not live')
-      third_poster = create(:poster, :draft, title: 'draft')
+    let(:uploads) do
+      [
+        [:image_front_color_download, test_pdf],
+        [:image_front_color_image, test_image]
+      ]
+    end
 
-      first_poster.image_front_color_download.attach test_pdf
-      first_poster.image_front_color_image.attach test_image
-      second_poster.image_front_color_download.attach test_pdf
-      second_poster.image_front_color_image.attach test_image
-      third_poster.image_front_color_download.attach test_pdf
-      third_poster.image_front_color_image.attach test_image
+    before do
+      create(:poster, :live, title: 'published', uploads: uploads)
+      create(:poster, :not_live, title: 'not live', uploads: uploads)
+      create(:poster, :draft, title: 'draft', uploads: uploads)
     end
 
     it_behaves_like "renders published tool type for the path", :posters
   end
 
   describe '/videos' do
+    let(:uploads) { [[:image_poster_frame, test_image]] }
+
     before do
-      create(:video, :live, title: 'published')
-      create(:video, :not_live, title: 'not live')
-      create(:video, :draft, title: 'draft')
+      create(:video, :live, title: 'published', uploads: uploads)
+      create(:video, :not_live, title: 'not live', uploads: uploads)
+      create(:video, :draft, title: 'draft', uploads: uploads)
     end
 
     it_behaves_like "renders published tool type for the path", :videos

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -4,13 +4,19 @@ describe 'Tools pages' do
   before {  Current.theme = '2017' }
 
   def test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
-  def test_pdf   = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')
+  def test_pdf   = fixture_file_upload 'spec/fixtures/files/test_pdf.pdf',   'image/pdf'
 
   shared_examples "renders published tool type for the path" do |tool|
-    let(:tool) { tool.to_sym }
+    let(:uploads) { [] }
 
-    it "renders published logos calling /#{tool}" do
-      visit tool
+    before do
+      create(tool, :live, title: 'published', uploads: uploads)
+      create(tool, :published, :not_live, title: 'not live', uploads: uploads)
+      create(tool, :draft, title: 'draft', uploads: uploads)
+    end
+
+    it "renders published logos calling /#{tool.to_s.pluralize}" do
+      visit tool.to_s.pluralize.to_sym
 
       expect(page).to have_text 'published'
       expect(page).to have_no_text 'draft'
@@ -19,67 +25,37 @@ describe 'Tools pages' do
   end
 
   describe '/logos' do
-    let(:uploads) { [[:image_jpg, test_image]] }
-
-    before do
-      create(:logo, :live, title: 'published', uploads: uploads)
-      create(:logo, :published, :not_live, title: 'not live', uploads: uploads)
-      create(:logo, :draft, title: 'draft', uploads: uploads)
+    it_behaves_like "renders published tool type for the path", :logo do
+      let(:uploads) { [[:image_jpg, test_image]] }
     end
-
-    it_behaves_like "renders published tool type for the path", :logos
   end
 
   describe '/stickers' do
-    let(:uploads) { [[:image_front_color_image, test_image]] }
-
-    before do
-      create(:sticker, :live, title: 'published', uploads: uploads)
-      create(:sticker, :not_live, title: 'not live', uploads: uploads)
-      create(:sticker, :draft, title: 'draft', uploads: uploads)
+    it_behaves_like "renders published tool type for the path", :sticker do
+      let(:uploads) { [[:image_front_color_image, test_image]] }
     end
-
-    it_behaves_like "renders published tool type for the path", :stickers
   end
 
   describe '/zines' do
-    let(:uploads) { [] }
-
-    before do
-      create(:zine, :live, title: 'published', uploads: uploads)
-      create(:zine, :not_live, title: 'not live', uploads: uploads)
-      create(:zine, :draft, title: 'draft', uploads: uploads)
+    it_behaves_like "renders published tool type for the path", :zine do
+      let(:uploads) { [] }
     end
-
-    it_behaves_like "renders published tool type for the path", :zines
   end
 
   describe '/posters' do
-    let(:uploads) do
-      [
-        [:image_front_color_download, test_pdf],
-        [:image_front_color_image, test_image]
-      ]
+    it_behaves_like "renders published tool type for the path", :poster do
+      let(:uploads) do
+        [
+          [:image_front_color_download, test_pdf],
+          [:image_front_color_image, test_image]
+        ]
+      end
     end
-
-    before do
-      create(:poster, :live, title: 'published', uploads: uploads)
-      create(:poster, :not_live, title: 'not live', uploads: uploads)
-      create(:poster, :draft, title: 'draft', uploads: uploads)
-    end
-
-    it_behaves_like "renders published tool type for the path", :posters
   end
 
   describe '/videos' do
-    let(:uploads) { [[:image_poster_frame, test_image]] }
-
-    before do
-      create(:video, :live, title: 'published', uploads: uploads)
-      create(:video, :not_live, title: 'not live', uploads: uploads)
-      create(:video, :draft, title: 'draft', uploads: uploads)
+    it_behaves_like "renders published tool type for the path", :video do
+      let(:uploads) { [[:image_poster_frame, test_image]] }
     end
-
-    it_behaves_like "renders published tool type for the path", :videos
   end
 end

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 describe 'Tools pages' do
-  before do
-    Current.theme = '2017'
-  end
+  before {  Current.theme = '2017' }
 
   def test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
   def test_pdf   = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -6,76 +6,86 @@ describe 'Tools pages' do
   def test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
   def test_pdf   = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')
 
-  it 'renders published logos calling /logos' do
-    logo = create(:logo, :live, title: 'published')
-    logo.image_jpg.attach test_image
+  describe '/logos' do
+    it 'renders published logos calling /logos' do
+      logo = create(:logo, :live, title: 'published')
+      logo.image_jpg.attach test_image
 
-    create(:logo, :published, :not_live, title: 'not live')
-    create(:logo, :draft, title: 'draft')
+      create(:logo, :published, :not_live, title: 'not live')
+      create(:logo, :draft, title: 'draft')
 
-    visit :logos
+      visit :logos
 
-    expect(page).to have_text 'published'
-    expect(page).to have_no_text 'draft'
-    expect(page).to have_no_text 'not live'
+      expect(page).to have_text 'published'
+      expect(page).to have_no_text 'draft'
+      expect(page).to have_no_text 'not live'
+    end
   end
 
-  it 'renders published stickers calling /stickers' do
-    first_sticker = create(:sticker, :live, title: 'published')
-    second_sticker = create(:sticker, :not_live, title: 'not live')
-    third_sticker = create(:sticker, :draft, title: 'draft')
+  describe '/stickers' do
+    it 'renders published stickers calling /stickers' do
+      first_sticker = create(:sticker, :live, title: 'published')
+      second_sticker = create(:sticker, :not_live, title: 'not live')
+      third_sticker = create(:sticker, :draft, title: 'draft')
 
-    first_sticker.image_front_color_image.attach test_image
-    second_sticker.image_front_color_image.attach test_image
-    third_sticker.image_front_color_image.attach test_image
+      first_sticker.image_front_color_image.attach test_image
+      second_sticker.image_front_color_image.attach test_image
+      third_sticker.image_front_color_image.attach test_image
 
-    visit :stickers
+      visit :stickers
 
-    expect(page).to have_text 'published'
-    expect(page).to have_no_text 'draft'
-    expect(page).to have_no_text 'not live'
+      expect(page).to have_text 'published'
+      expect(page).to have_no_text 'draft'
+      expect(page).to have_no_text 'not live'
+    end
   end
 
-  it 'renders published zines calling /zines' do
-    create(:zine, :live, title: 'published')
-    create(:zine, :not_live, title: 'not live')
-    create(:zine, :draft, title: 'draft')
+  describe '/zines' do
+    it 'renders published zines calling /zines' do
+      create(:zine, :live, title: 'published')
+      create(:zine, :not_live, title: 'not live')
+      create(:zine, :draft, title: 'draft')
 
-    visit :zines
+      visit :zines
 
-    expect(page).to have_text 'published'
-    expect(page).to have_no_text 'draft'
-    expect(page).to have_no_text 'not live'
+      expect(page).to have_text 'published'
+      expect(page).to have_no_text 'draft'
+      expect(page).to have_no_text 'not live'
+    end
   end
 
-  it 'renders published posters calling /posters' do
-    first_poster = create(:poster, :live, title: 'published')
-    second_poster = create(:poster, :not_live, title: 'not live')
-    third_poster = create(:poster, :draft, title: 'draft')
+  describe '/posters' do
+    it 'renders published posters calling /posters' do
+      first_poster = create(:poster, :live, title: 'published')
+      second_poster = create(:poster, :not_live, title: 'not live')
+      third_poster = create(:poster, :draft, title: 'draft')
 
-    first_poster.image_front_color_download.attach test_pdf
-    first_poster.image_front_color_image.attach test_image
-    second_poster.image_front_color_download.attach test_pdf
-    second_poster.image_front_color_image.attach test_image
-    third_poster.image_front_color_download.attach test_pdf
-    third_poster.image_front_color_image.attach test_image
+      first_poster.image_front_color_download.attach test_pdf
+      first_poster.image_front_color_image.attach test_image
+      second_poster.image_front_color_download.attach test_pdf
+      second_poster.image_front_color_image.attach test_image
+      third_poster.image_front_color_download.attach test_pdf
+      third_poster.image_front_color_image.attach test_image
 
-    visit :posters
+      visit :posters
 
-    expect(page).to have_text 'published'
-    expect(page).to have_no_text 'draft'
-    expect(page).to have_no_text 'not live'
+      expect(page).to have_text 'published'
+      expect(page).to have_no_text 'draft'
+      expect(page).to have_no_text 'not live'
+    end
   end
 
-  it 'renders published videos calling /videos' do
-    create(:video, :live, title: 'published')
-    create(:video, :not_live, title: 'not live')
-    create(:video, :draft, title: 'draft')
+  describe '/videos' do
+    it 'renders published videos calling /videos' do
+      create(:video, :live, title: 'published')
+      create(:video, :not_live, title: 'not live')
+      create(:video, :draft, title: 'draft')
     
-    visit :videos
+      visit :videos
 
-    expect(page).to have_text 'published'
-    expect(page).to have_no_text 'not live'
-    expect(page).to have_no_text 'draft'
+      expect(page).to have_text 'published'
+      expect(page).to have_no_text 'not live'
+      expect(page).to have_no_text 'draft'
+    end
   end
 end

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -7,13 +7,15 @@ describe 'Tools pages' do
   def test_pdf   = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')
 
   describe '/logos' do
-    it 'renders published logos calling /logos' do
+    before do
       logo = create(:logo, :live, title: 'published')
       logo.image_jpg.attach test_image
 
       create(:logo, :published, :not_live, title: 'not live')
       create(:logo, :draft, title: 'draft')
+    end
 
+    it 'renders published logos calling /logos' do
       visit :logos
 
       expect(page).to have_text 'published'
@@ -23,7 +25,7 @@ describe 'Tools pages' do
   end
 
   describe '/stickers' do
-    it 'renders published stickers calling /stickers' do
+    before do
       first_sticker = create(:sticker, :live, title: 'published')
       second_sticker = create(:sticker, :not_live, title: 'not live')
       third_sticker = create(:sticker, :draft, title: 'draft')
@@ -31,7 +33,9 @@ describe 'Tools pages' do
       first_sticker.image_front_color_image.attach test_image
       second_sticker.image_front_color_image.attach test_image
       third_sticker.image_front_color_image.attach test_image
+    end
 
+    it 'renders published stickers calling /stickers' do
       visit :stickers
 
       expect(page).to have_text 'published'
@@ -41,11 +45,13 @@ describe 'Tools pages' do
   end
 
   describe '/zines' do
-    it 'renders published zines calling /zines' do
+    before do
       create(:zine, :live, title: 'published')
       create(:zine, :not_live, title: 'not live')
       create(:zine, :draft, title: 'draft')
+    end
 
+    it 'renders published zines calling /zines' do
       visit :zines
 
       expect(page).to have_text 'published'
@@ -55,7 +61,7 @@ describe 'Tools pages' do
   end
 
   describe '/posters' do
-    it 'renders published posters calling /posters' do
+    before do
       first_poster = create(:poster, :live, title: 'published')
       second_poster = create(:poster, :not_live, title: 'not live')
       third_poster = create(:poster, :draft, title: 'draft')
@@ -66,7 +72,9 @@ describe 'Tools pages' do
       second_poster.image_front_color_image.attach test_image
       third_poster.image_front_color_download.attach test_pdf
       third_poster.image_front_color_image.attach test_image
+    end
 
+    it 'renders published posters calling /posters' do
       visit :posters
 
       expect(page).to have_text 'published'
@@ -76,11 +84,13 @@ describe 'Tools pages' do
   end
 
   describe '/videos' do
-    it 'renders published videos calling /videos' do
+    before do
       create(:video, :live, title: 'published')
       create(:video, :not_live, title: 'not live')
       create(:video, :draft, title: 'draft')
-    
+    end
+
+    it 'renders published videos calling /videos' do
       visit :videos
 
       expect(page).to have_text 'published'

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -9,21 +9,11 @@ describe 'Tools pages' do
   def test_pdf   = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')
 
   it 'renders published logos calling /logos' do
-    logo = create(:logo,
-                  title:              'published',
-                  published_at:       1.day.ago,
-                  publication_status: 'published')
-
+    logo = create(:logo, :live, title: 'published')
     logo.image_jpg.attach test_image
 
-    create(:logo,
-           title:              'not live',
-           published_at:       1.day.from_now,
-           publication_status: 'published')
-
-    create(:logo,
-           title:              'draft',
-           publication_status: 'draft')
+    create(:logo, :published, :not_live, title: 'not live')
+    create(:logo, :draft, title: 'draft')
 
     visit :logos
 
@@ -33,19 +23,9 @@ describe 'Tools pages' do
   end
 
   it 'renders published stickers calling /stickers' do
-    first_sticker = create(:sticker,
-                           title:              'published',
-                           published_at:       1.day.ago,
-                           publication_status: 'published')
-
-    second_sticker = create(:sticker,
-                            title:              'not live',
-                            published_at:       1.day.from_now,
-                            publication_status: 'published')
-
-    third_sticker = create(:sticker,
-                           title:              'draft',
-                           publication_status: 'draft')
+    first_sticker = create(:sticker, :live, title: 'published')
+    second_sticker = create(:sticker, :not_live, title: 'not live')
+    third_sticker = create(:sticker, :draft, title: 'draft')
 
     first_sticker.image_front_color_image.attach test_image
     second_sticker.image_front_color_image.attach test_image
@@ -59,19 +39,9 @@ describe 'Tools pages' do
   end
 
   it 'renders published zines calling /zines' do
-    create(:zine,
-           title:              'published',
-           published_at:       1.day.ago,
-           publication_status: 'published')
-
-    create(:zine,
-           title:              'not live',
-           published_at:       1.day.from_now,
-           publication_status: 'published')
-
-    create(:zine,
-           title:              'draft',
-           publication_status: 'draft')
+    create(:zine, :live, title: 'published')
+    create(:zine, :not_live, title: 'not live')
+    create(:zine, :draft, title: 'draft')
 
     visit :zines
 
@@ -81,19 +51,9 @@ describe 'Tools pages' do
   end
 
   it 'renders published posters calling /posters' do
-    first_poster = create(:poster,
-                          title:              'published',
-                          published_at:       1.day.ago,
-                          publication_status: 'published')
-
-    second_poster = create(:poster,
-                           title:              'not live',
-                           published_at:       1.day.from_now,
-                           publication_status: 'published')
-
-    third_poster = create(:poster,
-                          title:              'draft',
-                          publication_status: 'draft')
+    first_poster = create(:poster, :live, title: 'published')
+    second_poster = create(:poster, :not_live, title: 'not live')
+    third_poster = create(:poster, :draft, title: 'draft')
 
     first_poster.image_front_color_download.attach test_pdf
     first_poster.image_front_color_image.attach test_image
@@ -110,20 +70,10 @@ describe 'Tools pages' do
   end
 
   it 'renders published videos calling /videos' do
-    create(:video,
-           title:              'published',
-           published_at:       1.day.ago,
-           publication_status: 'published')
-
-    create(:video,
-           title:              'not live',
-           published_at:       1.day.from_now,
-           publication_status: 'published')
-
-    create(:video,
-           title:              'draft',
-           publication_status: 'draft')
-
+    create(:video, :live, title: 'published')
+    create(:video, :not_live, title: 'not live')
+    create(:video, :draft, title: 'draft')
+    
     visit :videos
 
     expect(page).to have_text 'published'

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -6,6 +6,18 @@ describe 'Tools pages' do
   def test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
   def test_pdf   = fixture_file_upload('spec/fixtures/files/test_pdf.pdf',   'image/pdf')
 
+  shared_examples "renders published tool type for the path" do |tool|
+    let(:tool) { tool.to_sym }
+
+    it "renders published logos calling /#{tool}" do
+      visit tool
+
+      expect(page).to have_text 'published'
+      expect(page).to have_no_text 'draft'
+      expect(page).to have_no_text 'not live'
+    end
+  end
+
   describe '/logos' do
     before do
       logo = create(:logo, :live, title: 'published')
@@ -15,13 +27,7 @@ describe 'Tools pages' do
       create(:logo, :draft, title: 'draft')
     end
 
-    it 'renders published logos calling /logos' do
-      visit :logos
-
-      expect(page).to have_text 'published'
-      expect(page).to have_no_text 'draft'
-      expect(page).to have_no_text 'not live'
-    end
+    it_behaves_like "renders published tool type for the path", :logos
   end
 
   describe '/stickers' do
@@ -35,13 +41,7 @@ describe 'Tools pages' do
       third_sticker.image_front_color_image.attach test_image
     end
 
-    it 'renders published stickers calling /stickers' do
-      visit :stickers
-
-      expect(page).to have_text 'published'
-      expect(page).to have_no_text 'draft'
-      expect(page).to have_no_text 'not live'
-    end
+    it_behaves_like "renders published tool type for the path", :stickers
   end
 
   describe '/zines' do
@@ -51,13 +51,7 @@ describe 'Tools pages' do
       create(:zine, :draft, title: 'draft')
     end
 
-    it 'renders published zines calling /zines' do
-      visit :zines
-
-      expect(page).to have_text 'published'
-      expect(page).to have_no_text 'draft'
-      expect(page).to have_no_text 'not live'
-    end
+    it_behaves_like "renders published tool type for the path", :zines
   end
 
   describe '/posters' do
@@ -74,13 +68,7 @@ describe 'Tools pages' do
       third_poster.image_front_color_image.attach test_image
     end
 
-    it 'renders published posters calling /posters' do
-      visit :posters
-
-      expect(page).to have_text 'published'
-      expect(page).to have_no_text 'draft'
-      expect(page).to have_no_text 'not live'
-    end
+    it_behaves_like "renders published tool type for the path", :posters
   end
 
   describe '/videos' do
@@ -90,12 +78,6 @@ describe 'Tools pages' do
       create(:video, :draft, title: 'draft')
     end
 
-    it 'renders published videos calling /videos' do
-      visit :videos
-
-      expect(page).to have_text 'published'
-      expect(page).to have_no_text 'not live'
-      expect(page).to have_no_text 'draft'
-    end
+    it_behaves_like "renders published tool type for the path", :videos
   end
 end

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe 'Tools pages' do
-  before {  Current.theme = '2017' }
+  before { Current.theme = '2017' }
 
   def test_image = fixture_file_upload 'spec/fixtures/files/test_image.jpg', 'image/jpeg'
   def test_pdf   = fixture_file_upload 'spec/fixtures/files/test_pdf.pdf',   'image/pdf'
 
-  shared_examples "renders published tool type for the path" do |tool|
+  shared_examples 'renders published tool type for the path' do |tool|
     let(:uploads) { [] }
 
     before do
@@ -23,10 +23,10 @@ describe 'Tools pages' do
       expect(page).to have_no_text 'not live'
     end
 
-    xcontext 'with no uploads' do
+    xcontext 'with no uploads', skip: 'bug will be fixed in followed' do # rubocop:disable RSpec/PendingWithoutReason
       let(:uploads) { [] }
 
-      it "can still render the page" do
+      it 'can still render the page' do
         visit tool.to_s.pluralize.to_sym
         expect(page).to have_text 'published'
       end
@@ -34,25 +34,25 @@ describe 'Tools pages' do
   end
 
   describe '/logos' do
-    it_behaves_like "renders published tool type for the path", :logo do
+    it_behaves_like 'renders published tool type for the path', :logo do
       let(:uploads) { [[:image_jpg, test_image]] }
     end
   end
 
   describe '/stickers' do
-    it_behaves_like "renders published tool type for the path", :sticker do
+    it_behaves_like 'renders published tool type for the path', :sticker do
       let(:uploads) { [[:image_front_color_image, test_image]] }
     end
   end
 
   describe '/zines' do
-    it_behaves_like "renders published tool type for the path", :zine do
+    it_behaves_like 'renders published tool type for the path', :zine do
       let(:uploads) { [] }
     end
   end
 
   describe '/posters' do
-    it_behaves_like "renders published tool type for the path", :poster do
+    it_behaves_like 'renders published tool type for the path', :poster do
       let(:uploads) do
         [
           [:image_front_color_download, test_pdf],
@@ -63,7 +63,7 @@ describe 'Tools pages' do
   end
 
   describe '/videos' do
-    it_behaves_like "renders published tool type for the path", :video do
+    it_behaves_like 'renders published tool type for the path', :video do
       let(:uploads) { [[:image_poster_frame, test_image]] }
     end
   end

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -22,6 +22,15 @@ describe 'Tools pages' do
       expect(page).to have_no_text 'draft'
       expect(page).to have_no_text 'not live'
     end
+
+    xcontext 'with no uploads' do
+      let(:uploads) { [] }
+
+      it "can still render the page" do
+        visit tool.to_s.pluralize.to_sym
+        expect(page).to have_text 'published'
+      end
+    end
   end
 
   describe '/logos' do


### PR DESCRIPTION
# What does this pull request do?

-   [Summary of the refactor commits in series.](#orgaa24fa0)
    -   [prep work: create a common tools factory](#orgb22b392)
    -   [remove unnecessary local variables](#orgf7b26f4)
    -   [use factory bot traits](#org0ab739a)
    -   [one line before](#org349f4ef)
    -   [wrap examples in describe blocks](#orgf21fdf9)
    -   [move setup code to a before block](#org4628567)
    -   [move common expects to shared example](#org3711a6e)
    -   [use the uploads trait](#org7f1e602)
    -   [move before block to shared example](#org2474b35)
    -   [add a failing spec for the bug](#org3d3a0a8)


<a id="org95aa09d"></a>

# how should it be tested?

-   run the full test suite


<a id="org959b940"></a>

# Context for reviewers

I have broken this into a series of three PRs:

1.  **[PR 5370](https://github.com/crimethinc/website/pull/5370)** contains the prep work needed for this refactor
    -   it is included on this PR as the first commit so that the
        branch can be pulled down and run locally without having to
        cherry-pick the prep work. Once the prep work PR is merged this
        commit will be rebased so that the diff no longer includes it.
2.  ****This PR****: contains the refactor, broken into commits so you can
    see the process.
3.  A final PR to include the bug fixes and un-skipp the specs added
    in this PR.


<a id="orgaa24fa0"></a>

## Summary of the refactor commits in series.


<a id="orgb22b392"></a>

### [prep work: create a common tools factory](https://github.com/crimethinc/website/pull/5369/changes/fbb28a9bbdd8ffba1ef041bbf79d4f3a0bab1ead)

This is prep work for a spec refactor related to issue #5305.

We already have a spec that should be covering that codepath:

-   `spec/system/tools_index_pages_spec.rb`

To add a regression test there, as an alternative to adding a
controller spec via #5324, I ended up refactoring that spec
significantly so that every tool type would have the same coverage.

This refactor uncovered a second bug of the same type.

I have broken this into a series of three PRs:

1.  [PR 5370](https://github.com/crimethinc/website/pull/5370): contains the prep work needed for this refactor
    -   it is included on this PR as the first commit so that the branch can be pulled down and run locally without having to cherry-pick the prep work. Once the prep work PR is merged this commit will be rebased so that the diff no longer includes it.
2.  **This PR**: contains the refactor, broken into commits so you can see the process.
3.  A final PR to include the bug fixes and un-skipp the specs added in this PR.


<a id="orgf7b26f4"></a>

### [remove unnecessary local variables](https://github.com/crimethinc/website/pull/5369/changes/a5308d089e85eac080275c9d542c2a4943d55aa4)

The first step in this refactor is to reduce line noise by replacing
many repeated in-line code with a function call.


<a id="org0ab739a"></a>

### [use factory bot traits](https://github.com/crimethinc/website/pull/5369/changes/e7884bca89278399f76f076a083919be0dd9bacd)

The next step is to further reduce line noise by using `factory_bot`
traits.


<a id="org349f4ef"></a>

### [one line before](https://github.com/crimethinc/website/pull/5369/changes/60757a874721f659b44cb6604b899553a628a2a0)

This isn't strictly nesseccary, however for ruby one-liners I prefer
to put them on one line.


<a id="orgf21fdf9"></a>

### [wrap examples in describe blocks](https://github.com/crimethinc/website/pull/5369/changes/5adb925ac2ff9ebd0e279582cc79329f0f0d00b9)

Without a containing block, either `describe` or `context`, it will be
difficult to add additonal test contexts (e.g. "when there are no
uploads").


<a id="org4628567"></a>

### [move setup code to a before block](https://github.com/crimethinc/website/pull/5369/changes/ff3907d6482c3e2b1acd1327af5d399f0ce909e7)

When code is strictly setup code, and there is no need to reference it
in the expectations, it should be in a before block.

There are several reasons for this:

-   if there is a refactor, setup code could change but the expectations
    should continue passing without change. (if they are changed that is
    an indication the refactor is not just a refactor)
-   it clearly indicates to future readers what you actually intend to
    test. With local variable being created, it gives the initial read
    that they are going to be used for something when, in this case,
    they are not.
-   with setup code moved to a `before` block it is easier to expand the
    test coverage with additional `context` blocks.
-   having the shared setup in a `before` block makes sure all of the
    specs are actually testing the same thing.


<a id="org3711a6e"></a>

### [move common expects to shared example](https://github.com/crimethinc/website/pull/5369/changes/98ff71cb01076176f4864f64dfeb8895e15d55fb)

With the setup code moved to `before` blocks, it becomes clear that
all of the expectation code is exactly the same. Moving it to a shared
example guarantees that regression tests added to cover bugs
discovered in one tool type will also be covered for every tool type.


<a id="org7f1e602"></a>

### [use the uploads trait](https://github.com/crimethinc/website/pull/5369/changes/ac0f8cc66dac617bae650be9c5ab6792cefc21ea)

With the setup code moved to `before` blocks, we can see that the
logic is the same across the blocks, though the implementation varies
across blocks.

The logic is always:

1.  create 3 records of `tool type`
    -   a "live" record, a "published but not live" record, and a "draft" record.
2.  create and attach any supported uploads to those records

Using a trait lets us match the implementation to that logic, allow
all of the tool types to have the same setup code.


<a id="org2474b35"></a>

### [move before block to shared example](https://github.com/crimethinc/website/pull/5369/changes/bdbbea51e4279069d9105897cd664d746fe88ebf)

Now that we are using the uploads trait, we have the same exact setup
code being used across every tool type.

Moving it to the shared example guarantees every tool type has the
same setup, and if we want to add additional test `context` blocks we
can easily vary the setup across tool types.


<a id="org3d3a0a8"></a>

### [add a failing spec for the bug](https://github.com/crimethinc/website/pull/5369/changes/2e14f96ac8b89a767c6866c201f0c055c84283fb)

With the refactor done, we can easily add a new test context to every
tool type.

This spec does detect the bug in #5305 as well as the same bug in the
logo tool type:

    Failures:
    
      1) Tools pages /logos behaves like renders published tool type for the path with no uploads can still render the page
         Failure/Error: <%= image_tag image_variant_by_width(tool.image_jpg, @preview_width),
    
         ActionView::Template::Error:
           Nil location provided. Can't build URI.
         Shared Example Group: "renders published tool type for the path" called from ./spec/system/tools_index_pages_spec.rb:37
         # ./app/views/2017/logos/_logo.html.erb:13:in 'block in ...
    
      2) Tools pages /posters behaves like renders published tool type for the path with no uploads can still render the page
         Failure/Error: <%= link_to image_tag(tool.front_image, alt: tool.front_image_description, class: "u-image"), tool.path %>
    
         ActionView::Template::Error:
           Nil location provided. Can't build URI.
         Shared Example Group: "renders published tool type for the path" called from ./spec/system/tools_index_pages_spec.rb:55
         # ./app/views/2017/tools/_tool.html.erb:8:in ...
    
    Finished in 6.44 seconds (files took 2.29 seconds to load)
    10 examples, 2 failures


<a id="org8662960"></a>

# Acceptance Criteria


<a id="orgb58900d"></a>

## Questions for the pull request author (delete any that don't apply)

-   [X] Does the code you updated have tests? If not, could you add some please?


<a id="orgcaf3d40"></a>

## Questions for the reviewer

-   [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

- blocked by: https://github.com/crimethinc/website/pull/5370
- related-to: https://github.com/crimethinc/website/issues/5305
- related-to: https://github.com/crimethinc/website/pull/5324
- related-to: https://github.com/crimethinc/website/pull/5369

