### PR TITLE
fix: error with logos and posters when image is nil

### DIFF
--- a/app/views/2017/logos/_logo.html.erb
+++ b/app/views/2017/logos/_logo.html.erb
@@ -10,9 +10,11 @@
         <div class="column column-one-quarter logo-first-column">
           <div class="tool-front">
             <%= link_to tool.path do %>
-              <%= image_tag image_variant_by_width(tool.image_jpg, @preview_width),
-                            class: "u-image",
-                            alt:   tool.description %>
+              <% if tool.image_jpg.present? %>
+                <%= image_tag image_variant_by_width(tool.image_jpg, @preview_width),
+                              class: "u-image",
+                              alt:   tool.description %>
+              <% end %>
             <% end %>
           </div> <!-- tool-front -->
         </div> <!-- logo-first-column -->

--- a/app/views/2017/tools/_tool.html.erb
+++ b/app/views/2017/tools/_tool.html.erb
@@ -5,7 +5,9 @@
 
   <div class="e-content row">
     <div class="tool-front column column-one-quarter">
-      <%= link_to image_tag(tool.front_image, alt: tool.front_image_description, class: "u-image"), tool.path %>
+      <% if tool.front_image.present? %>
+        <%= link_to image_tag(tool.front_image, alt: tool.front_image_description, class: "u-image"), tool.path %>
+      <% end %>
 
       <% if tool.published_at.present? %>
         <time datetime="<%= tool.published_at.iso8601 %>"><%= tool.published_at.year %></time>

--- a/spec/system/tools_index_pages_spec.rb
+++ b/spec/system/tools_index_pages_spec.rb
@@ -23,7 +23,7 @@ describe 'Tools pages' do
       expect(page).to have_no_text 'not live'
     end
 
-    xcontext 'with no uploads', skip: 'bug will be fixed in followed' do # rubocop:disable RSpec/PendingWithoutReason
+    context 'with no uploads' do
       let(:uploads) { [] }
 
       it 'can still render the page' do


### PR DESCRIPTION

# What does this pull request do?

* app/views/2017/logos/_logo.html.erb: skip image rendering if the image is nil.
* app/views/2017/tools/_tool.html.erb: skip image rendering if the image is nil.
* spec/system/tools_index_pages_spec.rb: un-skip the regression tests for this error.

# How should this be manually tested?

- browse the `/posters` and `/logos` index pages when there is a record without images.

|  | Header | Header |
|--------|--------|--------|
| **`/posters`** | <img width="2880" height="1920" alt="posters-before" src="https://github.com/user-attachments/assets/2ae01b83-ef36-4c3e-a456-0d66fcbaf150" /> | <img width="2880" height="1920" alt="posters-after" src="https://github.com/user-attachments/assets/5e5cede5-ebd0-475e-8de5-c9a0945e1160" /> |
| **`/logos`** | <img width="2880" height="1920" alt="logos-before" src="https://github.com/user-attachments/assets/0e23aa5a-cee8-480d-bc54-7aefccfc3d26" /> | <img width="2880" height="1920" alt="logos-after" src="https://github.com/user-attachments/assets/411ea5f5-413c-49d2-bbdb-2850f02cebc8" /> |          

# Acceptance Criteria
## Questions for the pull request author (delete any that don't apply)

- [X] Does the code you updated have tests? If not, could you add some please?

## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

- resolves: https://github.com/crimethinc/website/issues/5305
- closes: https://github.com/crimethinc/website/pull/5324
- related to: https://github.com/crimethinc/website/pull/5370

