### PR TITLE
sessions: use `has_secure_password#authenticate_by`

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,8 +13,8 @@ class SessionsController < Admin::AdminController
 
   # /signin
   def create
-    user = User.find_by(username: params[:username])
-    if user&.authenticate(params[:password])
+    user = User.authenticate_by(username: params[:username], password: params[:password])
+    if user
       session[:user_id] = user.id
       redirect_to admin_path, notice: t('.notice')
     else


### PR DESCRIPTION
Rails 7.1 introduce `#authenticate_by` to the `has_secure_password` concern, which is designed to mitigate timiing-based enumeration as stated in the api documentation[^1].

[^1]: https://apidock.com/rails/ActiveRecord/SecurePassword/ClassMethods/authenticate_by

# What does this pull request do?

Switch to `authenticate_by` to avoid timing-based enumeration. I've meant to do this since before rails 7.1 got release, but then end up doing way less rails, so it got back benched.

# How should this be manually tested?

Make sure you're still able to signin in the admin dashboard.

# Is there any background context you want to provide for reviewers?

Nope, not really.

# Acceptance Criteria
## Questions for the pull request author (delete any that don't apply)

- [ ] Are any needed README/wiki/documentation updates needed for this pull request?
- [ ] Does the code you updated have tests? If not, could you add some please?
- [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.

## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

<!-- links to related issues/commits/PRs -->
<!-- related-to: [link to github issue/commit/PR] -->
<!-- resolves: [link to github issue] -->