### PR TITLE
Fix /page/:page 400 from params.expect raising on missing format

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -143,13 +143,15 @@ class ArticlesController < ApplicationController
   end
 
   def redirect_malformed_pagination
-    return if params.expect(:format).in? %w[json atom]
+    return if non_html_format?
     return if @page_number == params[:page]
 
     redirect_to [:articles, { page: @page_number }]
   end
 
   def force_2025_theme_for_feeds
-    Current.theme = '2025' if params.expect(:format).in? %w[json atom]
+    Current.theme = '2025' if non_html_format?
   end
+
+  def non_html_format? = request.format.atom? || request.format.json?
 end

--- a/spec/requests/paginations_spec.rb
+++ b/spec/requests/paginations_spec.rb
@@ -3,6 +3,26 @@ require 'rails_helper'
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe 'Pagination Redirects' do
   # rubocop:enable RSpec/DescribeClass
+  describe 'home page articles' do
+    it 'renders a numbered page that has no format extension' do
+      get 'http://example.com/page/2'
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'redirects a malformed page number to the cleaned one' do
+      get 'http://example.com/page/2x'
+
+      expect(response).to redirect_to('/page/2')
+    end
+
+    it 'renders a feed format page without redirecting' do
+      get 'http://example.com/page/2.atom'
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe 'article archives' do
     it 'redirects on page 1' do
       get 'http://example.com/2017/01/01/page/1'


### PR DESCRIPTION
Disables a new Rubocop rule for a couple lines of code, which is wrongly identified as needs to be changed

Hopefully a future patch version of the gem will fix the false positive-ness 

