### PR TITLE
tests: refactor `set_published_at` tests into requests tests

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -181,15 +181,23 @@ module Admin
     end
 
     def handle_published_without_datetime permitted_params
-      return if @article&.published?
+      if @article&.published?
+        # in general, we don't un-publish articles, and if we do it
+        # should be via setting the publication status from "published"
+        # to "draft", not by nil-ing the publication dates...so if we
+        # are ever in this scenario, it is probably a bug. Just use the
+        # already saved publication dates.
+        permitted_params.delete(:published_at) if permitted_params[:published_at].blank?
+        permitted_params.delete(:published_at_tz) if permitted_params[:published_at_tz].blank?
+      else
+        publish_in_100_years = permitted_params[:publication_status] == 'published' &&
+                               permitted_params[:published_at].blank?
 
-      publish_in_100_years = permitted_params[:publication_status] == 'published' &&
-                             permitted_params[:published_at].blank?
+        time = 100.years.from_now
+        tz = Time.zone.name
 
-      time = 100.years.from_now
-      tz = Time.zone.name
-
-      handle_publish_now_situation(permitted_params, time: time, zone: tz) if publish_in_100_years
+        handle_publish_now_situation(permitted_params, time: time, zone: tz) if publish_in_100_years
+      end
     end
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -16,6 +16,15 @@ FactoryBot.define do
     end
   end
 
+  # TODO: create a published trait that set `published_at` and the
+  # `publication_status`, so the draft trait can properly set `published_at` to
+  # nil
+  trait(:draft) do
+    published_at { nil }
+    publication_status { 'draft' }
+    # TODO: should we also put `published_at_tz { "UTC" }` ?
+  end
+
   trait(:arabic)         { locale { 'ar' } }
   trait(:bengali)        { locale { 'bn' } }
   trait(:czech)          { locale { 'cs' } }

--- a/spec/requests/article_datetime_settings_spec.rb
+++ b/spec/requests/article_datetime_settings_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'admin article controller set_published_at before_action set published_at' do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:draft_attrs) { attributes_for(:article, :draft, published_at_tz: 'UTC', published_at: nil).compact }
+  let(:published_attrs) { attributes_for(:article, publication_at_tz: 'UTC', published_at: nil).compact }
+  let(:request_params) { { button: '', controller: 'admin/articles' } }
+
+  shared_examples 'handles the publication date' do |user_role|
+    subject(:actual_published_at) { Article.last.published_at.to_s }
+
+    let(:user) { create(:user, password: 'c' * 31, role: user_role) }
+    let(:now) { Time.now.utc }
+
+    before do
+      post sessions_url, params: { username: user.username, password: user.password }
+    end
+
+    context "when creating an article record with role: #{user_role}" do
+      before do
+        travel_to(now) do
+          post admin_articles_url, params: { article: article_attrs, action: 'create', **request_params }
+        end
+      end
+
+      it { is_expected.to eq expected_published_at }
+    end
+
+    context "when updating an existing article record with role: #{user_role}" do
+      before do
+        travel_to(now) do
+          put admin_article_url(existing_article.id),
+              params: { article: article_attrs, action: 'update', **request_params }
+        end
+      end
+
+      it { is_expected.to eq expected_published_at }
+    end
+  end
+
+  context 'with valid publication info' do
+    let(:request_params) { super().merge(published_at_date: '2018-12-24', published_at_time: '11:59:00') }
+    let(:article_attrs) { draft_attrs.merge(published_at: DateTime.parse('2018-12-25T03:59:00Z')) }
+    let(:existing_article) { create(:article, :draft, published_at: DateTime.parse('2018-12-25T03:59:00Z')) }
+
+    it_behaves_like 'handles the publication date', :author do
+      let(:expected_published_at) { '2018-12-24 11:59:00 UTC' }
+    end
+  end
+
+  context 'when the publication info is missing' do
+    let(:request_params) { super().merge(published_at_date: nil, published_at_time: nil) }
+
+    describe 'when the article is marked as published' do
+      let(:existing_article) { create(:article) }
+      let(:article_attrs) { published_attrs.merge(published_at: nil) }
+
+      it_behaves_like 'handles the publication date', :publisher do
+        let(:expected_published_at) { (now.utc + 100.years).to_s }
+      end
+
+      it_behaves_like 'handles the publication date', :author do
+        let(:expected_published_at) { '' }
+      end
+    end
+
+    describe 'when the article is still a draft' do
+      let(:existing_article) { create(:article, :draft) }
+      let(:article_attrs) { draft_attrs.merge(published_at: nil) }
+
+      it_behaves_like 'handles the publication date', :publisher do
+        let(:expected_published_at) { '' }
+      end
+
+      it_behaves_like 'handles the publication date', :author do
+        let(:expected_published_at) { '' }
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/requests/article_datetime_settings_spec.rb
+++ b/spec/requests/article_datetime_settings_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
         end
       end
 
-      it { is_expected.to eq expected_published_at }
+      it { is_expected.to eq expected_create_published_at }
     end
 
     context "when updating an existing article record with role: #{user_role}" do
@@ -36,7 +36,7 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
         end
       end
 
-      it { is_expected.to eq expected_published_at }
+      it { is_expected.to eq expected_update_published_at }
     end
   end
 
@@ -46,7 +46,8 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
     let(:existing_article) { create(:article, :draft, published_at: DateTime.parse('2018-12-25T03:59:00Z')) }
 
     it_behaves_like 'handles the publication date', :author do
-      let(:expected_published_at) { '2018-12-24 11:59:00 UTC' }
+      let(:expected_create_published_at) { '2018-12-24 11:59:00 UTC' }
+      let(:expected_update_published_at) { '2018-12-24 11:59:00 UTC' }
     end
   end
 
