### PR TITLE
ci: fix failling build with github ubuntu 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Install system libraries
-        run: sudo apt-get -y install libpq-dev libvips-dev
+        run: sudo apt-get update && sudo apt-get install -y -qq --no-install-recommends libpq-dev libvips-dev
 
       - name: Checkout repository
         uses: actions/checkout@main

--- a/.github/workflows/tests_system.yml
+++ b/.github/workflows/tests_system.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Install system libraries
-        run: sudo apt-get -y install libpq-dev libvips-dev
+        run: sudo apt-get update && sudo apt-get install -y -qq --no-install-recommends libpq-dev libvips-dev
 
       - name: Checkout repository
         uses: actions/checkout@main


### PR DESCRIPTION
# What does this pull request do?

CI was failing for a couple of day due to an archive not being found in the archive. Simply running `apt-get update` before installation the packages fix the issue.

It takes a little bit more time, but I also added `--no-install-recommands` which reduce the amount of packages installed and should compensate for the time spent updating the package repository.

# How should this be manually tested?

CI should pass.

# Is there any background context you want to provide for reviewers?

??

# Acceptance Criteria
## Questions for the pull request author (delete any that don't apply)

- [ ] Are any needed README/wiki/documentation updates needed for this pull request?
- [ ] Does the code you updated have tests? If not, could you add some please?
- [ ] Does this pull request require any new server dependencies which need to be added to the build process? If so, please explain what.

## Questions for the reviewer

- [ ] This pull request does not cause the database export script to become out of sync with the db schema

---

<!-- links to related issues/commits/PRs -->
<!-- related-to: [link to github issue/commit/PR] -->
<!-- resolves: [link to github issue] -->