### PR TITLE
specs: run time performance improvement for application_helper_spec

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,16 +2,30 @@ require 'rails_helper'
 
 RSpec.describe ApplicationHelper do
   describe '#largest_touch_icon_url' do
-    subject { helper.largest_touch_icon_url }
+    let(:stub_asset) { 'rails asset url' }
 
-    it { is_expected.to match('icons/icon-600x600') }
+    before do
+      allow(helper).to receive(:asset_url).and_return(stub_asset)
+    end
+
+    it 'fetches the expected icon size' do
+      expect(helper.largest_touch_icon_url).to eq stub_asset
+      expect(helper).to have_received(:asset_url).with('icons/icon-600x600.png').once
+    end
   end
 
   describe '#tt' do
-    it 'returns a themed translation' do
-      Current.theme = '2017'
+    let(:stub_translation) { 'i18n translation' }
+    let(:theme) { '2044' }
 
-      expect(helper.tt('site_name')).to be_present
+    before do
+      Current.theme = theme
+      allow(helper).to receive(:t).and_return(stub_translation)
+    end
+
+    it 'calls rails\' translation helper with the current theme' do
+      expect(helper.tt('site_name')).to eq stub_translation
+      expect(helper).to have_received(:t).with(start_with("#{theme}."))
     end
   end
 end


### PR DESCRIPTION
# What does this pull request do?

* `spec/helpers/application_helper_spec.rb`: Stubbed out calls to Rails to prevent loading framework dependencies for simple tests.

# How should this be manually tested?

run full suite before/after patch with: 

```sh
time bundle exec rspec --order rand --format documentation --profile --seed 30214
```

# Is there any background context you want to provide for reviewers?

I was profiling the whole test suite, **including `:js` system specs**, and was surprised to see helper specs occasionally show up as the slowest spec, (dependent on spec run ordering).

The specs in this change were the ones showing up, sometimes taking 5-6 seconds to run:

```sh
Top 10 slowest examples (13.09 seconds, 74.7% of total time):
  ApplicationHelper#largest_touch_icon_url is expected to match "icons/icon-600x600"
    5.16 seconds ./spec/helpers/application_helper_spec.rb:7
```

The reason these specs take so long is because they are not just testing our application logic, they are in fact full integration specs with the rails framework.

## This Change

I have changed the specs to stub out the framework calls.

The pattern I have introduced here has two things it is asserting:

1. **assert our application logic is correct in generating data to hand to the rails framework**
  
   This is done by asserting on the params with the `expect().to receive().with(expectations)` pattern

2. **assert that the return value of these helper methods are returning whatever the rails framework returns**

   For example, imagine in the future a bug is introduced in the helper where we are no longer returning the value from the framework:

   ```diff 
   diff --git a/app/helpers/application_helper.rb b/app/helpers/application_helper.rb index ce1a4fc0..f6411306 100644 --- a/app/helpers/application_helper.rb +++ b/app/helpers/application_helper.rb @@ -20,5 +20,6 @@ module ApplicationHelper

      def tt path
        t "#{Current.theme}.#{path}"
   +    :a_bug
      end
    end
    ```

    Then the specs would fail:

    ```sh
      1) ApplicationHelper#tt calls rails' translation helper with the current theme
         Failure/Error: expect(helper.tt('site_name')).to eq stub_translation

           expected: "i18n translation"
                got: :a_bug
    ```

## Performance

The specs now have run times more in line with what you would expect from a helper spec.

### Before

```sh
Top 2 slowest examples (5.62 seconds, 99.8% of total time):
  ApplicationHelper#largest_touch_icon_url is expected to match "icons/icon-600x600"
    5.25 seconds ./spec/helpers/application_helper_spec.rb:7
  ApplicationHelper#tt returns a themed translation
    0.36152 seconds ./spec/helpers/application_helper_spec.rb:11

Finished in 5.63 seconds (files took 2.13 seconds to load)
```

### After

```sh
Top 2 slowest examples (0.01883 seconds, 73.1% of total time):
  ApplicationHelper#largest_touch_icon_url fetches the expected icon size
    0.01564 seconds ./spec/helpers/application_helper_spec.rb:11
  ApplicationHelper#tt calls rails' translation helper with the current theme
    0.0032 seconds ./spec/helpers/application_helper_spec.rb:27

Finished in 0.02577 seconds (files took 2.1 seconds to load)
```

## Future Improvements

With the specs written in this manner, they also easier to expand. For example, the behavior of `Current.theme == nil` is undefined in these specs. It could be covered in one of several ways:

```ruby
context 'when Current.theme is nil' do
  # skip{ 'the current behavior is undefined' }

  before { Current.theme = nil }
  
  let(:default_theme) { '2017' }
  
  it 'calls rails\' translation helper with the default theme' do
    expect(helper).to receive(:t).with(start_with("#{default_theme}."))
    helper.tt('site_name')
  end

  # or...
  it 'calls rails\' translation helper unthemed' do
    expect(helper).to receive(:t).with("site_name")
    helper.tt('site_name')
  end

  # or...
  it 'raises a translation error' do
    #...
  end

  # or, what I would prefer, ...
  context 'in production' do
    it 'defaults to 2017' do
    end
  end
  context 'outside of production' do
    it 'raises a translation error' do
    end
  end
end
```

# Acceptance Criteria
## Questions for the pull request author (delete any that don't apply)

- [ ] Are any needed README/wiki/documentation updates needed for this pull request?
- [x] Does the code you updated have tests? If not, could you add some please?
- [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.

## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

