### PR TITLE
specs: move locale record creation to an optional trait

### DIFF
--- a/spec/factories/tools.rb
+++ b/spec/factories/tools.rb
@@ -13,6 +13,16 @@ FactoryBot.define do
       end
     end
 
+    trait :with_built_locale do
+      after(:build) do |tool|
+        locale = Locale.find_by(abbreviation: tool.locale)
+        if locale.blank?
+          trait_sym = tool.locale.underscore.to_sym
+          create(:locale, trait_sym)
+        end
+      end
+    end
+
     trait :draft do
       published_at { nil }
       publication_status { 'draft' }

--- a/spec/factories/zines.rb
+++ b/spec/factories/zines.rb
@@ -1,13 +1,5 @@
 FactoryBot.define do
   factory :zine, parent: :tool, class: 'Zine' do
     locale { 'en' }
-
-    after(:build) do |tool|
-      locale = Locale.find_by(abbreviation: tool.locale)
-      if locale.blank?
-        trait_sym = tool.locale.underscore.to_sym
-        create(:locale, trait_sym)
-      end
-    end
   end
 end


### PR DESCRIPTION
# What does this pull request do?

* spec/factories/tools.rb: copied the locale creation logic from zine, but wrapped in a trait.
* spec/factories/zines.rb: moved locale creation logic to parent tool factory.

# How should this be manually tested?

I was running:

```sh
time bundle exec rspec --format progress --profile --seed 44528 
```

# Is there any background context you want to provide for reviewers?

I was working on refactoring a database query, and to test if there was any performance improvement I modified a test to create 10,000 records of each tool type.

This made the spec take about 280 seconds to run. I discovered that most of this is spent in the `Zine` factory's `Locale` creation logic, which I didn't need for this particular spec.

So I made 2 changes:

1. wrapped the logic in a `trait` so that creating `Locale` records is opt-in.
2. moved the trait to the tool factory, so that it is available for any tool type.

## Performance

There isn't a difference with the current specs, as we don't often create a huge number of records for test data. However I didn't see any specs fail by making this change and it will unblock more aggressive testing on larger data sets if we have the need in the future.[^1]

### Before

```sh
Finished in 17.21 seconds (files took 2.35 seconds to load)
329 examples, 0 failures

Randomized with seed 44528

real	0m20.593s
user	0m19.954s
sys	0m2.416s
```

### After

```sh
Finished in 17.02 seconds (files took 2.35 seconds to load)
329 examples, 0 failures

Randomized with seed 44528

real	0m20.410s
user	0m19.956s
sys	0m2.429s
```

# Acceptance Criteria
## Questions for the pull request author (delete any that don't apply)

- [x] Does the code you updated have tests? If not, could you add some please?

## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

[^1]: It is useful for local development. For example, being able to
      easily create a more realistic sized database can help for local
      testing of database query changes, even if there is no intention to
      check in a spec that creates 10,000 records into `main`