@@ -58,11 +59,13 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
       let(:article_attrs) { published_attrs.merge(published_at: nil) }
 
       it_behaves_like 'handles the publication date', :publisher do
-        let(:expected_published_at) { (now.utc + 100.years).to_s }
+        let(:expected_create_published_at) { (now.utc + 100.years).to_s }
+        let(:expected_update_published_at) { existing_article.published_at.to_s }
       end
 
       it_behaves_like 'handles the publication date', :author do
-        let(:expected_published_at) { '' }
+        let(:expected_create_published_at) { '' }
+        let(:expected_update_published_at) { existing_article.published_at.to_s }
       end
     end
 
@@ -71,11 +74,13 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
       let(:article_attrs) { draft_attrs.merge(published_at: nil) }
 
       it_behaves_like 'handles the publication date', :publisher do
-        let(:expected_published_at) { '' }
+        let(:expected_create_published_at) { '' }
+        let(:expected_update_published_at) { '' }
       end
 
       it_behaves_like 'handles the publication date', :author do
-        let(:expected_published_at) { '' }
+        let(:expected_create_published_at) { '' }
+        let(:expected_update_published_at) { '' }
       end
     end
   end

--- a/spec/system/article_datetime_settings_spec.rb
+++ b/spec/system/article_datetime_settings_spec.rb
@@ -8,71 +8,6 @@ describe 'Setting and changing an articles published_at date', :js do
     create(:user, username: 'user1', password: 'c' * 31, role: 'publisher')
   end
 
-  it 'creates a new article' do
-    login_user
-    visit '/admin/articles'
-
-    click_link_or_button 'NEW'
-
-    within '#publication_datetime' do
-      execute_script("document.getElementById('publication_date').value = '2018-12-24';")
-      execute_script("document.getElementById('publication_time').value = '11:59:00';")
-      select('UTC', from: 'article_published_at_tz')
-    end
-
-    within('#publication-status') { find('label[for=publication_status_draft]').click }
-
-    find_button('Save', match: :first).click
-
-    expect(page).to have_text 'Article was successfully created'
-    article = Article.first
-    expect(article.published_at.utc).to eq('2018-12-24 11:59:00 UTC')
-  end
-
-  it 'updates an existing article' do
-    article = create(:article, published_at: Time.zone.parse('2018-12-24 11:59:00 UTC'))
-    expect(article.published_at.utc).to eq('2018-12-24 11:59:00 UTC')
-    expect(article.published_at_tz).to eq('Pacific Time (US & Canada)')
-
-    login_user
-    visit '/admin/articles'
-
-    click_link_or_button 'EDIT'
-    within '#publication_datetime' do
-      # make sure pre-fills are right
-      expect(find_field('published_at_date').value).to eq '2018-12-24'
-      expect(find_field('published_at_time').value).to eq '03:59:00'
-      expect(find_field('article_published_at_tz').value).to eq 'Pacific Time (US & Canada)'
-
-      execute_script("document.getElementById('publication_date').value = '2018-12-26';")
-      execute_script("document.getElementById('publication_time').value = '22:59:00';")
-      select('UTC', from: 'article_published_at_tz')
-    end
-
-    within('#publication-status') { find('label[for=publication_status_draft]').click }
-
-    find_button('Save', match: :first).click
-
-    expect(page).to have_text 'Article was successfully updated'
-    expect(article.reload.published_at.utc).to eq('2018-12-26 22:59:00 UTC')
-    expect(article.reload.published_at_tz).to eq('UTC')
-  end
-
-  it 'saves an article without entering publication date info' do
-    login_user
-    visit '/admin/articles'
-
-    click_link_or_button 'NEW'
-
-    within('#publication-status') { find('label[for=publication_status_draft]').click }
-
-    find_button('Save', match: :first).click
-
-    expect(page).to have_text 'Article was successfully created'
-    article = Article.first
-    expect(article.published_at).to be_nil
-  end
-
   it 'uses ‘PUBLISH NOW’ feature' do
     freeze_time do
       login_user
@@ -87,25 +22,6 @@ describe 'Setting and changing an articles published_at date', :js do
 
       expect(article.reload.published_at_tz).to eq('UTC')
       expect(article.published_at).to eq(Time.now.utc)
-      expect(article).to be_published
-    end
-  end
-
-  it 'sets the publication date/time if article is `published` and fields are blank' do
-    freeze_time do
-      login_user
-      visit '/admin/articles'
-
-      click_link_or_button 'NEW'
-
-      within('#publication-status') { find('label[for=publication_status_published]').click }
-      find_button('Save', match: :first).click
-
-      expect(page).to have_text 'Article was successfully created'
-      article = Article.last
-
-      expect(article.reload.published_at_tz).to eq('UTC')
-      expect(article.published_at).to eq(Time.now.utc + 100.years)
       expect(article).to be_published
     end
   end


### PR DESCRIPTION
# What does this pull request do?

Those tests were failing due to a change of syntax bring by rubocop, and after debugging them, I release they would be way to port the tests to requests test and avoid running a browser and slow tests.

# How should this be manually tested?

Make sure all specs are still passing.

# Is there any background context you want to provide for reviewers?

I was debugging some spec failling due to rubocop rules fix and I realize those specs could be refactored into not using a browser.

# Acceptance Criteria
## Questions for the pull request author (delete any that don't apply)

- [ ] Are any needed README/wiki/documentation updates needed for this pull request?
- [ ] Does the code you updated have tests? If not, could you add some please?
- [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.

## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

@Bargraph6 you seem to be the rspec domain expert around here, could you give this a look. I'm pretty sure there's a way to make those specs cleaner.