### PR TITLE
Fix admin article docx upload 400 from params.expect(:article) on a Hash

### DIFF
--- a/app/controllers/admin/articles_controller.rb
+++ b/app/controllers/admin/articles_controller.rb
@@ -98,7 +98,7 @@ module Admin
                                              .strip
 
       # Populate Aricle#content with the markdown
-      params.expect(:article)[:content] = markdown_from_html
+      params.require(:article)[:content] = markdown_from_html
       @article.content = markdown_from_html
       # /TEMP
     end


### PR DESCRIPTION
https://app.bugsnag.com/crimethinc/rails/errors/6a4364a7d7a912dd244592f1

## Summary

- `admin/articles#create` and `#update` 400 with `ActionController::ParameterMissing` whenever an admin uploads a `.docx` on the article form.
- Cause: `populate_content_from_docx_upload!` called `params.expect(:article)[:content] = …`. The scalar `expect(:article)` raises because `article` is a Hash, not a scalar. This was introduced by a `rubocop -A` autocorrect in #5366 (`Rails/StrongParametersExpect`) that rewrote `params[:article][:content] = …`.
- Fix: use `params.require(:article)[:content] = …`, which returns the hash and is not re-flagged by the cop.

No automated spec: this branch of the code only runs after `PandocRuby.convert`, and pandoc isn't installed in CI (only in the Aptfile for the Heroku runtime), so an end-to-end request spec would fail in CI for lack of the binary.

## Test plan

- [ ] In admin, create an article and upload a `.docx` — confirm the content converts to Markdown and saves instead of 400ing
- [ ] Same on an existing article via edit/update
