### PR TITLE
Restore graceful missing-amount handling on support#create (params.expect autocorrect from #5366)

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -31,7 +31,7 @@ class SupportController < ApplicationController
   private
 
   def create_subscription_checkout_session
-    amount = params.expect(:amount).to_i
+    amount = params[:amount].to_i
     prices = Stripe::Price.list(lookup_keys: ["crimethinc_monthly_#{amount}"], limit: 1)
     price  = prices.data.first
 
@@ -46,7 +46,7 @@ class SupportController < ApplicationController
   end
 
   def create_payment_checkout_session
-    amount = params.expect(:amount).to_i
+    amount = params[:amount].to_i
 
     Stripe::Checkout::Session.create(
       mode:        'payment',

--- a/spec/requests/support_spec.rb
+++ b/spec/requests/support_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe 'Support' do
         expect(response).to redirect_to('https://checkout.stripe.com/c/pay/test_session')
       end
 
+      it 'does not 400 when the amount param is missing' do
+        post support_create_path, params: { monthly: 'false' }
+
+        expect(response).not_to have_http_status(:bad_request)
+        expect(response).to redirect_to('https://checkout.stripe.com/c/pay/test_session')
+      end
+
       it 'sets line_items with inline price_data for the correct amount' do
         post support_create_path, params: { amount: 100, monthly: 'false' }
 


### PR DESCRIPTION
## Summary

Audit follow-up to #5366, whose `rubocop -A` run (`Rails/StrongParametersExpect`) autocorrected several `params[:x]` reads into `params.expect(:x)`. `expect` raises `ActionController::ParameterMissing` (400) on missing/invalid params where the bracket read did not, which has already caused production 400s.

- `support#create` is a public POST. `params.expect(:amount)` 400s on any POST without `amount` (bots, malformed submits), regressing the prior graceful path (`nil.to_i` → `0` → Stripe error → redirect back with a flash). Reverted both call sites to `params[:amount].to_i` . And `.to_i` is nil-safe and on the cop's ignore list, so it isn't re-flagged.

Rest of #5366's autocorrects, audited:

- `params.expect(:format)` on `/page/:page`  :  the original 400, already fixed in #5446.
- `params.expect(:article)[:content]` on the admin docx upload  :  separate fix in #5451.
- ~16 `Model.find(params.expect(:id))` in admin controllers  :  `:id` is a path-param scalar there, so `expect` can't raise on normal requests. Those were left as-is.

## Test plan

- [ ] On staging, submit the donation form one-time and monthly  :  confirm Stripe checkout still works
- [ ] `POST /support` with no `amount` param   :  confirm it redirects back gracefully instead of returning a 400
