### PR TITLE
Don't nil publication info if article is already published

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -181,15 +181,23 @@ module Admin
     end
 
     def handle_published_without_datetime permitted_params
-      return if @article&.published?
+      if @article&.published?
+        # in general, we don't un-publish articles, and if we do it
+        # should be via setting the publication status from "published"
+        # to "draft", not by nil-ing the publication dates...so if we
+        # are ever in this scenario, it is probably a bug. Just use the
+        # already saved publication dates.
+        permitted_params.delete(:published_at) if permitted_params[:published_at].blank?
+        permitted_params.delete(:published_at_tz) if permitted_params[:published_at_tz].blank?
+      else
+        publish_in_100_years = permitted_params[:publication_status] == 'published' &&
+                               permitted_params[:published_at].blank?
 
-      publish_in_100_years = permitted_params[:publication_status] == 'published' &&
-                             permitted_params[:published_at].blank?
+        time = 100.years.from_now
+        tz = Time.zone.name
 
-      time = 100.years.from_now
-      tz = Time.zone.name
-
-      handle_publish_now_situation(permitted_params, time: time, zone: tz) if publish_in_100_years
+        handle_publish_now_situation(permitted_params, time: time, zone: tz) if publish_in_100_years
+      end
     end
   end
 end

--- a/spec/requests/article_datetime_settings_spec.rb
+++ b/spec/requests/article_datetime_settings_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
         end
       end
 
-      it { is_expected.to eq expected_published_at }
+      it { is_expected.to eq expected_create_published_at }
     end
 
     context "when updating an existing article record with role: #{user_role}" do
@@ -36,7 +36,7 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
         end
       end
 
-      it { is_expected.to eq expected_published_at }
+      it { is_expected.to eq expected_update_published_at }
     end
   end
 
@@ -46,7 +46,8 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
     let(:existing_article) { create(:article, :draft, published_at: DateTime.parse('2018-12-25T03:59:00Z')) }
 
     it_behaves_like 'handles the publication date', :author do
-      let(:expected_published_at) { '2018-12-24 11:59:00 UTC' }
+      let(:expected_create_published_at) { '2018-12-24 11:59:00 UTC' }
+      let(:expected_update_published_at) { '2018-12-24 11:59:00 UTC' }
     end
   end
 
@@ -58,11 +59,13 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
       let(:article_attrs) { published_attrs.merge(published_at: nil) }
 
       it_behaves_like 'handles the publication date', :publisher do
-        let(:expected_published_at) { (now.utc + 100.years).to_s }
+        let(:expected_create_published_at) { (now.utc + 100.years).to_s }
+        let(:expected_update_published_at) { existing_article.published_at.to_s }
       end
 
       it_behaves_like 'handles the publication date', :author do
-        let(:expected_published_at) { '' }
+        let(:expected_create_published_at) { '' }
+        let(:expected_update_published_at) { existing_article.published_at.to_s }
       end
     end
 
@@ -71,11 +74,13 @@ RSpec.describe 'admin article controller set_published_at before_action set publ
       let(:article_attrs) { draft_attrs.merge(published_at: nil) }
 
       it_behaves_like 'handles the publication date', :publisher do
-        let(:expected_published_at) { '' }
+        let(:expected_create_published_at) { '' }
+        let(:expected_update_published_at) { '' }
       end
 
       it_behaves_like 'handles the publication date', :author do
-        let(:expected_published_at) { '' }
+        let(:expected_create_published_at) { '' }
+        let(:expected_update_published_at) { '' }
       end
     end
   end


### PR DESCRIPTION
# What does this pull request do?

* app/controllers/admin/articles_controller.rb (Admin::ArticlesController): updated the permitted_params logic for articles to delete nil publication date info if the article is already published.
* spec/requests/article_datetime_settings_spec.rb: Updated spec to allow for separate expected values for the update and create controller actions.


# Is there any background context you want to provide for reviewers?


I don't think this is a situation that ever really happens in practice, however while updating the `article_datetime_settings_spec`, it was discovered that it was technically possible to pass `nil` to the update action of the articles controller.

This would result in an error further down the line as `Article#path` would try to `strftime` the `nil`:

```sh
     NoMethodError:
       undefined method 'strftime' for nil
     Shared Example Group: "handles the publication date" called from ./spec/requests/article_datetime_settings_spec.rb:61
     # ./app/models/article.rb:56:in '
     # ./app/models/article.rb:150:in 'Article#update_or_create_redirect'
     # ./app/controllers/admin/articles_controller.rb:56:in 'Admin::ArticlesController#update'
     # ...
```

This change just updates the `article_params` method to remove the `published_at` and `published_at_tz` params from the permitted params if the article is already published and the params are `nil`.


---

related_to: https://github.com/crimethinc/website/pull/5391
